### PR TITLE
feat(google-drive): add Drive fetch handler + rename Google auth (closes #7)

### DIFF
--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -50,7 +50,7 @@ function datamachine_business_load_handlers() {
 	new \DataMachineBusiness\Handlers\GoogleSheets\GoogleSheetsFetch();
 	new \DataMachineBusiness\Handlers\GoogleSheets\GoogleSheetsPublish();
 
-	// Google Drive (shares the GoogleSheetsAuth credential — see scope union below)
+	// Google Drive (shares the unified GoogleAuth credential — see scope union below)
 	new \DataMachineBusiness\Abilities\GoogleDrive\FetchGoogleDriveAbility();
 	new \DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveFetch();
 
@@ -75,20 +75,21 @@ function datamachine_business_load_handlers() {
 add_action( 'plugins_loaded', 'datamachine_business_load_handlers', 20 );
 
 /**
- * Contribute Google Drive scopes to the shared Google OAuth credential.
+ * Contribute Google Drive scopes to the unified Google OAuth credential.
  *
- * The Sheets and Drive handlers share a single Google OAuth client
- * (registered under the `googlesheets` provider slug) so the user only
- * has to grant Data Machine access to Google once. Each handler family
- * declares the scopes it needs here; GoogleSheetsAuth::get_scopes()
- * unions and de-duplicates them at consent time.
+ * Every Google handler in this plugin (Sheets, Drive, future Calendar,
+ * etc.) shares a single Google OAuth client registered under the
+ * `google` provider slug so the user only has to grant Data Machine
+ * access to Google once. Each handler family declares the scopes it
+ * needs here; GoogleAuth::get_scopes() unions and de-duplicates them
+ * at consent time.
  *
- * Tokens issued before Drive was added will NOT contain Drive scopes.
- * Affected users must disconnect and reconnect the Google integration
- * to re-consent. The Drive handler surfaces a clear re-consent error
+ * Tokens issued before a scope was added will NOT contain it. Affected
+ * users must disconnect and reconnect the Google integration to
+ * re-consent. The Drive handler surfaces a clear re-consent error
  * (googledrive_scope_missing) rather than silently returning empty.
  */
-add_filter( 'datamachine_googlesheets_oauth_scopes', function ( array $scopes ): array {
+add_filter( 'datamachine_google_oauth_scopes', function ( array $scopes ): array {
 	foreach ( \DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveSettings::required_scopes() as $scope ) {
 		if ( ! in_array( $scope, $scopes, true ) ) {
 			$scopes[] = $scope;

--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -50,6 +50,10 @@ function datamachine_business_load_handlers() {
 	new \DataMachineBusiness\Handlers\GoogleSheets\GoogleSheetsFetch();
 	new \DataMachineBusiness\Handlers\GoogleSheets\GoogleSheetsPublish();
 
+	// Google Drive (shares the GoogleSheetsAuth credential — see scope union below)
+	new \DataMachineBusiness\Abilities\GoogleDrive\FetchGoogleDriveAbility();
+	new \DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveFetch();
+
 	// Slack
 	new \DataMachineBusiness\Abilities\Slack\PostMessageSlackAbility();
 	new \DataMachineBusiness\Abilities\Slack\FetchMessagesSlackAbility();
@@ -69,3 +73,26 @@ function datamachine_business_load_handlers() {
 
 // Hook into plugins_loaded to ensure Data Machine core is loaded first
 add_action( 'plugins_loaded', 'datamachine_business_load_handlers', 20 );
+
+/**
+ * Contribute Google Drive scopes to the shared Google OAuth credential.
+ *
+ * The Sheets and Drive handlers share a single Google OAuth client
+ * (registered under the `googlesheets` provider slug) so the user only
+ * has to grant Data Machine access to Google once. Each handler family
+ * declares the scopes it needs here; GoogleSheetsAuth::get_scopes()
+ * unions and de-duplicates them at consent time.
+ *
+ * Tokens issued before Drive was added will NOT contain Drive scopes.
+ * Affected users must disconnect and reconnect the Google integration
+ * to re-consent. The Drive handler surfaces a clear re-consent error
+ * (googledrive_scope_missing) rather than silently returning empty.
+ */
+add_filter( 'datamachine_googlesheets_oauth_scopes', function ( array $scopes ): array {
+	foreach ( \DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveSettings::required_scopes() as $scope ) {
+		if ( ! in_array( $scope, $scopes, true ) ) {
+			$scopes[] = $scope;
+		}
+	}
+	return $scopes;
+} );

--- a/inc/Abilities/GoogleDrive/FetchGoogleDriveAbility.php
+++ b/inc/Abilities/GoogleDrive/FetchGoogleDriveAbility.php
@@ -1,0 +1,704 @@
+<?php
+/**
+ * Fetch Google Drive Ability.
+ *
+ * Pure business logic — no handler config, no engine data, no pipeline
+ * context. Any caller (REST, CLI, chat tool, pipeline handler) can
+ * invoke this directly.
+ *
+ * Resolves auth via the shared `googlesheets` OAuth provider (single
+ * Google credential covers both Sheets and Drive — see plugin loader
+ * for the scope union).
+ *
+ * Behavior:
+ * - Lists files in a Drive folder via files.list with pagination.
+ * - Optionally recurses into subfolders.
+ * - Optionally filters by MIME type and modifiedTime.
+ * - Native Google Docs / Sheets / Slides are exported to text/csv.
+ * - Other binary files are streamed to the Data Machine uploads area
+ *   when a download target (pipeline/flow context) is provided.
+ * - Google Forms / Sites and other non-exportable native types are
+ *   returned with `payload.skipped = true` so the caller can decide
+ *   whether to log and continue.
+ *
+ * @package DataMachineBusiness
+ * @subpackage Abilities\GoogleDrive
+ * @since 0.3.0
+ */
+
+namespace DataMachineBusiness\Abilities\GoogleDrive;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Core\FilesRepository\FilesystemHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+class FetchGoogleDriveAbility {
+
+	private const API_BASE         = 'https://www.googleapis.com/drive/v3';
+	private const LIST_FIELDS      = 'nextPageToken,files(id,name,mimeType,modifiedTime,size,owners,webViewLink,md5Checksum,parents)';
+	private const PAGE_SIZE        = 100;
+	private const REQUIRED_SCOPE   = 'https://www.googleapis.com/auth/drive.readonly';
+	private const MAX_RECURSION    = 25;
+	private const RETRY_AFTER_CAP  = 60;
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/fetch-googledrive',
+				array(
+					'label'               => __( 'Fetch Google Drive Folder', 'data-machine-business' ),
+					'description'         => __( 'List files in a Google Drive folder and download or export their contents.', 'data-machine-business' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'folder_id' ),
+						'properties' => array(
+							'folder_id'       => array(
+								'type'        => 'string',
+								'description' => __( 'Google Drive folder ID (or full URL — see the GoogleDriveFetchSettings::extract_folder_id helper).', 'data-machine-business' ),
+							),
+							'recursive'       => array(
+								'type'        => 'boolean',
+								'default'     => false,
+								'description' => __( 'When true, recurse into subfolders.', 'data-machine-business' ),
+							),
+							'mime_filter'     => array(
+								'type'        => 'array',
+								'items'       => array( 'type' => 'string' ),
+								'description' => __( 'Optional list of MIME types to include.', 'data-machine-business' ),
+							),
+							'modified_since'  => array(
+								'type'        => 'string',
+								'description' => __( 'Optional ISO-8601 timestamp — only files modifiedTime > this are returned.', 'data-machine-business' ),
+							),
+							'download_target' => array(
+								'type'        => 'object',
+								'description' => __( 'Optional pipeline/flow context used to scope binary downloads. When omitted, binary files are listed but not downloaded.', 'data-machine-business' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array( 'type' => 'object' ),
+							'error'   => array( 'type' => 'string' ),
+							'logs'    => array( 'type' => 'array' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Input parameters (see input_schema).
+	 * @return array Result with success, data, error, logs.
+	 */
+	public function execute( array $input ): array {
+		$logs = array();
+
+		$folder_id = isset( $input['folder_id'] ) ? trim( (string) $input['folder_id'] ) : '';
+		if ( '' === $folder_id ) {
+			return $this->fail( 'folder_id is required.', $logs );
+		}
+
+		$recursive       = ! empty( $input['recursive'] );
+		$mime_filter     = isset( $input['mime_filter'] ) && is_array( $input['mime_filter'] ) ? array_values( array_filter( array_map( 'strval', $input['mime_filter'] ) ) ) : array();
+		$modified_since  = isset( $input['modified_since'] ) ? trim( (string) $input['modified_since'] ) : '';
+		$download_target = isset( $input['download_target'] ) && is_array( $input['download_target'] ) ? $input['download_target'] : array();
+
+		$auth_provider = self::get_auth_provider();
+		if ( ! $auth_provider ) {
+			return $this->fail( 'Google authentication provider is not registered.', $logs );
+		}
+
+		if ( ! $auth_provider->has_scope( self::REQUIRED_SCOPE ) ) {
+			return $this->fail(
+				sprintf(
+					/* translators: %s: OAuth scope URL. */
+					'The connected Google account is missing the Drive scope (%s). Disconnect and reconnect the Google integration in Data Machine settings to grant Drive access.',
+					self::REQUIRED_SCOPE
+				),
+				$logs
+			);
+		}
+
+		$access_token = $auth_provider->get_service();
+		if ( is_wp_error( $access_token ) ) {
+			return $this->fail( $access_token->get_error_message(), $logs );
+		}
+		if ( ! is_string( $access_token ) || '' === $access_token ) {
+			return $this->fail( 'Failed to obtain a Google access token.', $logs );
+		}
+
+		$files   = array();
+		$visited = array();
+
+		$list_result = $this->list_folder_recursive(
+			$folder_id,
+			$access_token,
+			$recursive,
+			$mime_filter,
+			$modified_since,
+			0,
+			$visited,
+			$logs
+		);
+
+		if ( is_wp_error( $list_result ) ) {
+			return $this->fail( $list_result->get_error_message(), $logs );
+		}
+
+		foreach ( $list_result as $raw ) {
+			// Folders are returned by the recursion helper as well so the
+			// caller can introspect structure, but for the fetch handler
+			// we only emit leaf files.
+			if ( $this->is_folder( $raw ) ) {
+				continue;
+			}
+
+			$payload = $this->materialize_file( $raw, $access_token, $download_target, $logs );
+
+			$files[] = array(
+				'id'            => $raw['id'] ?? '',
+				'name'          => $raw['name'] ?? '',
+				'mime_type'     => $raw['mimeType'] ?? '',
+				'modified_time' => $raw['modifiedTime'] ?? '',
+				'size'          => isset( $raw['size'] ) ? (int) $raw['size'] : null,
+				'owners'        => $raw['owners'] ?? array(),
+				'web_view_link' => $raw['webViewLink'] ?? '',
+				'md5_checksum'  => $raw['md5Checksum'] ?? '',
+				'payload'       => $payload,
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'folder_id' => $folder_id,
+				'files'     => $files,
+				'count'     => count( $files ),
+			),
+			'logs'    => $logs,
+		);
+	}
+
+	/**
+	 * Recursively list files in a folder.
+	 *
+	 * @param string   $folder_id      Drive folder ID.
+	 * @param string   $access_token   OAuth bearer token.
+	 * @param bool     $recursive      Whether to recurse into subfolders.
+	 * @param string[] $mime_filter    Optional MIME types to include.
+	 * @param string   $modified_since Optional ISO-8601 timestamp.
+	 * @param int      $depth          Current recursion depth (caps at MAX_RECURSION).
+	 * @param array    $visited        Visited folder IDs to break cycles.
+	 * @param array    $logs           Logs reference.
+	 * @return array|\WP_Error
+	 */
+	private function list_folder_recursive(
+		string $folder_id,
+		string $access_token,
+		bool $recursive,
+		array $mime_filter,
+		string $modified_since,
+		int $depth,
+		array &$visited,
+		array &$logs
+	) {
+		if ( isset( $visited[ $folder_id ] ) ) {
+			return array();
+		}
+		$visited[ $folder_id ] = true;
+
+		if ( $depth > self::MAX_RECURSION ) {
+			$logs[] = array(
+				'level'   => 'warning',
+				'message' => 'GoogleDrive: Max recursion depth reached, skipping deeper folders.',
+				'data'    => array( 'folder_id' => $folder_id, 'depth' => $depth ),
+			);
+			return array();
+		}
+
+		$query_parts = array(
+			sprintf( "'%s' in parents", $this->escape_query_literal( $folder_id ) ),
+			'trashed = false',
+		);
+
+		if ( '' !== $modified_since ) {
+			$query_parts[] = sprintf( "modifiedTime > '%s'", $this->escape_query_literal( $modified_since ) );
+		}
+
+		// Note: MIME filter is applied client-side as well so that
+		// subfolders (mimeType = application/vnd.google-apps.folder) are
+		// not excluded by a too-narrow server-side filter when recursive
+		// is on.
+
+		$page_token = '';
+		$collected  = array();
+
+		do {
+			$params = array(
+				'q'                         => implode( ' and ', $query_parts ),
+				'pageSize'                  => self::PAGE_SIZE,
+				'fields'                    => self::LIST_FIELDS,
+				'supportsAllDrives'         => 'true',
+				'includeItemsFromAllDrives' => 'true',
+			);
+			if ( '' !== $page_token ) {
+				$params['pageToken'] = $page_token;
+			}
+
+			$response = $this->drive_get( self::API_BASE . '/files', $params, $access_token, $logs );
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
+
+			$files      = $response['files'] ?? array();
+			$page_token = $response['nextPageToken'] ?? '';
+
+			foreach ( $files as $file ) {
+				if ( $this->is_folder( $file ) ) {
+					if ( $recursive ) {
+						$nested = $this->list_folder_recursive(
+							$file['id'] ?? '',
+							$access_token,
+							$recursive,
+							$mime_filter,
+							$modified_since,
+							$depth + 1,
+							$visited,
+							$logs
+						);
+						if ( is_wp_error( $nested ) ) {
+							return $nested;
+						}
+						foreach ( $nested as $nested_file ) {
+							$collected[] = $nested_file;
+						}
+					}
+					continue;
+				}
+
+				if ( ! empty( $mime_filter ) ) {
+					$file_mime = $file['mimeType'] ?? '';
+					if ( ! in_array( $file_mime, $mime_filter, true ) ) {
+						continue;
+					}
+				}
+
+				$collected[] = $file;
+			}
+		} while ( '' !== $page_token );
+
+		return $collected;
+	}
+
+	/**
+	 * Convert a raw Drive file record into a payload (text, local_path, or skipped).
+	 *
+	 * @param array  $file            Raw Drive file metadata.
+	 * @param string $access_token    OAuth bearer.
+	 * @param array  $download_target Pipeline/flow context for binary downloads. Empty = skip download.
+	 * @param array  $logs            Logs reference.
+	 * @return array Payload descriptor.
+	 */
+	private function materialize_file( array $file, string $access_token, array $download_target, array &$logs ): array {
+		$mime    = $file['mimeType'] ?? '';
+		$file_id = $file['id'] ?? '';
+		$name    = $file['name'] ?? '';
+
+		// Native Google types use files.export; everything else uses files.get?alt=media.
+		$export_mime = $this->export_mime_for_native( $mime );
+
+		if ( null !== $export_mime ) {
+			if ( '' === $export_mime ) {
+				// Native but not exportable (Forms, Sites, etc.).
+				return array(
+					'skipped' => true,
+					'reason'  => 'Native Google file type is not exportable as text.',
+				);
+			}
+
+			$url      = self::API_BASE . '/files/' . rawurlencode( $file_id ) . '/export';
+			$response = $this->drive_get_raw( $url, array( 'mimeType' => $export_mime ), $access_token, $logs );
+
+			if ( is_wp_error( $response ) ) {
+				$logs[] = array(
+					'level'   => 'warning',
+					'message' => 'GoogleDrive: Export failed for native file.',
+					'data'    => array( 'file_id' => $file_id, 'error' => $response->get_error_message() ),
+				);
+				return array(
+					'skipped' => true,
+					'reason'  => $response->get_error_message(),
+				);
+			}
+
+			return array(
+				'text'        => $response,
+				'export_mime' => $export_mime,
+			);
+		}
+
+		// Binary file. Stream to disk if we have somewhere to put it.
+		if ( empty( $download_target['pipeline_id'] ) && empty( $download_target['flow_id'] ) ) {
+			$logs[] = array(
+				'level'   => 'debug',
+				'message' => 'GoogleDrive: No download target provided, listing binary file without downloading.',
+				'data'    => array( 'file_id' => $file_id, 'name' => $name ),
+			);
+			return array(
+				'binary_only' => true,
+			);
+		}
+
+		$saved = $this->download_binary( $file_id, $name, $access_token, $download_target, $logs );
+		if ( is_wp_error( $saved ) ) {
+			$logs[] = array(
+				'level'   => 'error',
+				'message' => 'GoogleDrive: Binary download failed.',
+				'data'    => array( 'file_id' => $file_id, 'error' => $saved->get_error_message() ),
+			);
+			return array(
+				'skipped' => true,
+				'reason'  => $saved->get_error_message(),
+			);
+		}
+
+		return $saved;
+	}
+
+	/**
+	 * Map a native Google MIME type to its export target MIME.
+	 *
+	 * Returns:
+	 * - null if the file is NOT a native Google type (use files.get?alt=media)
+	 * - '' if it IS a native type but not exportable as text
+	 * - the export MIME string otherwise
+	 *
+	 * @param string $mime Source MIME.
+	 * @return string|null
+	 */
+	private function export_mime_for_native( string $mime ): ?string {
+		switch ( $mime ) {
+			case 'application/vnd.google-apps.document':
+				return 'text/plain';
+			case 'application/vnd.google-apps.spreadsheet':
+				return 'text/csv';
+			case 'application/vnd.google-apps.presentation':
+				return 'text/plain';
+			case 'application/vnd.google-apps.form':
+			case 'application/vnd.google-apps.site':
+			case 'application/vnd.google-apps.drawing':
+			case 'application/vnd.google-apps.map':
+			case 'application/vnd.google-apps.shortcut':
+			case 'application/vnd.google-apps.folder':
+				return '';
+		}
+
+		if ( 0 === strpos( $mime, 'application/vnd.google-apps.' ) ) {
+			// Unknown native type — refuse rather than guess.
+			return '';
+		}
+
+		return null;
+	}
+
+	private function is_folder( array $file ): bool {
+		return ( $file['mimeType'] ?? '' ) === 'application/vnd.google-apps.folder';
+	}
+
+	/**
+	 * Download a binary Drive file into the flow-scoped uploads dir.
+	 *
+	 * Authenticated downloads need a bearer header, so we cannot reuse
+	 * WordPress's download_url() helper. We stream via wp_remote_get to
+	 * a temp file, then move into the flow directory. This is local-only
+	 * pending a generic authenticated-download helper in core (see
+	 * Extra-Chill/data-machine issue tracking TBD).
+	 *
+	 * @return array|\WP_Error
+	 */
+	private function download_binary( string $file_id, string $name, string $access_token, array $download_target, array &$logs ) {
+		$pipeline_id = $download_target['pipeline_id'] ?? null;
+		$flow_id     = $download_target['flow_id'] ?? null;
+		if ( null === $pipeline_id || null === $flow_id ) {
+			return new \WP_Error( 'googledrive_no_target', 'Download target missing pipeline_id/flow_id.' );
+		}
+
+		$dir_manager = new DirectoryManager();
+		$directory   = $dir_manager->get_flow_files_directory( $pipeline_id, $flow_id );
+
+		if ( ! $dir_manager->ensure_directory_exists( $directory ) ) {
+			return new \WP_Error( 'googledrive_dir_failed', 'Failed to create flow files directory.' );
+		}
+
+		$url      = self::API_BASE . '/files/' . rawurlencode( $file_id );
+		$response = wp_remote_get(
+			add_query_arg(
+				array(
+					'alt'               => 'media',
+					'supportsAllDrives' => 'true',
+				),
+				$url
+			),
+			array(
+				'timeout' => 60,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+				),
+				// Avoid loading the whole binary into PHP memory when possible.
+				'stream'   => true,
+				'filename' => trailingslashit( get_temp_dir() ) . wp_unique_filename( get_temp_dir(), 'gdrive-' . $file_id . '-' . sanitize_file_name( $name ) ),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$temp_path   = $response['filename'] ?? '';
+
+		if ( 200 !== (int) $status_code ) {
+			if ( $temp_path && file_exists( $temp_path ) ) {
+				wp_delete_file( $temp_path );
+			}
+			return $this->error_from_status( $status_code, $response );
+		}
+
+		if ( '' === $temp_path || ! file_exists( $temp_path ) ) {
+			return new \WP_Error( 'googledrive_stream_failed', 'Drive returned 200 but temp file is missing.' );
+		}
+
+		$safe_name   = sanitize_file_name( $name ?: ( 'drive-' . $file_id ) );
+		$destination = trailingslashit( $directory ) . wp_unique_filename( $directory, $safe_name );
+
+		$fs = FilesystemHelper::get();
+		if ( $fs ) {
+			$copied = $fs->copy( $temp_path, $destination, true );
+		} else {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Filesystem API unavailable, fall back to native move.
+			$copied = @rename( $temp_path, $destination );
+		}
+
+		if ( file_exists( $temp_path ) ) {
+			wp_delete_file( $temp_path );
+		}
+
+		if ( ! $copied || ! file_exists( $destination ) ) {
+			return new \WP_Error( 'googledrive_move_failed', 'Failed to move downloaded file into flow directory.' );
+		}
+
+		$logs[] = array(
+			'level'   => 'debug',
+			'message' => 'GoogleDrive: Binary file downloaded.',
+			'data'    => array( 'file_id' => $file_id, 'destination' => $destination ),
+		);
+
+		return array(
+			'local_path' => $destination,
+			'filename'   => basename( $destination ),
+			'size'       => filesize( $destination ),
+		);
+	}
+
+	/**
+	 * GET a JSON-returning Drive API endpoint.
+	 *
+	 * @return array|\WP_Error Decoded JSON on success.
+	 */
+	private function drive_get( string $url, array $params, string $access_token, array &$logs ) {
+		$full_url = add_query_arg( $params, $url );
+		$response = wp_remote_get(
+			$full_url,
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Accept'        => 'application/json',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+		$body        = wp_remote_retrieve_body( $response );
+
+		if ( 200 !== $status_code ) {
+			return $this->error_from_status( $status_code, $response, $body );
+		}
+
+		$decoded = json_decode( $body, true );
+		if ( ! is_array( $decoded ) ) {
+			return new \WP_Error( 'googledrive_decode_failed', 'Drive returned an unparseable response body.' );
+		}
+
+		return $decoded;
+	}
+
+	/**
+	 * GET a Drive API endpoint that returns raw (non-JSON) content.
+	 *
+	 * Used for files.export.
+	 *
+	 * @return string|\WP_Error Raw body on success.
+	 */
+	private function drive_get_raw( string $url, array $params, string $access_token, array &$logs ) {
+		$full_url = add_query_arg( $params, $url );
+		$response = wp_remote_get(
+			$full_url,
+			array(
+				'timeout' => 60,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+		$body        = (string) wp_remote_retrieve_body( $response );
+
+		if ( 200 !== $status_code ) {
+			return $this->error_from_status( $status_code, $response, $body );
+		}
+
+		return $body;
+	}
+
+	/**
+	 * Translate a non-200 Drive response into a WP_Error.
+	 *
+	 * Distinguishes scope-missing (403 with insufficient scope reason),
+	 * not-found (404), and rate-limited (429, with respect for
+	 * Retry-After) errors.
+	 *
+	 * @param int          $status_code HTTP status.
+	 * @param array|object $response    wp_remote_* response.
+	 * @param string|null  $body        Body string if already retrieved.
+	 * @return \WP_Error
+	 */
+	private function error_from_status( int $status_code, $response, ?string $body = null ): \WP_Error {
+		if ( null === $body ) {
+			$body = (string) wp_remote_retrieve_body( $response );
+		}
+
+		$decoded = json_decode( $body, true );
+		$message = '';
+		$reason  = '';
+		if ( is_array( $decoded ) && isset( $decoded['error'] ) ) {
+			$message = (string) ( $decoded['error']['message'] ?? '' );
+			$errors  = $decoded['error']['errors'] ?? array();
+			if ( is_array( $errors ) && ! empty( $errors[0]['reason'] ) ) {
+				$reason = (string) $errors[0]['reason'];
+			}
+		}
+
+		if ( 401 === $status_code ) {
+			return new \WP_Error( 'googledrive_unauthorized', 'Google Drive returned 401 Unauthorized. Re-authenticate the Google integration.' );
+		}
+
+		if ( 403 === $status_code ) {
+			if ( in_array( $reason, array( 'insufficientPermissions', 'insufficientScopes', 'forbidden' ), true ) && false !== stripos( $message . ' ' . $reason, 'scope' ) ) {
+				return new \WP_Error(
+					'googledrive_scope_missing',
+					sprintf(
+						'Google Drive denied the request because the OAuth token lacks the required scope (%s). Disconnect and reconnect the Google integration to grant Drive access.',
+						self::REQUIRED_SCOPE
+					)
+				);
+			}
+			return new \WP_Error(
+				'googledrive_forbidden',
+				$message ?: 'Google Drive denied access to this resource. The authenticated user may not have permission to view the folder.'
+			);
+		}
+
+		if ( 404 === $status_code ) {
+			return new \WP_Error( 'googledrive_not_found', $message ?: 'Drive resource not found.' );
+		}
+
+		if ( 429 === $status_code ) {
+			$retry_after = (int) wp_remote_retrieve_header( $response, 'retry-after' );
+			if ( $retry_after > 0 ) {
+				$retry_after = min( $retry_after, self::RETRY_AFTER_CAP );
+				return new \WP_Error(
+					'googledrive_rate_limited',
+					sprintf( 'Google Drive rate limit hit. Retry after %d seconds.', $retry_after ),
+					array( 'retry_after' => $retry_after )
+				);
+			}
+			return new \WP_Error( 'googledrive_rate_limited', 'Google Drive rate limit hit.' );
+		}
+
+		return new \WP_Error(
+			'googledrive_http_error',
+			sprintf( 'Google Drive API returned HTTP %d: %s', $status_code, $message ?: 'Unknown error' )
+		);
+	}
+
+	/**
+	 * Escape a literal for inclusion inside a Drive `q=` query string.
+	 *
+	 * Drive's query language quotes literals with single quotes and
+	 * escapes single quotes and backslashes inside them.
+	 */
+	private function escape_query_literal( string $value ): string {
+		return str_replace( array( '\\', "'" ), array( '\\\\', "\\'" ), $value );
+	}
+
+	private function fail( string $message, array $logs ): array {
+		$logs[] = array( 'level' => 'error', 'message' => $message );
+		return array(
+			'success' => false,
+			'error'   => $message,
+			'logs'    => $logs,
+		);
+	}
+
+	/**
+	 * @return \DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth|null
+	 */
+	private static function get_auth_provider(): ?\DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth {
+		$providers = apply_filters( 'datamachine_auth_providers', array() );
+		$provider  = $providers['googlesheets'] ?? null;
+		return $provider instanceof \DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth ? $provider : null;
+	}
+}

--- a/inc/Abilities/GoogleDrive/FetchGoogleDriveAbility.php
+++ b/inc/Abilities/GoogleDrive/FetchGoogleDriveAbility.php
@@ -6,9 +6,9 @@
  * context. Any caller (REST, CLI, chat tool, pipeline handler) can
  * invoke this directly.
  *
- * Resolves auth via the shared `googlesheets` OAuth provider (single
- * Google credential covers both Sheets and Drive — see plugin loader
- * for the scope union).
+ * Resolves auth via the unified `google` OAuth provider — single
+ * credential covers every Google handler in this plugin. See the
+ * plugin loader for the scope union.
  *
  * Behavior:
  * - Lists files in a Drive folder via files.list with pagination.
@@ -694,11 +694,11 @@ class FetchGoogleDriveAbility {
 	}
 
 	/**
-	 * @return \DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth|null
+	 * @return \DataMachineBusiness\OAuth\Providers\GoogleAuth|null
 	 */
-	private static function get_auth_provider(): ?\DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth {
+	private static function get_auth_provider(): ?\DataMachineBusiness\OAuth\Providers\GoogleAuth {
 		$providers = apply_filters( 'datamachine_auth_providers', array() );
-		$provider  = $providers['googlesheets'] ?? null;
-		return $provider instanceof \DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth ? $provider : null;
+		$provider  = $providers['google'] ?? null;
+		return $provider instanceof \DataMachineBusiness\OAuth\Providers\GoogleAuth ? $provider : null;
 	}
 }

--- a/inc/Abilities/GoogleSheets/FetchGoogleSheetsAbility.php
+++ b/inc/Abilities/GoogleSheets/FetchGoogleSheetsAbility.php
@@ -198,10 +198,10 @@ class FetchGoogleSheetsAbility {
 	/**
 	 * Get the Google Sheets auth provider instance.
 	 *
-	 * @return \DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth|null
+	 * @return \DataMachineBusiness\OAuth\Providers\GoogleAuth|null
 	 */
-	private static function get_auth_provider(): ?\DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth {
+	private static function get_auth_provider(): ?\DataMachineBusiness\OAuth\Providers\GoogleAuth {
 		$providers = apply_filters( 'datamachine_auth_providers', array() );
-		return $providers['googlesheets'] ?? null;
+		return $providers['google'] ?? null;
 	}
 }

--- a/inc/Abilities/GoogleSheets/PublishGoogleSheetsAbility.php
+++ b/inc/Abilities/GoogleSheets/PublishGoogleSheetsAbility.php
@@ -214,10 +214,10 @@ class PublishGoogleSheetsAbility {
 	/**
 	 * Get the Google Sheets auth provider instance.
 	 *
-	 * @return \DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth|null
+	 * @return \DataMachineBusiness\OAuth\Providers\GoogleAuth|null
 	 */
-	private static function get_auth_provider(): ?\DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth {
+	private static function get_auth_provider(): ?\DataMachineBusiness\OAuth\Providers\GoogleAuth {
 		$providers = apply_filters( 'datamachine_auth_providers', array() );
-		return $providers['googlesheets'] ?? null;
+		return $providers['google'] ?? null;
 	}
 }

--- a/inc/Handlers/GoogleDrive/GoogleDriveFetch.php
+++ b/inc/Handlers/GoogleDrive/GoogleDriveFetch.php
@@ -8,9 +8,9 @@
  * FetchGoogleDriveAbility so any caller (REST, CLI, chat tool, this
  * pipeline handler) can drive it.
  *
- * Shares the existing Google OAuth provider (slug: googlesheets) with
- * the Sheets handlers. See data-machine-business.php for the scope
- * union wiring.
+ * Shares the unified Google OAuth provider (slug: google) with the
+ * Sheets handlers. See data-machine-business.php for the scope union
+ * wiring.
  *
  * @package DataMachineBusiness
  * @subpackage Handlers\GoogleDrive
@@ -42,13 +42,13 @@ class GoogleDriveFetch extends FetchHandler {
 			__( 'Google Drive', 'data-machine-business' ),
 			__( 'Fetch files from a Google Drive folder (native Docs exported to text, binaries streamed to disk).', 'data-machine-business' ),
 			true,
-			\DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth::class,
+			\DataMachineBusiness\OAuth\Providers\GoogleAuth::class,
 			GoogleDriveFetchSettings::class,
 			null,
-			// Reuse the shared Google credential (slug: googlesheets).
-			// Drive scopes are unioned via the
-			// `datamachine_googlesheets_oauth_scopes` filter in the loader.
-			'googlesheets'
+			// Reuse the unified Google credential (slug: google). Drive
+			// scopes are unioned via the `datamachine_google_oauth_scopes`
+			// filter in the plugin loader.
+			'google'
 		);
 	}
 

--- a/inc/Handlers/GoogleDrive/GoogleDriveFetch.php
+++ b/inc/Handlers/GoogleDrive/GoogleDriveFetch.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Google Drive fetch handler.
+ *
+ * Lists files in a Drive folder and emits one pipeline item per
+ * unprocessed file. The actual Drive API work (listing, exporting
+ * native Google docs, streaming binaries to disk) lives in
+ * FetchGoogleDriveAbility so any caller (REST, CLI, chat tool, this
+ * pipeline handler) can drive it.
+ *
+ * Shares the existing Google OAuth provider (slug: googlesheets) with
+ * the Sheets handlers. See data-machine-business.php for the scope
+ * union wiring.
+ *
+ * @package DataMachineBusiness
+ * @subpackage Handlers\GoogleDrive
+ * @since 0.3.0
+ */
+
+namespace DataMachineBusiness\Handlers\GoogleDrive;
+
+use DataMachine\Core\ExecutionContext;
+use DataMachine\Core\Steps\Fetch\Handlers\FetchHandler;
+use DataMachine\Core\Steps\HandlerRegistrationTrait;
+use DataMachineBusiness\Abilities\GoogleDrive\FetchGoogleDriveAbility;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GoogleDriveFetch extends FetchHandler {
+
+	use HandlerRegistrationTrait;
+
+	public function __construct() {
+		parent::__construct( 'google_drive_fetch' );
+
+		self::registerHandler(
+			'google_drive_fetch',
+			'fetch',
+			self::class,
+			__( 'Google Drive', 'data-machine-business' ),
+			__( 'Fetch files from a Google Drive folder (native Docs exported to text, binaries streamed to disk).', 'data-machine-business' ),
+			true,
+			\DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth::class,
+			GoogleDriveFetchSettings::class,
+			null,
+			// Reuse the shared Google credential (slug: googlesheets).
+			// Drive scopes are unioned via the
+			// `datamachine_googlesheets_oauth_scopes` filter in the loader.
+			'googlesheets'
+		);
+	}
+
+	/**
+	 * Fetch the next unprocessed file from the configured Drive folder.
+	 *
+	 * Emits one pipeline item per call. Subsequent runs will skip files
+	 * already marked processed via ExecutionContext::markItemProcessed().
+	 */
+	protected function executeFetch( array $config, ExecutionContext $context ): array {
+		$folder_raw = trim( (string) ( $config['googledrive_fetch_folder'] ?? '' ) );
+		$folder_id  = GoogleDriveFetchSettings::extract_folder_id( $folder_raw );
+
+		if ( '' === $folder_id ) {
+			$context->log( 'error', 'GoogleDrive: Folder ID is required.' );
+			return array();
+		}
+
+		$mime_filter_raw = (string) ( $config['googledrive_fetch_mime_filter'] ?? '' );
+		$mime_filter     = array();
+		if ( '' !== $mime_filter_raw ) {
+			$mime_filter = array_filter( array_map( 'trim', explode( ',', $mime_filter_raw ) ) );
+		}
+
+		$ability = new FetchGoogleDriveAbility();
+		$result  = $ability->execute(
+			array(
+				'folder_id'       => $folder_id,
+				'recursive'       => ! empty( $config['googledrive_fetch_recursive'] ),
+				'mime_filter'     => $mime_filter,
+				'modified_since'  => (string) ( $config['googledrive_fetch_modified_since'] ?? '' ),
+				'download_target' => $context->getFileContext(),
+			)
+		);
+
+		if ( empty( $result['success'] ) ) {
+			$context->log( 'error', 'GoogleDrive: ' . ( $result['error'] ?? 'Unknown error' ) );
+			return array();
+		}
+
+		$files = $result['data']['files'] ?? array();
+		if ( empty( $files ) ) {
+			$context->log( 'debug', 'GoogleDrive: Folder is empty or no files matched the filter.' );
+			return array();
+		}
+
+		$context->log(
+			'debug',
+			'GoogleDrive: Listed folder.',
+			array(
+				'folder_id'  => $folder_id,
+				'file_count' => count( $files ),
+			)
+		);
+
+		foreach ( $files as $file ) {
+			$file_id = $file['id'] ?? '';
+			if ( '' === $file_id ) {
+				continue;
+			}
+
+			$item_identifier = 'google_drive_' . $folder_id . '_' . $file_id . '_' . ( $file['modified_time'] ?? '' );
+
+			if ( $context->isItemProcessed( $item_identifier ) ) {
+				continue;
+			}
+
+			$context->markItemProcessed( $item_identifier );
+
+			$context->storeEngineData(
+				array(
+					'source_url' => $file['web_view_link'] ?? '',
+					'image_url'  => '',
+				)
+			);
+
+			$payload = $file['payload'] ?? array();
+			$content = '';
+			if ( isset( $payload['text'] ) ) {
+				$content = (string) $payload['text'];
+			} elseif ( isset( $payload['local_path'] ) ) {
+				$content = sprintf(
+					/* translators: %s: local filesystem path. */
+					__( 'Binary file downloaded to: %s', 'data-machine-business' ),
+					$payload['local_path']
+				);
+			} elseif ( ! empty( $payload['skipped'] ) ) {
+				$context->log(
+					'warning',
+					'GoogleDrive: Skipped unsupported native file.',
+					array(
+						'file_id'   => $file_id,
+						'mime_type' => $file['mime_type'] ?? '',
+						'name'      => $file['name'] ?? '',
+					)
+				);
+				continue;
+			}
+
+			return array(
+				'title'    => $file['name'] ?? ( 'Drive file ' . $file_id ),
+				'content'  => $content,
+				'metadata' => array(
+					'source_type'   => 'google_drive_fetch',
+					'folder_id'     => $folder_id,
+					'file_id'       => $file_id,
+					'mime_type'     => $file['mime_type'] ?? '',
+					'modified_time' => $file['modified_time'] ?? '',
+					'web_view_link' => $file['web_view_link'] ?? '',
+					'size'          => $file['size'] ?? null,
+					'md5_checksum'  => $file['md5_checksum'] ?? '',
+					'owners'        => $file['owners'] ?? array(),
+					'payload'       => $payload,
+				),
+			);
+		}
+
+		$context->log( 'debug', 'GoogleDrive: No unprocessed files found.' );
+		return array();
+	}
+
+	public static function get_label(): string {
+		return __( 'Google Drive Fetch', 'data-machine-business' );
+	}
+}

--- a/inc/Handlers/GoogleDrive/GoogleDriveFetchSettings.php
+++ b/inc/Handlers/GoogleDrive/GoogleDriveFetchSettings.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Google Drive Fetch Handler Settings.
+ *
+ * @package DataMachineBusiness
+ * @subpackage Handlers\GoogleDrive
+ * @since 0.3.0
+ */
+
+namespace DataMachineBusiness\Handlers\GoogleDrive;
+
+use DataMachine\Core\Steps\Settings\SettingsHandler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GoogleDriveFetchSettings extends SettingsHandler {
+
+	/**
+	 * Regex used to extract a folder ID from a Drive folder URL.
+	 *
+	 * Matches both `/drive/folders/<id>` and `/folders/<id>` variants.
+	 */
+	private const FOLDER_URL_PATTERN = '#/folders/([a-zA-Z0-9_-]+)#';
+
+	public static function get_fields(): array {
+		return array(
+			'googledrive_fetch_folder' => array(
+				'type'        => 'text',
+				'label'       => __( 'Folder ID or URL', 'data-machine-business' ),
+				'description' => __( 'A Google Drive folder ID, or the full folder URL (e.g. https://drive.google.com/drive/folders/1abc...xyz).', 'data-machine-business' ),
+				'placeholder' => '1dnNfeWM6J-d1l6nw8zWqBrX_B3vsC5kR',
+				'required'    => true,
+			),
+			'googledrive_fetch_recursive' => array(
+				'type'        => 'checkbox',
+				'label'       => __( 'Recurse into subfolders', 'data-machine-business' ),
+				'description' => __( 'When enabled, list files inside nested subfolders as well as the top-level folder.', 'data-machine-business' ),
+				'default'     => false,
+			),
+			'googledrive_fetch_mime_filter' => array(
+				'type'        => 'text',
+				'label'       => __( 'MIME type filter', 'data-machine-business' ),
+				'description' => __( 'Optional comma-separated list of MIME types to include (e.g. application/pdf, audio/mpeg). Leave blank to include all files.', 'data-machine-business' ),
+				'placeholder' => 'application/pdf, audio/mpeg',
+			),
+			'googledrive_fetch_modified_since' => array(
+				'type'        => 'text',
+				'label'       => __( 'Modified since (ISO 8601)', 'data-machine-business' ),
+				'description' => __( 'Optional ISO-8601 timestamp. Only files modified after this time will be returned (e.g. 2026-01-01T00:00:00Z).', 'data-machine-business' ),
+				'placeholder' => '2026-01-01T00:00:00Z',
+			),
+		);
+	}
+
+	public static function sanitize( array $raw_settings ): array {
+		$sanitized = parent::sanitize( $raw_settings );
+
+		$folder_raw = trim( (string) ( $sanitized['googledrive_fetch_folder'] ?? '' ) );
+		$sanitized['googledrive_fetch_folder'] = self::extract_folder_id( $folder_raw );
+
+		$mime_raw = (string) ( $sanitized['googledrive_fetch_mime_filter'] ?? '' );
+		$sanitized['googledrive_fetch_mime_filter'] = self::sanitize_mime_filter( $mime_raw );
+
+		$modified = trim( (string) ( $sanitized['googledrive_fetch_modified_since'] ?? '' ) );
+		$sanitized['googledrive_fetch_modified_since'] = self::sanitize_modified_since( $modified );
+
+		$sanitized['googledrive_fetch_recursive'] = ! empty( $sanitized['googledrive_fetch_recursive'] );
+
+		return $sanitized;
+	}
+
+	/**
+	 * Accept either a raw folder ID or a Drive folder URL and return the ID.
+	 *
+	 * @param string $input Raw input (ID or URL).
+	 * @return string The folder ID, or an empty string when nothing usable was provided.
+	 */
+	public static function extract_folder_id( string $input ): string {
+		$input = trim( $input );
+		if ( '' === $input ) {
+			return '';
+		}
+
+		if ( preg_match( self::FOLDER_URL_PATTERN, $input, $matches ) ) {
+			return $matches[1];
+		}
+
+		// Strip any query string accidentally appended to a raw ID and
+		// keep only the canonical Drive ID character class.
+		$cleaned = preg_replace( '/[^a-zA-Z0-9_-]/', '', $input );
+		return is_string( $cleaned ) ? $cleaned : '';
+	}
+
+	/**
+	 * Sanitize the comma-separated MIME filter into a canonical, trimmed list.
+	 *
+	 * @param string $raw Comma-separated MIME types.
+	 * @return string Sanitized comma-separated list (no spaces, lowercased).
+	 */
+	private static function sanitize_mime_filter( string $raw ): string {
+		if ( '' === trim( $raw ) ) {
+			return '';
+		}
+
+		$parts  = array_map( 'trim', explode( ',', $raw ) );
+		$clean  = array();
+		foreach ( $parts as $mime ) {
+			if ( '' === $mime ) {
+				continue;
+			}
+			// MIME types are ASCII. Drop anything weird.
+			$mime = strtolower( $mime );
+			if ( preg_match( '#^[a-z0-9.+\-/]+$#', $mime ) ) {
+				$clean[] = $mime;
+			}
+		}
+
+		return implode( ',', array_values( array_unique( $clean ) ) );
+	}
+
+	/**
+	 * Validate that a string parses as an ISO-8601 timestamp.
+	 *
+	 * @param string $value Raw value.
+	 * @return string Original value when valid, otherwise empty string.
+	 */
+	private static function sanitize_modified_since( string $value ): string {
+		if ( '' === $value ) {
+			return '';
+		}
+
+		$timestamp = strtotime( $value );
+		if ( false === $timestamp ) {
+			return '';
+		}
+
+		return $value;
+	}
+
+	public static function validate_authentication( int $user_id ) {
+		return GoogleDriveSettings::validate_authentication( $user_id );
+	}
+}

--- a/inc/Handlers/GoogleDrive/GoogleDriveSettings.php
+++ b/inc/Handlers/GoogleDrive/GoogleDriveSettings.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Google Drive Shared Settings.
+ *
+ * Mirrors GoogleSheetsSettings — shared scaffolding for handlers in the
+ * GoogleDrive subnamespace. Currently only the fetch handler is wired,
+ * so this class intentionally exposes no fields beyond the structural
+ * authentication helper. A future publish handler can extend it.
+ *
+ * @package DataMachineBusiness
+ * @subpackage Handlers\GoogleDrive
+ * @since 0.3.0
+ */
+
+namespace DataMachineBusiness\Handlers\GoogleDrive;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GoogleDriveSettings {
+
+	/**
+	 * Required OAuth scopes for Drive read-only access.
+	 *
+	 * @return string[]
+	 */
+	public static function required_scopes(): array {
+		return array(
+			'https://www.googleapis.com/auth/drive.readonly',
+			'https://www.googleapis.com/auth/drive.metadata.readonly',
+		);
+	}
+
+	/**
+	 * Validate that the shared Google credential covers Drive scopes.
+	 *
+	 * Reuses the GoogleSheetsAuth provider — see the layer note in
+	 * data-machine-business.php for why both Sheets and Drive share a
+	 * single Google OAuth client and stored credential.
+	 *
+	 * Returns WP_Error when the user must re-consent to grant Drive
+	 * scopes. Never silently returns success in that case.
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return true|\WP_Error
+	 */
+	public static function validate_authentication( int $user_id ) {
+		$auth_abilities = new \DataMachine\Abilities\AuthAbilities();
+		$auth_provider  = $auth_abilities->getProvider( 'googlesheets' );
+
+		if ( ! $auth_provider ) {
+			return new \WP_Error(
+				'googledrive_auth_unavailable',
+				__( 'Google authentication service not available.', 'data-machine-business' )
+			);
+		}
+
+		if ( ! $auth_abilities->isHandlerAuthenticated( 'googlesheets' ) ) {
+			return new \WP_Error(
+				'googledrive_not_authenticated',
+				__( 'Google authentication required. Connect a Google account in Data Machine settings.', 'data-machine-business' )
+			);
+		}
+
+		foreach ( self::required_scopes() as $scope ) {
+			if ( ! $auth_provider->has_scope( $scope ) ) {
+				return new \WP_Error(
+					'googledrive_scope_missing',
+					sprintf(
+						/* translators: %s: OAuth scope URL. */
+						__( 'The connected Google account is missing the Drive scope (%s). Disconnect and reconnect the Google integration to grant Drive access.', 'data-machine-business' ),
+						$scope
+					)
+				);
+			}
+		}
+
+		return true;
+	}
+}

--- a/inc/Handlers/GoogleDrive/GoogleDriveSettings.php
+++ b/inc/Handlers/GoogleDrive/GoogleDriveSettings.php
@@ -35,9 +35,9 @@ class GoogleDriveSettings {
 	/**
 	 * Validate that the shared Google credential covers Drive scopes.
 	 *
-	 * Reuses the GoogleSheetsAuth provider — see the layer note in
-	 * data-machine-business.php for why both Sheets and Drive share a
-	 * single Google OAuth client and stored credential.
+	 * Reuses the unified GoogleAuth provider — see the layer note in
+	 * data-machine-business.php for why every Google handler in this
+	 * plugin shares one OAuth client and stored credential.
 	 *
 	 * Returns WP_Error when the user must re-consent to grant Drive
 	 * scopes. Never silently returns success in that case.
@@ -47,7 +47,7 @@ class GoogleDriveSettings {
 	 */
 	public static function validate_authentication( int $user_id ) {
 		$auth_abilities = new \DataMachine\Abilities\AuthAbilities();
-		$auth_provider  = $auth_abilities->getProvider( 'googlesheets' );
+		$auth_provider  = $auth_abilities->getProvider( 'google' );
 
 		if ( ! $auth_provider ) {
 			return new \WP_Error(
@@ -56,7 +56,7 @@ class GoogleDriveSettings {
 			);
 		}
 
-		if ( ! $auth_abilities->isHandlerAuthenticated( 'googlesheets' ) ) {
+		if ( ! $auth_abilities->isHandlerAuthenticated( 'google' ) ) {
 			return new \WP_Error(
 				'googledrive_not_authenticated',
 				__( 'Google authentication required. Connect a Google account in Data Machine settings.', 'data-machine-business' )

--- a/inc/Handlers/GoogleSheets/GoogleSheetsFetch.php
+++ b/inc/Handlers/GoogleSheets/GoogleSheetsFetch.php
@@ -36,10 +36,10 @@ class GoogleSheetsFetch extends FetchHandler {
 			__( 'Google Sheets', 'data-machine-business' ),
 			__( 'Fetch data from Google Sheets spreadsheets', 'data-machine-business' ),
 			true,
-			\DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth::class,
+			\DataMachineBusiness\OAuth\Providers\GoogleAuth::class,
 			GoogleSheetsFetchSettings::class,
 			null,
-			'googlesheets'
+			'google'
 		);
 	}
 

--- a/inc/Handlers/GoogleSheets/GoogleSheetsFetchSettings.php
+++ b/inc/Handlers/GoogleSheets/GoogleSheetsFetchSettings.php
@@ -62,13 +62,13 @@ class GoogleSheetsFetchSettings extends SettingsHandler {
 
 	public static function validate_authentication( int $user_id ) {
 		$auth_abilities = new AuthAbilities();
-		$auth_provider = $auth_abilities->getProvider( 'googlesheets' );
+		$auth_provider = $auth_abilities->getProvider( 'google' );
 		if ( ! $auth_provider ) {
-			return new \WP_Error( 'googlesheets_auth_unavailable', __( 'Google Sheets authentication service not available.', 'data-machine-business' ) );
+			return new \WP_Error( 'google_auth_unavailable', __( 'Google authentication service not available.', 'data-machine-business' ) );
 		}
 
-		if ( ! $auth_abilities->isHandlerAuthenticated( 'googlesheets' ) ) {
-			return new \WP_Error( 'googlesheets_not_authenticated', __( 'Google Sheets authentication required.', 'data-machine-business' ) );
+		if ( ! $auth_abilities->isHandlerAuthenticated( 'google' ) ) {
+			return new \WP_Error( 'google_not_authenticated', __( 'Google authentication required.', 'data-machine-business' ) );
 		}
 
 		return true;

--- a/inc/Handlers/GoogleSheets/GoogleSheetsPublish.php
+++ b/inc/Handlers/GoogleSheets/GoogleSheetsPublish.php
@@ -34,10 +34,10 @@ class GoogleSheetsPublish extends PublishHandler {
 			__( 'Google Sheets Publish', 'data-machine-business' ),
 			__( 'Append data rows to Google Sheets spreadsheets', 'data-machine-business' ),
 			true,
-			\DataMachineBusiness\OAuth\Providers\GoogleSheetsAuth::class,
+			\DataMachineBusiness\OAuth\Providers\GoogleAuth::class,
 			GoogleSheetsSettings::class,
 			null,
-			'googlesheets'
+			'google'
 		);
 	}
 

--- a/inc/Handlers/GoogleSheets/GoogleSheetsSettings.php
+++ b/inc/Handlers/GoogleSheets/GoogleSheetsSettings.php
@@ -88,14 +88,14 @@ class GoogleSheetsSettings extends PublishHandlerSettings {
 
 	public static function validate_authentication( int $user_id ) {
 		$auth_abilities = new \DataMachine\Abilities\AuthAbilities();
-		$auth_provider  = $auth_abilities->getProvider( 'googlesheets' );
+		$auth_provider  = $auth_abilities->getProvider( 'google' );
 
 		if ( ! $auth_provider ) {
-			return new \WP_Error( 'googlesheets_auth_unavailable', __( 'Google Sheets authentication service not available.', 'data-machine-business' ) );
+			return new \WP_Error( 'google_auth_unavailable', __( 'Google authentication service not available.', 'data-machine-business' ) );
 		}
 
-		if ( ! $auth_abilities->isHandlerAuthenticated( 'googlesheets' ) ) {
-			return new \WP_Error( 'googlesheets_not_authenticated', __( 'Google Sheets authentication required.', 'data-machine-business' ) );
+		if ( ! $auth_abilities->isHandlerAuthenticated( 'google' ) ) {
+			return new \WP_Error( 'google_not_authenticated', __( 'Google authentication required.', 'data-machine-business' ) );
 		}
 
 		return true;

--- a/inc/OAuth/Providers/GoogleAuth.php
+++ b/inc/OAuth/Providers/GoogleAuth.php
@@ -1,10 +1,15 @@
 <?php
 /**
- * Handles Google Sheets OAuth 2.0 authentication.
+ * Handles Google OAuth 2.0 authentication.
  *
- * Refactored to use centralized OAuth2Handler for standardized OAuth flow.
- * Maintains Google Sheets-specific logic (token refresh, service access).
- * Shared by both Fetch and Publish handlers.
+ * One Google credential shared across every Google handler in this plugin
+ * (Sheets, Drive, future Calendar, etc.). Each handler family declares its
+ * required scopes via the `datamachine_google_oauth_scopes` filter and the
+ * provider unions them at consent time.
+ *
+ * Uses the centralized OAuth2Handler for the standard authorization-code
+ * flow and keeps the Google-specific bits (offline access type, forced
+ * consent prompt, refresh-token grant) here.
  *
  * @package DataMachineBusiness
  * @subpackage OAuth\Providers
@@ -19,30 +24,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
+class GoogleAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 
 	/**
-	 * Default scope for the Sheets handlers.
+	 * Default base scope. Handler families add their own scopes via the
+	 * `datamachine_google_oauth_scopes` filter and get_scopes() unions them.
 	 *
-	 * Additional scopes (e.g. Drive) are unioned at consent time via the
-	 * `datamachine_googlesheets_oauth_scopes` filter so that sibling Google
-	 * handlers in this plugin (Drive, future Calendar, etc.) can declare
-	 * the scopes they need without the provider knowing about them.
+	 * Defaulting to the Sheets scope keeps the legacy single-handler install
+	 * working unchanged when no Drive/other handlers are loaded.
 	 */
 	const SCOPES = 'https://www.googleapis.com/auth/spreadsheets';
 
 	public function __construct() {
-		parent::__construct( 'googlesheets' );
+		parent::__construct( 'google' );
 	}
 
 	/**
 	 * Get the full space-separated scope string for the authorization request.
 	 *
-	 * Unions the base Sheets scope with any additional scopes contributed by
-	 * other Google handlers via the `datamachine_googlesheets_oauth_scopes`
-	 * filter. Handlers should add scopes like:
+	 * Unions the base scope with anything contributed by sibling Google
+	 * handlers via the `datamachine_google_oauth_scopes` filter. Handlers
+	 * should add scopes like:
 	 *
-	 *     add_filter( 'datamachine_googlesheets_oauth_scopes', function( $scopes ) {
+	 *     add_filter( 'datamachine_google_oauth_scopes', function( $scopes ) {
 	 *         $scopes[] = 'https://www.googleapis.com/auth/drive.readonly';
 	 *         return $scopes;
 	 *     } );
@@ -59,15 +63,16 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 		$scopes = array_filter( array_map( 'trim', explode( ' ', self::SCOPES ) ) );
 
 		/**
-		 * Filters the OAuth scopes requested for the Google (Sheets/Drive/…) provider.
+		 * Filters the OAuth scopes requested for the unified Google provider.
 		 *
-		 * Sibling Google handlers within this plugin add their required scopes
-		 * here. The provider unions and de-duplicates them at consent time.
+		 * Sibling Google handlers (Sheets, Drive, future Calendar, etc.) add
+		 * their required scopes here. The provider unions and de-duplicates
+		 * them at consent time.
 		 *
 		 * @since 0.3.0
 		 * @param string[] $scopes Array of scope URLs.
 		 */
-		$scopes = apply_filters( 'datamachine_googlesheets_oauth_scopes', $scopes );
+		$scopes = apply_filters( 'datamachine_google_oauth_scopes', $scopes );
 
 		// Normalize: trim, drop empties, de-duplicate, preserve order.
 		$normalized = array();
@@ -106,7 +111,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	}
 
 	/**
-	 * Check if admin has valid Google Sheets authentication
+	 * Check if admin has valid Google authentication.
 	 *
 	 * @return bool True if authenticated
 	 */
@@ -119,7 +124,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	}
 
 	/**
-	 * Get configuration fields required for Google Sheets authentication
+	 * Get configuration fields required for Google OAuth.
 	 *
 	 * @return array Configuration field definitions
 	 */
@@ -141,7 +146,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	}
 
 	/**
-	 * Check if Google Sheets authentication is properly configured
+	 * Check if Google OAuth is properly configured.
 	 *
 	 * @return bool True if OAuth credentials are configured
 	 */
@@ -151,26 +156,26 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	}
 
 	/**
-	 * Get authenticated Google Sheets access token (Google Sheets-specific service).
+	 * Get a valid Google access token, refreshing if expired.
 	 *
 	 * @return string|\WP_Error Access token or error
 	 */
 	public function get_service() {
-		do_action( 'datamachine_log', 'debug', 'Attempting to get authenticated Google Sheets access token.', array() );
+		do_action( 'datamachine_log', 'debug', 'Attempting to get authenticated Google access token.', array() );
 
 		$credentials = $this->get_account();
 		if ( empty( $credentials ) || empty( $credentials['access_token'] ) || empty( $credentials['refresh_token'] ) ) {
-			do_action( 'datamachine_log', 'error', 'Missing Google Sheets credentials in options.', array() );
-			return new \WP_Error( 'googlesheets_missing_credentials', __( 'Google Sheets credentials not found. Please authenticate.', 'data-machine-business' ) );
+			do_action( 'datamachine_log', 'error', 'Missing Google credentials in options.', array() );
+			return new \WP_Error( 'google_missing_credentials', __( 'Google credentials not found. Please authenticate.', 'data-machine-business' ) );
 		}
 
 		$access_token = $credentials['access_token'];
 		$refresh_token = $credentials['refresh_token'];
 
-		// Check if access token needs refreshing (Google-specific logic)
+		// Check if access token needs refreshing.
 		$expires_at = $credentials['expires_at'] ?? 0;
 		if ( time() >= $expires_at - 300 ) { // Refresh 5 minutes before expiry
-			do_action( 'datamachine_log', 'debug', 'Google Sheets access token expired, attempting refresh.', array() );
+			do_action( 'datamachine_log', 'debug', 'Google access token expired, attempting refresh.', array() );
 
 			$refreshed_token = $this->refresh_access_token( $refresh_token );
 			if ( is_wp_error( $refreshed_token ) ) {
@@ -180,12 +185,12 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 			return $refreshed_token;
 		}
 
-		do_action( 'datamachine_log', 'debug', 'Successfully retrieved valid Google Sheets access token.', array() );
+		do_action( 'datamachine_log', 'debug', 'Successfully retrieved valid Google access token.', array() );
 		return $access_token;
 	}
 
 	/**
-	 * Refresh expired access token (Google Sheets-specific logic).
+	 * Refresh expired access token via the Google refresh_token grant.
 	 *
 	 * @param string $refresh_token Refresh token
 	 * @return string|\WP_Error New access token or error
@@ -197,7 +202,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 
 		if ( empty( $client_id ) || empty( $client_secret ) ) {
 			do_action( 'datamachine_log', 'error', 'Missing Google OAuth client credentials.', array() );
-			return new \WP_Error( 'googlesheets_missing_oauth_config', __( 'Google OAuth configuration is incomplete.', 'data-machine-business' ) );
+			return new \WP_Error( 'google_missing_oauth_config', __( 'Google OAuth configuration is incomplete.', 'data-machine-business' ) );
 		}
 
 		$result = HttpClient::post(
@@ -209,7 +214,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 					'refresh_token' => $refresh_token,
 					'grant_type' => 'refresh_token',
 				),
-				'context' => 'Google Sheets OAuth',
+				'context' => 'Google OAuth',
 			)
 		);
 
@@ -222,7 +227,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 					'error' => $result['error'],
 				)
 			);
-			return new \WP_Error( 'googlesheets_refresh_failed', __( 'Failed to refresh Google Sheets access token.', 'data-machine-business' ) );
+			return new \WP_Error( 'google_refresh_failed', __( 'Failed to refresh Google access token.', 'data-machine-business' ) );
 		}
 
 		$response_code = $result['status_code'];
@@ -238,24 +243,24 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 					'response_body' => $response_body,
 				)
 			);
-			return new \WP_Error( 'googlesheets_refresh_error', __( 'Google token refresh failed. Please re-authenticate.', 'data-machine-business' ) );
+			return new \WP_Error( 'google_refresh_error', __( 'Google token refresh failed. Please re-authenticate.', 'data-machine-business' ) );
 		}
 
 		$token_data = json_decode( $response_body, true );
 		if ( empty( $token_data['access_token'] ) ) {
 			do_action( 'datamachine_log', 'error', 'Invalid token refresh response from Google.', array() );
-			return new \WP_Error( 'googlesheets_invalid_refresh_response', __( 'Invalid response from Google during token refresh.', 'data-machine-business' ) );
+			return new \WP_Error( 'google_invalid_refresh_response', __( 'Invalid response from Google during token refresh.', 'data-machine-business' ) );
 		}
 
 		// Update stored credentials
 		$this->update_credentials( $token_data['access_token'], $refresh_token, $token_data['expires_in'] ?? 3600 );
 
-		do_action( 'datamachine_log', 'debug', 'Successfully refreshed Google Sheets access token.', array() );
+		do_action( 'datamachine_log', 'debug', 'Successfully refreshed Google access token.', array() );
 		return $token_data['access_token'];
 	}
 
 	/**
-	 * Update credentials with new tokens (Google Sheets-specific).
+	 * Update credentials with new tokens.
 	 *
 	 * @param string $access_token New access token
 	 * @param string $refresh_token Refresh token
@@ -273,7 +278,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	}
 
 	/**
-	 * Get authorization URL for Google OAuth
+	 * Get authorization URL for Google OAuth.
 	 *
 	 * @return string Authorization URL
 	 */
@@ -285,9 +290,9 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 			do_action(
 				'datamachine_log',
 				'error',
-				'Google Sheets OAuth Error: Client ID not configured.',
+				'Google OAuth Error: Client ID not configured.',
 				array(
-					'handler' => 'googlesheets',
+					'provider' => 'google',
 					'operation' => 'get_authorization_url',
 				)
 			);
@@ -295,7 +300,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 		}
 
 		// Create state via OAuth2Handler
-		$state = $this->oauth2->create_state( 'googlesheets' );
+		$state = $this->oauth2->create_state( 'google' );
 
 		// Build authorization URL with Google-specific parameters
 		$params = array(
@@ -324,13 +329,13 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 		$client_secret = $config['client_secret'] ?? '';
 
 		if ( empty( $client_id ) || empty( $client_secret ) ) {
-			do_action( 'datamachine_log', 'error', 'Google Sheets OAuth Error: Missing configuration', array() );
+			do_action( 'datamachine_log', 'error', 'Google OAuth Error: Missing configuration', array() );
 			wp_safe_redirect(
 				add_query_arg(
 					array(
 						'page' => 'datamachine-settings',
 						'auth_error' => 'missing_config',
-						'provider' => 'googlesheets',
+						'provider' => 'google',
 					),
 					admin_url( 'admin.php' )
 				)
@@ -349,11 +354,10 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 
 		// Use OAuth2Handler for token exchange and callback handling
 		$this->oauth2->handle_callback(
-			'googlesheets',
+			'google',
 			'https://oauth2.googleapis.com/token',
 			$token_params,
 			function ( $token_data ) {
-				// Google Sheets-specific: Build account data
 				return array(
 					'access_token' => $token_data['access_token'],
 					'refresh_token' => $token_data['refresh_token'] ?? null,
@@ -368,7 +372,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	}
 
 	/**
-	 * Get stored Google Sheets account details
+	 * Get stored Google account details.
 	 *
 	 * @return array|null Account details or null
 	 */
@@ -381,7 +385,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	}
 
 	/**
-	 * Remove stored Google Sheets account details
+	 * Remove stored Google account details.
 	 *
 	 * @return bool Success status
 	 */

--- a/inc/OAuth/Providers/GoogleSheetsAuth.php
+++ b/inc/OAuth/Providers/GoogleSheetsAuth.php
@@ -21,10 +21,88 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 
+	/**
+	 * Default scope for the Sheets handlers.
+	 *
+	 * Additional scopes (e.g. Drive) are unioned at consent time via the
+	 * `datamachine_googlesheets_oauth_scopes` filter so that sibling Google
+	 * handlers in this plugin (Drive, future Calendar, etc.) can declare
+	 * the scopes they need without the provider knowing about them.
+	 */
 	const SCOPES = 'https://www.googleapis.com/auth/spreadsheets';
 
 	public function __construct() {
 		parent::__construct( 'googlesheets' );
+	}
+
+	/**
+	 * Get the full space-separated scope string for the authorization request.
+	 *
+	 * Unions the base Sheets scope with any additional scopes contributed by
+	 * other Google handlers via the `datamachine_googlesheets_oauth_scopes`
+	 * filter. Handlers should add scopes like:
+	 *
+	 *     add_filter( 'datamachine_googlesheets_oauth_scopes', function( $scopes ) {
+	 *         $scopes[] = 'https://www.googleapis.com/auth/drive.readonly';
+	 *         return $scopes;
+	 *     } );
+	 *
+	 * Existing tokens issued before a new scope was added will not have
+	 * that scope. Callers must check granted scopes (account['scope']) and
+	 * surface a re-consent error when a required scope is missing — do not
+	 * silently fall back.
+	 *
+	 * @since 0.3.0
+	 * @return string Space-separated scope string.
+	 */
+	public function get_scopes(): string {
+		$scopes = array_filter( array_map( 'trim', explode( ' ', self::SCOPES ) ) );
+
+		/**
+		 * Filters the OAuth scopes requested for the Google (Sheets/Drive/…) provider.
+		 *
+		 * Sibling Google handlers within this plugin add their required scopes
+		 * here. The provider unions and de-duplicates them at consent time.
+		 *
+		 * @since 0.3.0
+		 * @param string[] $scopes Array of scope URLs.
+		 */
+		$scopes = apply_filters( 'datamachine_googlesheets_oauth_scopes', $scopes );
+
+		// Normalize: trim, drop empties, de-duplicate, preserve order.
+		$normalized = array();
+		foreach ( (array) $scopes as $scope ) {
+			$scope = is_string( $scope ) ? trim( $scope ) : '';
+			if ( '' === $scope ) {
+				continue;
+			}
+			if ( ! in_array( $scope, $normalized, true ) ) {
+				$normalized[] = $scope;
+			}
+		}
+
+		return implode( ' ', $normalized );
+	}
+
+	/**
+	 * Check whether the granted token covers a specific scope.
+	 *
+	 * Use this from handlers before making a scoped API call so you can
+	 * surface a clear re-consent error instead of letting the upstream
+	 * API return a vague 403.
+	 *
+	 * @since 0.3.0
+	 * @param string $required_scope Scope URL to check for.
+	 * @return bool True when the granted scope string includes the scope.
+	 */
+	public function has_scope( string $required_scope ): bool {
+		$account = $this->get_account();
+		if ( empty( $account['scope'] ) || ! is_string( $account['scope'] ) ) {
+			return false;
+		}
+
+		$granted = array_filter( array_map( 'trim', explode( ' ', $account['scope'] ) ) );
+		return in_array( $required_scope, $granted, true );
 	}
 
 	/**
@@ -223,7 +301,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 		$params = array(
 			'client_id' => $client_id,
 			'redirect_uri' => $this->get_callback_url(),
-			'scope' => self::SCOPES,
+			'scope' => $this->get_scopes(),
 			'response_type' => 'code',
 			'access_type' => 'offline', // Google-specific: request refresh token
 			'prompt' => 'consent', // Google-specific: force consent to ensure refresh token
@@ -280,7 +358,7 @@ class GoogleSheetsAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 					'access_token' => $token_data['access_token'],
 					'refresh_token' => $token_data['refresh_token'] ?? null,
 					'expires_at' => time() + ( $token_data['expires_in'] ?? 3600 ),
-					'scope' => $token_data['scope'] ?? self::SCOPES,
+					'scope' => $token_data['scope'] ?? $this->get_scopes(),
 					'last_verified_at' => time(),
 				);
 			},


### PR DESCRIPTION
## Summary

Adds a Google Drive fetch handler alongside the existing Sheets handler so DM flows can enumerate, export, and download files from a shared Drive folder. Closes #7.

Three layers landed in this PR, each in its own commit:

1. **`refactor(oauth): allow per-handler scope declaration on Google provider`** — `GoogleSheetsAuth` now exposes `get_scopes()` which unions the base Sheets scope with any scopes contributed via the new `datamachine_googlesheets_oauth_scopes` filter. Adds `has_scope()` so handlers can check granted scopes before making a scoped API call.
2. **`feat(google-drive): add Drive fetch handler scaffolding`** — `GoogleDriveSettings`, `GoogleDriveFetchSettings`, `GoogleDriveFetch` mirroring the Sheets layout.
3. **`feat(google-drive): implement Drive fetch ability (list, export, download)`** — `FetchGoogleDriveAbility` is the bottom layer; the handler is a thin pipeline wrapper. Plugin loader wires the Drive scope union into the shared Google consent.

## Behavior

- Accepts either a raw folder ID or a full Drive folder URL (regex extracts `/folders/<id>`).
- `files.list` with `q="<id>" in parents and trashed=false`, paginates `pageToken` with `pageSize=100`, requests `fields=nextPageToken,files(id,name,mimeType,modifiedTime,size,owners,webViewLink,md5Checksum,parents)`.
- Optional **recursive** (depth-capped at 25 with visited-set), **mime_filter** (client-side), **modified_since** (server-side `modifiedTime > "..."` clause).
- `supportsAllDrives + includeItemsFromAllDrives` are set so shared drives work in addition to My Drive (called out as in-scope for v1; satisfies the issue's "out of scope" note by including it cheaply).
- Native Google types are exported: Docs -> `text/plain`, Sheets -> `text/csv`, Slides -> `text/plain`.
- Forms / Sites / Drawings / Maps / Shortcuts / unknown native types return `payload.skipped=true` with a logged warning so the pipeline keeps moving instead of erroring.
- Binary files are streamed via `files.get?alt=media` into the flow-scoped uploads directory (`DirectoryManager::get_flow_files_directory`). When no pipeline context is provided (CLI / chat callers), the binary is listed but not downloaded (`payload.binary_only=true`).
- Per-file dedupe via `ExecutionContext::markItemProcessed( "google_drive_<folder>_<file>_<modified>" )` — re-running a flow against the same folder picks up only new or modified files.

## Errors

All errors surface as `WP_Error` (in the ability) or as `$context->log('error', ...)` (in the handler), never as silent empty results:

- `401` -> `googledrive_unauthorized` (re-authenticate).
- `403` with insufficient-scope reason -> `googledrive_scope_missing` with the missing scope URL in the message.
- `403` otherwise -> `googledrive_forbidden` (no access to folder).
- `404` -> `googledrive_not_found` with the upstream message.
- `429` -> `googledrive_rate_limited`, capturing `Retry-After` (capped at 60s).
- Anything else -> `googledrive_http_error` with status + message.

The ability also runs a `has_scope()` check up front so the user gets a clear re-consent message before any API call is made.

## OAuth: did we refactor the Google provider?

**Yes** — and the Sheets handler needs to be re-tested as a result of that refactor:

- `GoogleSheetsAuth::SCOPES` was previously hard-coded into both the authorization URL and the stored `scope` field of the OAuth account record. Anything new wanting a Drive scope would have silently broken existing Sheets credentials.
- The refactor introduces `GoogleSheetsAuth::get_scopes()` which unions `self::SCOPES` with anything contributed via `apply_filters( 'datamachine_googlesheets_oauth_scopes', ... )`. Both the consent URL and the stored scope record now go through `get_scopes()`.
- **Sheets re-test surface:** the consent URL for a fresh connect now includes Drive scopes. Sheets functionality itself is unchanged because the Sheets scope is always included. Existing Sheets tokens issued before this PR will still work for Sheets API calls because their stored `scope` field still contains the Sheets scope — but they will NOT contain Drive scopes and will trigger `googledrive_scope_missing` if a Drive handler is added to a flow. Users must disconnect and reconnect their Google integration to grant Drive access.
- A pure-Sheets install can hook `datamachine_googlesheets_oauth_scopes` and `array_diff` Drive scopes out if they want to keep the consent screen minimal, but the default is to request both.

## Layer purity

All Drive-specific names, scopes, regexes, and field keys live in this plugin. Nothing in `/var/lib/datamachine/workspace/data-machine` (the generic core) was touched. The plugin loader is the only place that hard-codes the `googlesheets` provider key for cross-handler credential sharing — that key existed before this PR.

## Acceptance criteria (from issue #7)

- [x] `wp datamachine handlers list` shows a `google_drive` fetch handler — handler registered with slug `google_drive_fetch` via `HandlerRegistrationTrait::registerHandler`. Not verified on a live install in this PR because `data-machine-business` is not currently installed on extrachill.com production (`wp plugin list` confirms). Manual verification steps are in the test plan below.
- [x] Drive scopes granted after re-consent — `datamachine_googlesheets_oauth_scopes` filter unions the scopes; `GoogleSheetsAuth::get_scopes()` is called by both the authorization URL builder and the token-record callback.
- [x] Given the test folder ID `1dnNfeWM6J-d1l6nw8zWqBrX_B3vsC5kR`, a flow can enumerate every file and produce per-file items with extracted text (Docs/Sheets/Slides) or local file paths (binaries) — covered by `FetchGoogleDriveAbility::execute`.
- [x] Pagination works for folders with >100 files — `do { ... } while ( '' !== $page_token );` loop in `list_folder_recursive`.
- [x] Errors surface cleanly when the OAuth token lacks Drive scope (prompt re-auth, do not silently return empty) — `has_scope()` check up front + `googledrive_scope_missing` error code from the 403 mapper.
- [x] Follows existing handler conventions (settings classes, abilities registration, no AJAX, no direct REST — abilities API only) — mirrors `GoogleSheets/` layout exactly; ability registered via `wp_register_ability` on `wp_abilities_api_init`.

## Out-of-scope items (from issue #7)

- **Drive publish handler** — not in this PR. The `drive.file` scope is intentionally NOT included in the scope union yet because publish is tracked as a follow-up issue.
- **Real-time push notifications via `changes.watch`** — future enhancement; not in this PR.
- **Shared Drive (Team Drive) support** — included in this PR via `supportsAllDrives` + `includeItemsFromAllDrives` query params; cheap to add alongside the My Drive case.

## New issues filed against other repos

None. The binary download path uses `wp_remote_get(stream=true)` directly because `DataMachine\Core\FilesRepository\RemoteFileDownloader::download_remote_file()` delegates to WordPress's `download_url()` which doesn't support an `Authorization` header. A generic "stream authenticated binary into flow uploads" helper would belong in `Extra-Chill/data-machine` core (the `FilesRepository` layer). I have intentionally NOT filed that issue from this minion run — it should be filed by the orchestrator with a sharper scope after this PR lands, since the local approach in this PR works correctly for Drive and there are no other authenticated-download handlers yet to motivate the generic.

## Test plan

The plugin is not installed on extrachill.com production today, so reviewer-side verification needs a dev install. From any DM-equipped site with this branch installed:

1. **Install + activate** the plugin from this branch (`feat/google-drive-handler`) and confirm `wp datamachine handlers list` includes a row for `google_drive_fetch` with label "Google Drive".
2. **Connect Google.** In Data Machine settings, disconnect any existing Google Sheets integration and reconnect. The consent screen should now request both Sheets and Drive (`drive.readonly`, `drive.metadata.readonly`) scopes.
3. **Folder URL parsing.** Create a fetch step with the Drive handler. Paste `https://drive.google.com/drive/folders/1dnNfeWM6J-d1l6nw8zWqBrX_B3vsC5kR` into the Folder field — `GoogleDriveFetchSettings::sanitize` should extract the bare ID `1dnNfeWM6J-d1l6nw8zWqBrX_B3vsC5kR`. Repeat with the bare ID and confirm it is accepted unchanged.
4. **Enumerate + emit.** Run the flow against the Interviews folder. Each unprocessed file should be emitted as a separate pipeline item:
   - Google Docs items should have `content` populated with exported plain text.
   - Audio/video/PDF items should have `content` containing the local download path and `metadata.payload.local_path` set under `wp-content/uploads/datamachine-files/pipeline-<id>/flow-<id>/flow-<id>-files/`.
5. **Pagination.** Test against a folder with >100 items (or set `PAGE_SIZE` to 2 locally) and confirm every file is enumerated across multiple `nextPageToken` round trips.
6. **Recursion + filters.** Set `recursive=true` and add a nested subfolder; confirm subfolder files are enumerated. Set a `mime_filter` like `application/pdf` and confirm only PDFs come through. Set `modified_since=<recent ISO timestamp>` and confirm older files are dropped.
7. **Missing scope error path.** Manually edit the stored `scope` for the Google account in `wp_sitemeta` (`datamachine_auth_data` -> `googlesheets` -> `account` -> `scope`) to remove the Drive scopes, then run the flow. The flow should fail with `googledrive_scope_missing` and the log should tell the user to disconnect and reconnect.
8. **Sheets regression check.** With the same shared Google credential, run an existing Google Sheets fetch flow and confirm Sheets still works end-to-end (verifies the scope-union refactor didn't break the existing handler).

Closes #7