### PR TITLE
feat(google-drive): one-shot abilities for list/read/download (closes #10)

### DIFF
--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -60,6 +60,7 @@ function datamachine_business_load_handlers() {
 	// Google Drive (shares the unified GoogleAuth credential — see scope union below)
 	new \DataMachineBusiness\Abilities\GoogleDrive\FetchGoogleDriveAbility();
 	new \DataMachineBusiness\Abilities\GoogleDrive\ListGoogleDriveFilesAbility();
+	new \DataMachineBusiness\Abilities\GoogleDrive\ReadGoogleDriveDocAbility();
 	new \DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveFetch();
 
 	// Slack

--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -59,6 +59,7 @@ function datamachine_business_load_handlers() {
 
 	// Google Drive (shares the unified GoogleAuth credential — see scope union below)
 	new \DataMachineBusiness\Abilities\GoogleDrive\FetchGoogleDriveAbility();
+	new \DataMachineBusiness\Abilities\GoogleDrive\ListGoogleDriveFilesAbility();
 	new \DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveFetch();
 
 	// Slack

--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -61,6 +61,7 @@ function datamachine_business_load_handlers() {
 	new \DataMachineBusiness\Abilities\GoogleDrive\FetchGoogleDriveAbility();
 	new \DataMachineBusiness\Abilities\GoogleDrive\ListGoogleDriveFilesAbility();
 	new \DataMachineBusiness\Abilities\GoogleDrive\ReadGoogleDriveDocAbility();
+	new \DataMachineBusiness\Abilities\GoogleDrive\DownloadGoogleDriveAbility();
 	new \DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveFetch();
 
 	// Slack

--- a/inc/Abilities/GoogleDrive/AuthHelper.php
+++ b/inc/Abilities/GoogleDrive/AuthHelper.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Shared auth resolution for Google Drive abilities.
+ *
+ * Every Drive ability needs the same dance: look up the unified Google
+ * OAuth provider via the `datamachine_auth_providers` filter, confirm
+ * the connected account has the Drive scope, and pull a refreshed
+ * access token. This helper centralizes that so each ability stays
+ * focused on its own input/output shape.
+ *
+ * @package DataMachineBusiness
+ * @subpackage Abilities\GoogleDrive
+ * @since 0.4.0
+ */
+
+namespace DataMachineBusiness\Abilities\GoogleDrive;
+
+use DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveClient;
+use DataMachineBusiness\OAuth\Providers\GoogleAuth;
+
+defined( 'ABSPATH' ) || exit;
+
+class AuthHelper {
+
+	/**
+	 * Resolve the unified Google OAuth provider instance, if registered.
+	 */
+	public static function get_provider(): ?GoogleAuth {
+		$providers = apply_filters( 'datamachine_auth_providers', array() );
+		$provider  = $providers['google'] ?? null;
+		return $provider instanceof GoogleAuth ? $provider : null;
+	}
+
+	/**
+	 * Obtain a valid Drive access token, or a WP_Error explaining why not.
+	 *
+	 * Surfaces three distinct error codes so callers can produce the right
+	 * user-facing message:
+	 * - `googledrive_auth_unavailable` — provider not registered (plugin
+	 *   load order or missing GoogleAuth class).
+	 * - `googledrive_scope_missing` — provider registered but the stored
+	 *   token does not cover the Drive scope. User must disconnect and
+	 *   reconnect.
+	 * - any token-refresh WP_Error from GoogleAuth::get_service().
+	 *
+	 * @return string|\WP_Error Access token on success.
+	 */
+	public static function get_access_token() {
+		$provider = self::get_provider();
+		if ( ! $provider ) {
+			return new \WP_Error(
+				'googledrive_auth_unavailable',
+				__( 'Google authentication provider is not registered.', 'data-machine-business' )
+			);
+		}
+
+		if ( ! $provider->has_scope( GoogleDriveClient::REQUIRED_SCOPE ) ) {
+			return new \WP_Error(
+				'googledrive_scope_missing',
+				sprintf(
+					/* translators: %s: OAuth scope URL. */
+					__( 'The connected Google account is missing the Drive scope (%s). Disconnect and reconnect the Google integration in Data Machine settings to grant Drive access.', 'data-machine-business' ),
+					GoogleDriveClient::REQUIRED_SCOPE
+				)
+			);
+		}
+
+		$token = $provider->get_service();
+		if ( is_wp_error( $token ) ) {
+			return $token;
+		}
+
+		if ( ! is_string( $token ) || '' === $token ) {
+			return new \WP_Error(
+				'googledrive_token_missing',
+				__( 'Failed to obtain a Google access token.', 'data-machine-business' )
+			);
+		}
+
+		return $token;
+	}
+}

--- a/inc/Abilities/GoogleDrive/DownloadGoogleDriveAbility.php
+++ b/inc/Abilities/GoogleDrive/DownloadGoogleDriveAbility.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * Download Google Drive Ability.
+ *
+ * One-shot download of a binary Drive file to local disk for direct
+ * CLI / chat / REST invocation. The destination is configurable; the
+ * default lives under the WordPress uploads area at
+ * `<uploads>/drive-imports/<YYYY>/<MM>/` so subsequent abilities (e.g.
+ * a future media-library import) can pick the file up by absolute path.
+ *
+ * Refuses native Google types (Doc / Sheet / Slide) — those go through
+ * `datamachine/read-googledrive-doc` instead.
+ *
+ * @package DataMachineBusiness
+ * @subpackage Abilities\GoogleDrive
+ * @since 0.4.0
+ */
+
+namespace DataMachineBusiness\Abilities\GoogleDrive;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveClient;
+
+defined( 'ABSPATH' ) || exit;
+
+class DownloadGoogleDriveAbility {
+
+	private const DEFAULT_SUBDIR = 'drive-imports';
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/download-googledrive',
+				array(
+					'label'               => __( 'Download Google Drive File', 'data-machine-business' ),
+					'description'         => __( 'Download a binary Google Drive file to local disk. Defaults to the WordPress uploads area under drive-imports/<YYYY>/<MM>/. Refuses native Google Docs/Sheets/Slides — use read-googledrive-doc for those.', 'data-machine-business' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'file' ),
+						'properties' => array(
+							'file' => array(
+								'type'        => 'string',
+								'description' => __( 'Google Drive file ID or full Drive URL (e.g. https://drive.google.com/file/d/1abc...xyz/view). Accepts either form; the URL is parsed server-side.', 'data-machine-business' ),
+							),
+							'destination' => array(
+								'type'        => 'string',
+								'description' => __( 'Optional destination. Accepts an absolute server path (resolves to a directory the downloaded file is placed inside) OR a subdirectory relative to the WordPress uploads root. When omitted, the file lands in <wp-uploads>/drive-imports/<YYYY>/<MM>/.', 'data-machine-business' ),
+							),
+							'overwrite' => array(
+								'type'        => 'boolean',
+								'default'     => false,
+								'description' => __( 'When false (default), the ability refuses to overwrite an existing file at the resolved destination and returns googledrive_file_exists. When true, the existing file is replaced.', 'data-machine-business' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array(
+								'type'       => 'object',
+								'properties' => array(
+									'id'            => array( 'type' => 'string' ),
+									'name'          => array( 'type' => 'string' ),
+									'mime_type'     => array( 'type' => 'string' ),
+									'size'          => array( 'type' => array( 'integer', 'null' ) ),
+									'local_path'    => array( 'type' => 'string', 'description' => __( 'Absolute server path where the file was written. A follow-up ability (e.g. media-library import) can pick the file up by this path.', 'data-machine-business' ) ),
+									'web_view_link' => array( 'type' => 'string' ),
+								),
+							),
+							'error'   => array( 'type' => 'string' ),
+							'logs'    => array( 'type' => 'array' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result envelope.
+	 */
+	public function execute( array $input ): array {
+		$logs = array();
+
+		$file_raw = isset( $input['file'] ) ? (string) $input['file'] : '';
+		$file_id  = GoogleDriveClient::extract_file_id( $file_raw );
+		if ( '' === $file_id ) {
+			return $this->fail( 'file is required (Drive file ID or URL).', $logs );
+		}
+
+		$overwrite       = ! empty( $input['overwrite'] );
+		$destination_raw = isset( $input['destination'] ) ? trim( (string) $input['destination'] ) : '';
+
+		$access_token = AuthHelper::get_access_token();
+		if ( is_wp_error( $access_token ) ) {
+			return $this->fail( $access_token->get_error_message(), $logs );
+		}
+
+		$client = new GoogleDriveClient( $access_token );
+
+		$metadata = $client->get_file_metadata( $file_id, $logs );
+		if ( is_wp_error( $metadata ) ) {
+			return $this->fail( $metadata->get_error_message(), $logs );
+		}
+
+		$mime = (string) ( $metadata['mimeType'] ?? '' );
+		$name = (string) ( $metadata['name'] ?? '' );
+
+		if ( GoogleDriveClient::is_native_google_type( $mime ) ) {
+			$logs[] = array(
+				'level'   => 'error',
+				'message' => 'GoogleDrive: download called on a native Google type.',
+				'data'    => array( 'file_id' => $file_id, 'mime_type' => $mime ),
+			);
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'File "%s" is a native Google type (mime: %s). Use datamachine/read-googledrive-doc to export its text content.', $name, $mime ),
+				'data'    => array(
+					'id'        => $file_id,
+					'name'      => $name,
+					'mime_type' => $mime,
+				),
+				'error_code' => 'googledrive_not_a_binary',
+				'logs'       => $logs,
+			);
+		}
+
+		$directory_result = $this->resolve_destination_directory( $destination_raw );
+		if ( is_wp_error( $directory_result ) ) {
+			return $this->fail( $directory_result->get_error_message(), $logs );
+		}
+		$directory = $directory_result;
+
+		$safe_name        = sanitize_file_name( $name ?: ( 'drive-' . $file_id ) );
+		if ( '' === $safe_name ) {
+			$safe_name = 'drive-' . $file_id;
+		}
+		$destination_path = trailingslashit( $directory ) . $safe_name;
+
+		if ( file_exists( $destination_path ) && ! $overwrite ) {
+			$logs[] = array(
+				'level'   => 'error',
+				'message' => 'GoogleDrive: Destination file exists and overwrite=false.',
+				'data'    => array( 'destination' => $destination_path ),
+			);
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'File already exists at %s. Pass overwrite=true to replace it.', $destination_path ),
+				'data'    => array(
+					'id'         => $file_id,
+					'name'       => $name,
+					'mime_type'  => $mime,
+					'local_path' => $destination_path,
+				),
+				'error_code' => 'googledrive_file_exists',
+				'logs'       => $logs,
+			);
+		}
+
+		// If overwrite is requested and the target exists, remove it
+		// first so download_binary's rename() never fails with EEXIST on
+		// platforms where rename() does not overwrite atomically.
+		if ( file_exists( $destination_path ) && $overwrite ) {
+			wp_delete_file( $destination_path );
+		}
+
+		$saved = $client->download_binary( $file_id, $destination_path, $logs );
+		if ( is_wp_error( $saved ) ) {
+			return $this->fail( $saved->get_error_message(), $logs );
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'id'            => $file_id,
+				'name'          => $name,
+				'mime_type'     => $mime,
+				'size'          => isset( $saved['size'] ) ? (int) $saved['size'] : null,
+				'local_path'    => (string) $saved['local_path'],
+				'web_view_link' => (string) ( $metadata['webViewLink'] ?? '' ),
+			),
+			'logs'    => $logs,
+		);
+	}
+
+	/**
+	 * Resolve the destination directory and ensure it exists.
+	 *
+	 * Accepts:
+	 * - empty / missing → default to <wp-uploads>/drive-imports/<YYYY>/<MM>/
+	 * - absolute path   → used verbatim as the directory (parent must exist
+	 *                     or be creatable). Treated as a directory; the file
+	 *                     name is always derived from the Drive name.
+	 * - relative path   → joined under the WordPress uploads root.
+	 *
+	 * @param string $raw Caller-supplied destination.
+	 * @return string|\WP_Error Absolute directory path on success.
+	 */
+	private function resolve_destination_directory( string $raw ) {
+		$uploads = wp_get_upload_dir();
+		if ( ! empty( $uploads['error'] ) ) {
+			return new \WP_Error( 'googledrive_uploads_unavailable', sprintf( 'WordPress uploads directory unavailable: %s', $uploads['error'] ) );
+		}
+
+		$uploads_basedir = isset( $uploads['basedir'] ) ? (string) $uploads['basedir'] : '';
+		if ( '' === $uploads_basedir ) {
+			return new \WP_Error( 'googledrive_uploads_unavailable', 'WordPress uploads basedir is empty.' );
+		}
+
+		if ( '' === $raw ) {
+			$dir = trailingslashit( $uploads_basedir )
+				. self::DEFAULT_SUBDIR . '/'
+				. gmdate( 'Y' ) . '/'
+				. gmdate( 'm' );
+		} elseif ( $this->is_absolute_path( $raw ) ) {
+			$dir = rtrim( $raw, '/\\' );
+		} else {
+			// Relative paths sit under uploads/. Strip leading separators
+			// and parent-directory shenanigans before joining.
+			$clean = ltrim( $raw, '/\\' );
+			$clean = str_replace( array( '..', "\0" ), '', $clean );
+			if ( '' === $clean ) {
+				return new \WP_Error( 'googledrive_invalid_destination', 'Destination resolved to an empty path.' );
+			}
+			$dir = trailingslashit( $uploads_basedir ) . $clean;
+			$dir = rtrim( $dir, '/\\' );
+		}
+
+		if ( ! wp_mkdir_p( $dir ) ) {
+			return new \WP_Error( 'googledrive_dir_failed', sprintf( 'Failed to create destination directory: %s', $dir ) );
+		}
+
+		if ( ! is_writable( $dir ) ) {
+			return new \WP_Error( 'googledrive_dir_not_writable', sprintf( 'Destination directory is not writable: %s', $dir ) );
+		}
+
+		return $dir;
+	}
+
+	private function is_absolute_path( string $path ): bool {
+		if ( '' === $path ) {
+			return false;
+		}
+		if ( '/' === $path[0] ) {
+			return true;
+		}
+		// Windows: drive letter + colon (`C:\...`) or `\\server\share`.
+		if ( preg_match( '#^[A-Za-z]:[\\\\/]#', $path ) || 0 === strpos( $path, '\\\\' ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	private function fail( string $message, array $logs ): array {
+		$logs[] = array( 'level' => 'error', 'message' => $message );
+		return array(
+			'success' => false,
+			'error'   => $message,
+			'logs'    => $logs,
+		);
+	}
+}

--- a/inc/Abilities/GoogleDrive/FetchGoogleDriveAbility.php
+++ b/inc/Abilities/GoogleDrive/FetchGoogleDriveAbility.php
@@ -2,24 +2,18 @@
 /**
  * Fetch Google Drive Ability.
  *
- * Pure business logic — no handler config, no engine data, no pipeline
- * context. Any caller (REST, CLI, chat tool, pipeline handler) can
- * invoke this directly.
+ * Pipeline-shaped Drive fetcher — accepts a download target (pipeline
+ * + flow IDs) so binary files can be streamed to the flow-scoped
+ * uploads directory. Any caller (REST, CLI, chat tool, pipeline
+ * handler) can invoke this directly, but binary downloads only happen
+ * when a flow context is supplied. Callers that want a one-shot
+ * download into the WP uploads area should call the dedicated
+ * `datamachine/download-googledrive` ability instead.
  *
- * Resolves auth via the unified `google` OAuth provider — single
- * credential covers every Google handler in this plugin. See the
- * plugin loader for the scope union.
- *
- * Behavior:
- * - Lists files in a Drive folder via files.list with pagination.
- * - Optionally recurses into subfolders.
- * - Optionally filters by MIME type and modifiedTime.
- * - Native Google Docs / Sheets / Slides are exported to text/csv.
- * - Other binary files are streamed to the Data Machine uploads area
- *   when a download target (pipeline/flow context) is provided.
- * - Google Forms / Sites and other non-exportable native types are
- *   returned with `payload.skipped = true` so the caller can decide
- *   whether to log and continue.
+ * Resolves auth via the unified `google` OAuth provider. All HTTP /
+ * pagination / export / error mapping lives in
+ * `Handlers\GoogleDrive\GoogleDriveClient` — this class is just the
+ * pipeline glue.
  *
  * @package DataMachineBusiness
  * @subpackage Abilities\GoogleDrive
@@ -30,18 +24,12 @@ namespace DataMachineBusiness\Abilities\GoogleDrive;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\FilesRepository\DirectoryManager;
-use DataMachine\Core\FilesRepository\FilesystemHelper;
+use DataMachineBusiness\Abilities\GoogleDrive\AuthHelper;
+use DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveClient;
 
 defined( 'ABSPATH' ) || exit;
 
 class FetchGoogleDriveAbility {
-
-	private const API_BASE         = 'https://www.googleapis.com/drive/v3';
-	private const LIST_FIELDS      = 'nextPageToken,files(id,name,mimeType,modifiedTime,size,owners,webViewLink,md5Checksum,parents)';
-	private const PAGE_SIZE        = 100;
-	private const REQUIRED_SCOPE   = 'https://www.googleapis.com/auth/drive.readonly';
-	private const MAX_RECURSION    = 25;
-	private const RETRY_AFTER_CAP  = 60;
 
 	private static bool $registered = false;
 
@@ -131,46 +119,24 @@ class FetchGoogleDriveAbility {
 			return $this->fail( 'folder_id is required.', $logs );
 		}
 
-		$recursive       = ! empty( $input['recursive'] );
-		$mime_filter     = isset( $input['mime_filter'] ) && is_array( $input['mime_filter'] ) ? array_values( array_filter( array_map( 'strval', $input['mime_filter'] ) ) ) : array();
-		$modified_since  = isset( $input['modified_since'] ) ? trim( (string) $input['modified_since'] ) : '';
 		$download_target = isset( $input['download_target'] ) && is_array( $input['download_target'] ) ? $input['download_target'] : array();
 
-		$auth_provider = self::get_auth_provider();
-		if ( ! $auth_provider ) {
-			return $this->fail( 'Google authentication provider is not registered.', $logs );
-		}
-
-		if ( ! $auth_provider->has_scope( self::REQUIRED_SCOPE ) ) {
-			return $this->fail(
-				sprintf(
-					/* translators: %s: OAuth scope URL. */
-					'The connected Google account is missing the Drive scope (%s). Disconnect and reconnect the Google integration in Data Machine settings to grant Drive access.',
-					self::REQUIRED_SCOPE
-				),
-				$logs
-			);
-		}
-
-		$access_token = $auth_provider->get_service();
+		$access_token = AuthHelper::get_access_token();
 		if ( is_wp_error( $access_token ) ) {
 			return $this->fail( $access_token->get_error_message(), $logs );
 		}
-		if ( ! is_string( $access_token ) || '' === $access_token ) {
-			return $this->fail( 'Failed to obtain a Google access token.', $logs );
-		}
 
-		$files   = array();
-		$visited = array();
+		$client = new GoogleDriveClient( $access_token );
 
-		$list_result = $this->list_folder_recursive(
+		$list_result = $client->list_folder(
 			$folder_id,
-			$access_token,
-			$recursive,
-			$mime_filter,
-			$modified_since,
-			0,
-			$visited,
+			array(
+				'recursive'      => ! empty( $input['recursive'] ),
+				'mime_filter'    => isset( $input['mime_filter'] ) && is_array( $input['mime_filter'] )
+					? array_values( array_filter( array_map( 'strval', $input['mime_filter'] ) ) )
+					: array(),
+				'modified_since' => isset( $input['modified_since'] ) ? trim( (string) $input['modified_since'] ) : '',
+			),
 			$logs
 		);
 
@@ -178,15 +144,9 @@ class FetchGoogleDriveAbility {
 			return $this->fail( $list_result->get_error_message(), $logs );
 		}
 
+		$files = array();
 		foreach ( $list_result as $raw ) {
-			// Folders are returned by the recursion helper as well so the
-			// caller can introspect structure, but for the fetch handler
-			// we only emit leaf files.
-			if ( $this->is_folder( $raw ) ) {
-				continue;
-			}
-
-			$payload = $this->materialize_file( $raw, $access_token, $download_target, $logs );
+			$payload = $this->materialize_file( $raw, $client, $download_target, $logs );
 
 			$files[] = array(
 				'id'            => $raw['id'] ?? '',
@@ -213,136 +173,23 @@ class FetchGoogleDriveAbility {
 	}
 
 	/**
-	 * Recursively list files in a folder.
-	 *
-	 * @param string   $folder_id      Drive folder ID.
-	 * @param string   $access_token   OAuth bearer token.
-	 * @param bool     $recursive      Whether to recurse into subfolders.
-	 * @param string[] $mime_filter    Optional MIME types to include.
-	 * @param string   $modified_since Optional ISO-8601 timestamp.
-	 * @param int      $depth          Current recursion depth (caps at MAX_RECURSION).
-	 * @param array    $visited        Visited folder IDs to break cycles.
-	 * @param array    $logs           Logs reference.
-	 * @return array|\WP_Error
-	 */
-	private function list_folder_recursive(
-		string $folder_id,
-		string $access_token,
-		bool $recursive,
-		array $mime_filter,
-		string $modified_since,
-		int $depth,
-		array &$visited,
-		array &$logs
-	) {
-		if ( isset( $visited[ $folder_id ] ) ) {
-			return array();
-		}
-		$visited[ $folder_id ] = true;
-
-		if ( $depth > self::MAX_RECURSION ) {
-			$logs[] = array(
-				'level'   => 'warning',
-				'message' => 'GoogleDrive: Max recursion depth reached, skipping deeper folders.',
-				'data'    => array( 'folder_id' => $folder_id, 'depth' => $depth ),
-			);
-			return array();
-		}
-
-		$query_parts = array(
-			sprintf( "'%s' in parents", $this->escape_query_literal( $folder_id ) ),
-			'trashed = false',
-		);
-
-		if ( '' !== $modified_since ) {
-			$query_parts[] = sprintf( "modifiedTime > '%s'", $this->escape_query_literal( $modified_since ) );
-		}
-
-		// Note: MIME filter is applied client-side as well so that
-		// subfolders (mimeType = application/vnd.google-apps.folder) are
-		// not excluded by a too-narrow server-side filter when recursive
-		// is on.
-
-		$page_token = '';
-		$collected  = array();
-
-		do {
-			$params = array(
-				'q'                         => implode( ' and ', $query_parts ),
-				'pageSize'                  => self::PAGE_SIZE,
-				'fields'                    => self::LIST_FIELDS,
-				'supportsAllDrives'         => 'true',
-				'includeItemsFromAllDrives' => 'true',
-			);
-			if ( '' !== $page_token ) {
-				$params['pageToken'] = $page_token;
-			}
-
-			$response = $this->drive_get( self::API_BASE . '/files', $params, $access_token, $logs );
-			if ( is_wp_error( $response ) ) {
-				return $response;
-			}
-
-			$files      = $response['files'] ?? array();
-			$page_token = $response['nextPageToken'] ?? '';
-
-			foreach ( $files as $file ) {
-				if ( $this->is_folder( $file ) ) {
-					if ( $recursive ) {
-						$nested = $this->list_folder_recursive(
-							$file['id'] ?? '',
-							$access_token,
-							$recursive,
-							$mime_filter,
-							$modified_since,
-							$depth + 1,
-							$visited,
-							$logs
-						);
-						if ( is_wp_error( $nested ) ) {
-							return $nested;
-						}
-						foreach ( $nested as $nested_file ) {
-							$collected[] = $nested_file;
-						}
-					}
-					continue;
-				}
-
-				if ( ! empty( $mime_filter ) ) {
-					$file_mime = $file['mimeType'] ?? '';
-					if ( ! in_array( $file_mime, $mime_filter, true ) ) {
-						continue;
-					}
-				}
-
-				$collected[] = $file;
-			}
-		} while ( '' !== $page_token );
-
-		return $collected;
-	}
-
-	/**
 	 * Convert a raw Drive file record into a payload (text, local_path, or skipped).
 	 *
-	 * @param array  $file            Raw Drive file metadata.
-	 * @param string $access_token    OAuth bearer.
-	 * @param array  $download_target Pipeline/flow context for binary downloads. Empty = skip download.
-	 * @param array  $logs            Logs reference.
+	 * @param array             $file            Raw Drive file metadata.
+	 * @param GoogleDriveClient $client          Drive client (pre-authenticated).
+	 * @param array             $download_target Pipeline/flow context. Empty = skip binary download.
+	 * @param array             $logs            Logs reference.
 	 * @return array Payload descriptor.
 	 */
-	private function materialize_file( array $file, string $access_token, array $download_target, array &$logs ): array {
+	private function materialize_file( array $file, GoogleDriveClient $client, array $download_target, array &$logs ): array {
 		$mime    = $file['mimeType'] ?? '';
 		$file_id = $file['id'] ?? '';
 		$name    = $file['name'] ?? '';
 
-		// Native Google types use files.export; everything else uses files.get?alt=media.
-		$export_candidates = $this->export_candidates_for_native( $mime );
+		$export_candidates = GoogleDriveClient::export_candidates_for_native( $mime );
 
 		if ( null !== $export_candidates ) {
 			if ( empty( $export_candidates ) ) {
-				// Native but not exportable (Forms, Sites, etc.).
 				return array(
 					'skipped' => true,
 					'reason'  => 'Native Google file type is not exportable as text.',
@@ -351,8 +198,7 @@ class FetchGoogleDriveAbility {
 
 			$last_error = null;
 			foreach ( $export_candidates as $candidate_mime ) {
-				$url      = self::API_BASE . '/files/' . rawurlencode( $file_id ) . '/export';
-				$response = $this->drive_get_raw( $url, array( 'mimeType' => $candidate_mime ), $access_token, $logs );
+				$response = $client->export_native( $file_id, $candidate_mime, $logs );
 
 				if ( ! is_wp_error( $response ) ) {
 					return array(
@@ -386,7 +232,7 @@ class FetchGoogleDriveAbility {
 		}
 
 		// Binary file. Stream to disk if we have somewhere to put it.
-		if ( empty( $download_target['pipeline_id'] ) && empty( $download_target['flow_id'] ) ) {
+		if ( empty( $download_target['pipeline_id'] ) || empty( $download_target['flow_id'] ) ) {
 			$logs[] = array(
 				'level'   => 'debug',
 				'message' => 'GoogleDrive: No download target provided, listing binary file without downloading.',
@@ -397,7 +243,28 @@ class FetchGoogleDriveAbility {
 			);
 		}
 
-		$saved = $this->download_binary( $file_id, $name, $access_token, $download_target, $logs );
+		$pipeline_id = (int) $download_target['pipeline_id'];
+		$flow_id     = (int) $download_target['flow_id'];
+
+		$dir_manager = new DirectoryManager();
+		$directory   = $dir_manager->get_flow_files_directory( $pipeline_id, $flow_id );
+
+		if ( ! $dir_manager->ensure_directory_exists( $directory ) ) {
+			$logs[] = array(
+				'level'   => 'error',
+				'message' => 'GoogleDrive: Failed to create flow files directory.',
+				'data'    => array( 'directory' => $directory ),
+			);
+			return array(
+				'skipped' => true,
+				'reason'  => 'Failed to create flow files directory.',
+			);
+		}
+
+		$safe_name   = sanitize_file_name( $name ?: ( 'drive-' . $file_id ) );
+		$destination = trailingslashit( $directory ) . wp_unique_filename( $directory, $safe_name );
+
+		$saved = $client->download_binary( $file_id, $destination, $logs );
 		if ( is_wp_error( $saved ) ) {
 			$logs[] = array(
 				'level'   => 'error',
@@ -410,305 +277,11 @@ class FetchGoogleDriveAbility {
 			);
 		}
 
-		return $saved;
-	}
-
-	/**
-	 * Map a native Google MIME type to its preferred export target MIMEs.
-	 *
-	 * Returns an ORDERED list of MIME candidates to try via files.export.
-	 * The first candidate that the Drive API accepts wins. This lets us
-	 * prefer the LLM-friendlier text/markdown for Google Docs while
-	 * falling back to text/plain if Drive rejects it (older accounts or
-	 * documents with features the markdown exporter doesn't handle).
-	 *
-	 * Returns:
-	 * - null if the file is NOT a native Google type (caller falls back
-	 *   to files.get?alt=media for binary download).
-	 * - [] (empty array) if it IS a native type but not exportable as
-	 *   text (Forms, Sites, etc.).
-	 * - non-empty list of MIME candidates otherwise.
-	 *
-	 * @param string $mime Source MIME.
-	 * @return string[]|null
-	 */
-	private function export_candidates_for_native( string $mime ): ?array {
-		switch ( $mime ) {
-			case 'application/vnd.google-apps.document':
-				// Markdown is the LLM-preferred format. Drive started
-				// supporting it as a Docs export target in 2024 but older
-				// project credentials still 4xx on it — fall back to
-				// text/plain so the export still succeeds.
-				return array( 'text/markdown', 'text/plain' );
-			case 'application/vnd.google-apps.spreadsheet':
-				return array( 'text/csv' );
-			case 'application/vnd.google-apps.presentation':
-				return array( 'text/plain' );
-			case 'application/vnd.google-apps.form':
-			case 'application/vnd.google-apps.site':
-			case 'application/vnd.google-apps.drawing':
-			case 'application/vnd.google-apps.map':
-			case 'application/vnd.google-apps.shortcut':
-			case 'application/vnd.google-apps.folder':
-				return array();
-		}
-
-		if ( 0 === strpos( $mime, 'application/vnd.google-apps.' ) ) {
-			// Unknown native type — refuse rather than guess.
-			return array();
-		}
-
-		return null;
-	}
-
-	private function is_folder( array $file ): bool {
-		return ( $file['mimeType'] ?? '' ) === 'application/vnd.google-apps.folder';
-	}
-
-	/**
-	 * Download a binary Drive file into the flow-scoped uploads dir.
-	 *
-	 * Authenticated downloads need a bearer header, so we cannot reuse
-	 * WordPress's download_url() helper. We stream via wp_remote_get to
-	 * a temp file, then move into the flow directory. This is local-only
-	 * pending a generic authenticated-download helper in core (see
-	 * Extra-Chill/data-machine issue tracking TBD).
-	 *
-	 * @return array|\WP_Error
-	 */
-	private function download_binary( string $file_id, string $name, string $access_token, array $download_target, array &$logs ) {
-		$pipeline_id = $download_target['pipeline_id'] ?? null;
-		$flow_id     = $download_target['flow_id'] ?? null;
-		if ( null === $pipeline_id || null === $flow_id ) {
-			return new \WP_Error( 'googledrive_no_target', 'Download target missing pipeline_id/flow_id.' );
-		}
-
-		$dir_manager = new DirectoryManager();
-		$directory   = $dir_manager->get_flow_files_directory( $pipeline_id, $flow_id );
-
-		if ( ! $dir_manager->ensure_directory_exists( $directory ) ) {
-			return new \WP_Error( 'googledrive_dir_failed', 'Failed to create flow files directory.' );
-		}
-
-		$url      = self::API_BASE . '/files/' . rawurlencode( $file_id );
-		$response = wp_remote_get(
-			add_query_arg(
-				array(
-					'alt'               => 'media',
-					'supportsAllDrives' => 'true',
-				),
-				$url
-			),
-			array(
-				'timeout' => 60,
-				'headers' => array(
-					'Authorization' => 'Bearer ' . $access_token,
-				),
-				// Avoid loading the whole binary into PHP memory when possible.
-				'stream'   => true,
-				'filename' => trailingslashit( get_temp_dir() ) . wp_unique_filename( get_temp_dir(), 'gdrive-' . $file_id . '-' . sanitize_file_name( $name ) ),
-			)
-		);
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-		$temp_path   = $response['filename'] ?? '';
-
-		if ( 200 !== (int) $status_code ) {
-			if ( $temp_path && file_exists( $temp_path ) ) {
-				wp_delete_file( $temp_path );
-			}
-			return $this->error_from_status( $status_code, $response );
-		}
-
-		if ( '' === $temp_path || ! file_exists( $temp_path ) ) {
-			return new \WP_Error( 'googledrive_stream_failed', 'Drive returned 200 but temp file is missing.' );
-		}
-
-		$safe_name   = sanitize_file_name( $name ?: ( 'drive-' . $file_id ) );
-		$destination = trailingslashit( $directory ) . wp_unique_filename( $directory, $safe_name );
-
-		$fs = FilesystemHelper::get();
-		if ( $fs ) {
-			$copied = $fs->copy( $temp_path, $destination, true );
-		} else {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Filesystem API unavailable, fall back to native move.
-			$copied = @rename( $temp_path, $destination );
-		}
-
-		if ( file_exists( $temp_path ) ) {
-			wp_delete_file( $temp_path );
-		}
-
-		if ( ! $copied || ! file_exists( $destination ) ) {
-			return new \WP_Error( 'googledrive_move_failed', 'Failed to move downloaded file into flow directory.' );
-		}
-
-		$logs[] = array(
-			'level'   => 'debug',
-			'message' => 'GoogleDrive: Binary file downloaded.',
-			'data'    => array( 'file_id' => $file_id, 'destination' => $destination ),
-		);
-
 		return array(
-			'local_path' => $destination,
-			'filename'   => basename( $destination ),
-			'size'       => filesize( $destination ),
+			'local_path' => $saved['local_path'],
+			'filename'   => basename( $saved['local_path'] ),
+			'size'       => $saved['size'],
 		);
-	}
-
-	/**
-	 * GET a JSON-returning Drive API endpoint.
-	 *
-	 * @return array|\WP_Error Decoded JSON on success.
-	 */
-	private function drive_get( string $url, array $params, string $access_token, array &$logs ) {
-		$full_url = add_query_arg( $params, $url );
-		$response = wp_remote_get(
-			$full_url,
-			array(
-				'timeout' => 30,
-				'headers' => array(
-					'Authorization' => 'Bearer ' . $access_token,
-					'Accept'        => 'application/json',
-				),
-			)
-		);
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$status_code = (int) wp_remote_retrieve_response_code( $response );
-		$body        = wp_remote_retrieve_body( $response );
-
-		if ( 200 !== $status_code ) {
-			return $this->error_from_status( $status_code, $response, $body );
-		}
-
-		$decoded = json_decode( $body, true );
-		if ( ! is_array( $decoded ) ) {
-			return new \WP_Error( 'googledrive_decode_failed', 'Drive returned an unparseable response body.' );
-		}
-
-		return $decoded;
-	}
-
-	/**
-	 * GET a Drive API endpoint that returns raw (non-JSON) content.
-	 *
-	 * Used for files.export.
-	 *
-	 * @return string|\WP_Error Raw body on success.
-	 */
-	private function drive_get_raw( string $url, array $params, string $access_token, array &$logs ) {
-		$full_url = add_query_arg( $params, $url );
-		$response = wp_remote_get(
-			$full_url,
-			array(
-				'timeout' => 60,
-				'headers' => array(
-					'Authorization' => 'Bearer ' . $access_token,
-				),
-			)
-		);
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$status_code = (int) wp_remote_retrieve_response_code( $response );
-		$body        = (string) wp_remote_retrieve_body( $response );
-
-		if ( 200 !== $status_code ) {
-			return $this->error_from_status( $status_code, $response, $body );
-		}
-
-		return $body;
-	}
-
-	/**
-	 * Translate a non-200 Drive response into a WP_Error.
-	 *
-	 * Distinguishes scope-missing (403 with insufficient scope reason),
-	 * not-found (404), and rate-limited (429, with respect for
-	 * Retry-After) errors.
-	 *
-	 * @param int          $status_code HTTP status.
-	 * @param array|object $response    wp_remote_* response.
-	 * @param string|null  $body        Body string if already retrieved.
-	 * @return \WP_Error
-	 */
-	private function error_from_status( int $status_code, $response, ?string $body = null ): \WP_Error {
-		if ( null === $body ) {
-			$body = (string) wp_remote_retrieve_body( $response );
-		}
-
-		$decoded = json_decode( $body, true );
-		$message = '';
-		$reason  = '';
-		if ( is_array( $decoded ) && isset( $decoded['error'] ) ) {
-			$message = (string) ( $decoded['error']['message'] ?? '' );
-			$errors  = $decoded['error']['errors'] ?? array();
-			if ( is_array( $errors ) && ! empty( $errors[0]['reason'] ) ) {
-				$reason = (string) $errors[0]['reason'];
-			}
-		}
-
-		if ( 401 === $status_code ) {
-			return new \WP_Error( 'googledrive_unauthorized', 'Google Drive returned 401 Unauthorized. Re-authenticate the Google integration.' );
-		}
-
-		if ( 403 === $status_code ) {
-			if ( in_array( $reason, array( 'insufficientPermissions', 'insufficientScopes', 'forbidden' ), true ) && false !== stripos( $message . ' ' . $reason, 'scope' ) ) {
-				return new \WP_Error(
-					'googledrive_scope_missing',
-					sprintf(
-						'Google Drive denied the request because the OAuth token lacks the required scope (%s). Disconnect and reconnect the Google integration to grant Drive access.',
-						self::REQUIRED_SCOPE
-					)
-				);
-			}
-			return new \WP_Error(
-				'googledrive_forbidden',
-				$message ?: 'Google Drive denied access to this resource. The authenticated user may not have permission to view the folder.'
-			);
-		}
-
-		if ( 404 === $status_code ) {
-			return new \WP_Error( 'googledrive_not_found', $message ?: 'Drive resource not found.' );
-		}
-
-		if ( 429 === $status_code ) {
-			$retry_after = (int) wp_remote_retrieve_header( $response, 'retry-after' );
-			if ( $retry_after > 0 ) {
-				$retry_after = min( $retry_after, self::RETRY_AFTER_CAP );
-				return new \WP_Error(
-					'googledrive_rate_limited',
-					sprintf( 'Google Drive rate limit hit. Retry after %d seconds.', $retry_after ),
-					array( 'retry_after' => $retry_after )
-				);
-			}
-			return new \WP_Error( 'googledrive_rate_limited', 'Google Drive rate limit hit.' );
-		}
-
-		return new \WP_Error(
-			'googledrive_http_error',
-			sprintf( 'Google Drive API returned HTTP %d: %s', $status_code, $message ?: 'Unknown error' )
-		);
-	}
-
-	/**
-	 * Escape a literal for inclusion inside a Drive `q=` query string.
-	 *
-	 * Drive's query language quotes literals with single quotes and
-	 * escapes single quotes and backslashes inside them.
-	 */
-	private function escape_query_literal( string $value ): string {
-		return str_replace( array( '\\', "'" ), array( '\\\\', "\\'" ), $value );
 	}
 
 	private function fail( string $message, array $logs ): array {
@@ -718,14 +291,5 @@ class FetchGoogleDriveAbility {
 			'error'   => $message,
 			'logs'    => $logs,
 		);
-	}
-
-	/**
-	 * @return \DataMachineBusiness\OAuth\Providers\GoogleAuth|null
-	 */
-	private static function get_auth_provider(): ?\DataMachineBusiness\OAuth\Providers\GoogleAuth {
-		$providers = apply_filters( 'datamachine_auth_providers', array() );
-		$provider  = $providers['google'] ?? null;
-		return $provider instanceof \DataMachineBusiness\OAuth\Providers\GoogleAuth ? $provider : null;
 	}
 }

--- a/inc/Abilities/GoogleDrive/ListGoogleDriveFilesAbility.php
+++ b/inc/Abilities/GoogleDrive/ListGoogleDriveFilesAbility.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * List Google Drive Files Ability.
+ *
+ * One-shot enumeration of every file in a Drive folder, suitable for
+ * direct CLI / chat / REST invocation. Drains all pagination pages
+ * server-side and returns a flat array of file records — no
+ * `nextPageToken` ever leaks to the caller.
+ *
+ * Sibling of `datamachine/fetch-googledrive`: the fetch ability is
+ * pipeline-shaped (dedupes via ExecutionContext, downloads binaries
+ * into flow-scoped uploads) while this ability is a pure listing
+ * surface (no I/O beyond the API call, no dedup state).
+ *
+ * @package DataMachineBusiness
+ * @subpackage Abilities\GoogleDrive
+ * @since 0.4.0
+ */
+
+namespace DataMachineBusiness\Abilities\GoogleDrive;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveClient;
+
+defined( 'ABSPATH' ) || exit;
+
+class ListGoogleDriveFilesAbility {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/list-googledrive-files',
+				array(
+					'label'               => __( 'List Google Drive Files', 'data-machine-business' ),
+					'description'         => __( 'List every file in a Google Drive folder. Drains all pagination pages and returns metadata only — does not export Docs or download binaries.', 'data-machine-business' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'folder' ),
+						'properties' => array(
+							'folder' => array(
+								'type'        => 'string',
+								'description' => __( 'Google Drive folder ID or full folder URL (e.g. https://drive.google.com/drive/folders/1abc...xyz). Accepts either form; the URL is parsed server-side.', 'data-machine-business' ),
+							),
+							'recursive' => array(
+								'type'        => 'boolean',
+								'default'     => false,
+								'description' => __( 'When true, recurse into subfolders and return files from every level. When false (default), only return immediate children of the folder.', 'data-machine-business' ),
+							),
+							'mime_filter' => array(
+								'type'        => 'string',
+								'description' => __( 'Optional comma-separated list of MIME types to include (e.g. "application/pdf,audio/mpeg"). Filter is applied after pagination so subfolders are not excluded during recursion. Leave empty to include every MIME type.', 'data-machine-business' ),
+							),
+							'modified_since' => array(
+								'type'        => 'string',
+								'description' => __( 'Optional ISO-8601 timestamp (e.g. "2026-01-01T00:00:00Z"). When set, only files with modifiedTime greater than this value are returned.', 'data-machine-business' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array(
+								'type'       => 'object',
+								'properties' => array(
+									'folder_id' => array(
+										'type'        => 'string',
+										'description' => __( 'The Drive folder ID that was listed (parsed from input).', 'data-machine-business' ),
+									),
+									'count' => array(
+										'type'        => 'integer',
+										'description' => __( 'Number of file records returned.', 'data-machine-business' ),
+									),
+									'files' => array(
+										'type'        => 'array',
+										'description' => __( 'Array of Drive file records. Each entry includes id, name, mime_type, modified_time, web_view_link, size, parents.', 'data-machine-business' ),
+										'items'       => array(
+											'type'       => 'object',
+											'properties' => array(
+												'id'             => array( 'type' => 'string' ),
+												'name'           => array( 'type' => 'string' ),
+												'mime_type'      => array( 'type' => 'string' ),
+												'modified_time'  => array( 'type' => 'string' ),
+												'web_view_link'  => array( 'type' => 'string' ),
+												'size'           => array( 'type' => array( 'integer', 'null' ) ),
+												'parents'        => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+											),
+										),
+									),
+								),
+							),
+							'error'   => array( 'type' => 'string' ),
+							'logs'    => array( 'type' => 'array' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result envelope.
+	 */
+	public function execute( array $input ): array {
+		$logs = array();
+
+		$folder_raw = isset( $input['folder'] ) ? (string) $input['folder'] : '';
+		$folder_id  = GoogleDriveClient::extract_folder_id( $folder_raw );
+		if ( '' === $folder_id ) {
+			return $this->fail( 'folder is required (Drive folder ID or URL).', $logs );
+		}
+
+		$mime_filter = $this->parse_mime_filter( $input['mime_filter'] ?? '' );
+
+		$access_token = AuthHelper::get_access_token();
+		if ( is_wp_error( $access_token ) ) {
+			return $this->fail( $access_token->get_error_message(), $logs );
+		}
+
+		$client = new GoogleDriveClient( $access_token );
+
+		$raw_files = $client->list_folder(
+			$folder_id,
+			array(
+				'recursive'      => ! empty( $input['recursive'] ),
+				'mime_filter'    => $mime_filter,
+				'modified_since' => isset( $input['modified_since'] ) ? trim( (string) $input['modified_since'] ) : '',
+			),
+			$logs
+		);
+
+		if ( is_wp_error( $raw_files ) ) {
+			return $this->fail( $raw_files->get_error_message(), $logs );
+		}
+
+		$files = array();
+		foreach ( $raw_files as $raw ) {
+			$files[] = array(
+				'id'            => (string) ( $raw['id'] ?? '' ),
+				'name'          => (string) ( $raw['name'] ?? '' ),
+				'mime_type'     => (string) ( $raw['mimeType'] ?? '' ),
+				'modified_time' => (string) ( $raw['modifiedTime'] ?? '' ),
+				'web_view_link' => (string) ( $raw['webViewLink'] ?? '' ),
+				'size'          => isset( $raw['size'] ) ? (int) $raw['size'] : null,
+				'parents'       => isset( $raw['parents'] ) && is_array( $raw['parents'] ) ? array_values( array_map( 'strval', $raw['parents'] ) ) : array(),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'data'    => array(
+				'folder_id' => $folder_id,
+				'count'     => count( $files ),
+				'files'     => $files,
+			),
+			'logs'    => $logs,
+		);
+	}
+
+	/**
+	 * Accept either a comma-separated string or an array of MIME types.
+	 *
+	 * @param mixed $raw Input value.
+	 * @return string[]
+	 */
+	private function parse_mime_filter( $raw ): array {
+		if ( is_array( $raw ) ) {
+			$parts = $raw;
+		} else {
+			$raw = trim( (string) $raw );
+			if ( '' === $raw ) {
+				return array();
+			}
+			$parts = explode( ',', $raw );
+		}
+
+		$clean = array();
+		foreach ( $parts as $mime ) {
+			$mime = is_string( $mime ) ? trim( $mime ) : '';
+			if ( '' === $mime ) {
+				continue;
+			}
+			$clean[] = $mime;
+		}
+
+		return array_values( array_unique( $clean ) );
+	}
+
+	private function fail( string $message, array $logs ): array {
+		$logs[] = array( 'level' => 'error', 'message' => $message );
+		return array(
+			'success' => false,
+			'error'   => $message,
+			'logs'    => $logs,
+		);
+	}
+}

--- a/inc/Abilities/GoogleDrive/ReadGoogleDriveDocAbility.php
+++ b/inc/Abilities/GoogleDrive/ReadGoogleDriveDocAbility.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Read Google Drive Doc Ability.
+ *
+ * One-shot text export of a native Google file (Doc, Sheet, Slide)
+ * suitable for direct CLI / chat / REST invocation.
+ *
+ * Routing by source MIME:
+ * - Google Docs        → exports as text/markdown (preferred) or text/plain
+ *                        when the caller requests `format=text`. Falls back
+ *                        from markdown to plain when older Drive credentials
+ *                        reject the markdown exporter.
+ * - Google Sheets      → exports as text/csv. CSV is the only useful text
+ *                        representation; `format=markdown` is treated as
+ *                        CSV for sheets rather than failing.
+ * - Google Slides      → exports as text/plain.
+ * - Native binary file → WP_Error( googledrive_not_a_document ) telling
+ *                        the caller to use `datamachine/download-googledrive`
+ *                        instead. This is intentional: text export of an
+ *                        MP3 or a PDF doesn't have a meaningful answer.
+ *
+ * @package DataMachineBusiness
+ * @subpackage Abilities\GoogleDrive
+ * @since 0.4.0
+ */
+
+namespace DataMachineBusiness\Abilities\GoogleDrive;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveClient;
+
+defined( 'ABSPATH' ) || exit;
+
+class ReadGoogleDriveDocAbility {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! class_exists( 'WP_Ability' ) || self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/read-googledrive-doc',
+				array(
+					'label'               => __( 'Read Google Drive Document', 'data-machine-business' ),
+					'description'         => __( 'Export the text content of a Google Doc, Sheet, or Slides file as markdown, plain text, or CSV. Refuses native binary files (use download-googledrive for those).', 'data-machine-business' ),
+					'category'            => 'datamachine',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'file' ),
+						'properties' => array(
+							'file' => array(
+								'type'        => 'string',
+								'description' => __( 'Google Drive file ID or full Drive URL (e.g. https://docs.google.com/document/d/1abc...xyz/edit, https://docs.google.com/spreadsheets/d/..., https://drive.google.com/file/d/...). Accepts either form; the URL is parsed server-side.', 'data-machine-business' ),
+							),
+							'format' => array(
+								'type'        => 'string',
+								'enum'        => array( 'markdown', 'text', 'csv' ),
+								'default'     => 'markdown',
+								'description' => __( 'Preferred export format. "markdown" exports Google Docs as text/markdown (falling back to text/plain on older Drive credentials) and is treated as CSV for Google Sheets. "text" exports Docs/Slides as text/plain. "csv" forces text/csv export and is only meaningful for Google Sheets.', 'data-machine-business' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'data'    => array(
+								'type'       => 'object',
+								'properties' => array(
+									'id'            => array( 'type' => 'string' ),
+									'name'          => array( 'type' => 'string' ),
+									'mime_type'     => array( 'type' => 'string', 'description' => __( 'Source MIME type of the Drive file (e.g. application/vnd.google-apps.document).', 'data-machine-business' ) ),
+									'export_mime'   => array( 'type' => 'string', 'description' => __( 'The MIME type the body was exported as (e.g. text/markdown, text/csv, text/plain).', 'data-machine-business' ) ),
+									'text'          => array( 'type' => 'string', 'description' => __( 'Exported text content of the document.', 'data-machine-business' ) ),
+									'modified_time' => array( 'type' => 'string' ),
+									'web_view_link' => array( 'type' => 'string' ),
+								),
+							),
+							'error'   => array( 'type' => 'string' ),
+							'logs'    => array( 'type' => 'array' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public function checkPermission(): bool {
+		return PermissionHelper::can_manage();
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array Result envelope.
+	 */
+	public function execute( array $input ): array {
+		$logs = array();
+
+		$file_raw = isset( $input['file'] ) ? (string) $input['file'] : '';
+		$file_id  = GoogleDriveClient::extract_file_id( $file_raw );
+		if ( '' === $file_id ) {
+			return $this->fail( 'file is required (Drive file ID or URL).', $logs );
+		}
+
+		$format = isset( $input['format'] ) ? strtolower( trim( (string) $input['format'] ) ) : 'markdown';
+		if ( ! in_array( $format, array( 'markdown', 'text', 'csv' ), true ) ) {
+			return $this->fail( sprintf( 'Unsupported format "%s". Use one of: markdown, text, csv.', $format ), $logs );
+		}
+
+		$access_token = AuthHelper::get_access_token();
+		if ( is_wp_error( $access_token ) ) {
+			return $this->fail( $access_token->get_error_message(), $logs );
+		}
+
+		$client = new GoogleDriveClient( $access_token );
+
+		$metadata = $client->get_file_metadata( $file_id, $logs );
+		if ( is_wp_error( $metadata ) ) {
+			return $this->fail( $metadata->get_error_message(), $logs );
+		}
+
+		$mime = (string) ( $metadata['mimeType'] ?? '' );
+		$name = (string) ( $metadata['name'] ?? '' );
+
+		if ( ! GoogleDriveClient::is_native_google_type( $mime ) ) {
+			$logs[] = array(
+				'level'   => 'error',
+				'message' => 'GoogleDrive: read-doc called on a non-native file.',
+				'data'    => array( 'file_id' => $file_id, 'mime_type' => $mime ),
+			);
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'File "%s" is not a Google Doc / Sheet / Slides (mime: %s). Use datamachine/download-googledrive to fetch binary files.', $name, $mime ),
+				'data'    => array(
+					'id'        => $file_id,
+					'name'      => $name,
+					'mime_type' => $mime,
+				),
+				'error_code' => 'googledrive_not_a_document',
+				'logs'       => $logs,
+			);
+		}
+
+		$candidates = $this->candidates_for_format( $mime, $format );
+		if ( empty( $candidates ) ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Native Google file "%s" (mime: %s) is not exportable as text.', $name, $mime ),
+				'data'    => array(
+					'id'        => $file_id,
+					'name'      => $name,
+					'mime_type' => $mime,
+				),
+				'error_code' => 'googledrive_not_exportable',
+				'logs'       => $logs,
+			);
+		}
+
+		$last_error = null;
+		foreach ( $candidates as $candidate_mime ) {
+			$body = $client->export_native( $file_id, $candidate_mime, $logs );
+			if ( ! is_wp_error( $body ) ) {
+				return array(
+					'success' => true,
+					'data'    => array(
+						'id'            => $file_id,
+						'name'          => $name,
+						'mime_type'     => $mime,
+						'export_mime'   => $candidate_mime,
+						'text'          => (string) $body,
+						'modified_time' => (string) ( $metadata['modifiedTime'] ?? '' ),
+						'web_view_link' => (string) ( $metadata['webViewLink'] ?? '' ),
+					),
+					'logs'    => $logs,
+				);
+			}
+
+			$last_error = $body;
+			$logs[]     = array(
+				'level'   => 'debug',
+				'message' => 'GoogleDrive: Export candidate not accepted, trying next.',
+				'data'    => array(
+					'file_id'        => $file_id,
+					'candidate_mime' => $candidate_mime,
+					'error'          => $body->get_error_message(),
+				),
+			);
+		}
+
+		$reason = $last_error instanceof \WP_Error ? $last_error->get_error_message() : 'Export failed.';
+		return $this->fail( $reason, $logs );
+	}
+
+	/**
+	 * Resolve the ordered list of export MIMEs for a (source-MIME, format) pair.
+	 *
+	 * @param string $mime   Source MIME (a native Google type).
+	 * @param string $format Caller-requested format: markdown | text | csv.
+	 * @return string[]      Ordered candidates to try via files.export.
+	 */
+	private function candidates_for_format( string $mime, string $format ): array {
+		switch ( $mime ) {
+			case 'application/vnd.google-apps.document':
+				if ( 'text' === $format ) {
+					return array( 'text/plain' );
+				}
+				if ( 'csv' === $format ) {
+					// CSV doesn't make sense for a Doc — fall back to text/plain
+					// rather than failing, so a chat-driven caller asking for
+					// "csv" doesn't get an error on the first non-Sheet file.
+					return array( 'text/plain' );
+				}
+				// markdown (default): try text/markdown first, fall back to
+				// text/plain when older Drive credentials reject markdown.
+				return array( 'text/markdown', 'text/plain' );
+
+			case 'application/vnd.google-apps.spreadsheet':
+				// Sheets are always CSV regardless of requested format.
+				// markdown / text requests collapse to CSV because that
+				// is the only useful single-export representation.
+				return array( 'text/csv' );
+
+			case 'application/vnd.google-apps.presentation':
+				return array( 'text/plain' );
+
+			case 'application/vnd.google-apps.form':
+			case 'application/vnd.google-apps.site':
+			case 'application/vnd.google-apps.drawing':
+			case 'application/vnd.google-apps.map':
+			case 'application/vnd.google-apps.shortcut':
+			case 'application/vnd.google-apps.folder':
+				return array();
+		}
+
+		// Unknown native type — refuse rather than guess.
+		return array();
+	}
+
+	private function fail( string $message, array $logs ): array {
+		$logs[] = array( 'level' => 'error', 'message' => $message );
+		return array(
+			'success' => false,
+			'error'   => $message,
+			'logs'    => $logs,
+		);
+	}
+}

--- a/inc/Handlers/GoogleDrive/GoogleDriveClient.php
+++ b/inc/Handlers/GoogleDrive/GoogleDriveClient.php
@@ -1,0 +1,594 @@
+<?php
+/**
+ * Google Drive HTTP client.
+ *
+ * Plain class that wraps the Google Drive v3 REST surface needed by
+ * every Drive-touching ability in this plugin. Owns HTTP, pagination,
+ * native-export, binary streaming, error mapping, and URL parsing.
+ *
+ * Why this exists: PR #8 landed an inline copy of all this logic inside
+ * `FetchGoogleDriveAbility`. With multiple one-shot abilities (list,
+ * read-doc, download) being added on top of the same Drive API surface
+ * we extract the shared logic so there is exactly one place that knows
+ * how to talk to Drive. The pipeline ability and the new one-shot
+ * abilities all call into this client.
+ *
+ * The client is stateless beyond the access token. Callers obtain the
+ * token from the `google` OAuth provider (`GoogleAuth::get_service()`)
+ * and pass it in. Logs are appended to a caller-supplied array so the
+ * ability layer can surface them in its result envelope.
+ *
+ * Layer purity: this file is the only place in the plugin that knows
+ * the Drive API URL, query language, export MIME table, or error
+ * shape. Higher layers stay free of HTTP concerns.
+ *
+ * @package DataMachineBusiness
+ * @subpackage Handlers\GoogleDrive
+ * @since 0.4.0
+ */
+
+namespace DataMachineBusiness\Handlers\GoogleDrive;
+
+defined( 'ABSPATH' ) || exit;
+
+class GoogleDriveClient {
+
+	public const API_BASE        = 'https://www.googleapis.com/drive/v3';
+	public const LIST_FIELDS     = 'nextPageToken,files(id,name,mimeType,modifiedTime,size,owners,webViewLink,md5Checksum,parents)';
+	public const PAGE_SIZE       = 100;
+	public const REQUIRED_SCOPE  = 'https://www.googleapis.com/auth/drive.readonly';
+	public const MAX_RECURSION   = 25;
+	public const RETRY_AFTER_CAP = 60;
+
+	/**
+	 * Regex used to extract a file or folder ID from a Drive URL.
+	 *
+	 * Matches `/folders/<id>`, `/file/d/<id>`, and `/document/d/<id>`,
+	 * `/spreadsheets/d/<id>`, `/presentation/d/<id>` variants.
+	 */
+	private const FOLDER_URL_PATTERN = '#/folders/([a-zA-Z0-9_-]+)#';
+	private const FILE_URL_PATTERN   = '#/(?:file|document|spreadsheets|presentation|drawings)/d/([a-zA-Z0-9_-]+)#';
+
+	private string $access_token;
+
+	public function __construct( string $access_token ) {
+		$this->access_token = $access_token;
+	}
+
+	/**
+	 * Recursively list files in a folder, draining all pagination pages.
+	 *
+	 * Returns a flat array of raw Drive file records (NOT folder records
+	 * — folders are walked when `recursive` is true and dropped from the
+	 * result). When `recursive` is false, only the immediate children of
+	 * `$folder_id` are returned.
+	 *
+	 * MIME filtering is applied client-side after pagination so that
+	 * subfolders are not excluded by a too-narrow server-side filter
+	 * when recursion is on.
+	 *
+	 * @param string $folder_id Drive folder ID.
+	 * @param array  $opts      Options: bool 'recursive', string[] 'mime_filter', string 'modified_since'.
+	 * @param array  $logs      Logs reference.
+	 * @return array|\WP_Error  Array of raw file records, or WP_Error on HTTP failure.
+	 */
+	public function list_folder( string $folder_id, array $opts, array &$logs ) {
+		$recursive      = ! empty( $opts['recursive'] );
+		$mime_filter    = isset( $opts['mime_filter'] ) && is_array( $opts['mime_filter'] )
+			? array_values( array_filter( array_map( 'strval', $opts['mime_filter'] ) ) )
+			: array();
+		$modified_since = isset( $opts['modified_since'] ) ? trim( (string) $opts['modified_since'] ) : '';
+
+		$visited = array();
+		return $this->list_folder_recursive(
+			$folder_id,
+			$recursive,
+			$mime_filter,
+			$modified_since,
+			0,
+			$visited,
+			$logs
+		);
+	}
+
+	/**
+	 * Fetch a single file's metadata.
+	 *
+	 * @param string $file_id Drive file ID.
+	 * @param array  $logs    Logs reference.
+	 * @return array|\WP_Error Raw file record, or WP_Error.
+	 */
+	public function get_file_metadata( string $file_id, array &$logs ) {
+		$url      = self::API_BASE . '/files/' . rawurlencode( $file_id );
+		$response = $this->drive_get(
+			$url,
+			array(
+				'fields'            => 'id,name,mimeType,modifiedTime,size,owners,webViewLink,md5Checksum,parents',
+				'supportsAllDrives' => 'true',
+			),
+			$logs
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Export a native Google file (Doc, Sheet, Slide) to a text MIME.
+	 *
+	 * @param string $file_id     Drive file ID.
+	 * @param string $target_mime Target export MIME (e.g. text/markdown).
+	 * @param array  $logs        Logs reference.
+	 * @return string|\WP_Error   Exported body on success.
+	 */
+	public function export_native( string $file_id, string $target_mime, array &$logs ) {
+		$url = self::API_BASE . '/files/' . rawurlencode( $file_id ) . '/export';
+		return $this->drive_get_raw( $url, array( 'mimeType' => $target_mime ), $logs );
+	}
+
+	/**
+	 * Map a native Google MIME type to its preferred export target MIMEs.
+	 *
+	 * Returns an ORDERED list of MIME candidates to try via files.export.
+	 * The first candidate that Drive accepts wins.
+	 *
+	 * Returns:
+	 * - null if the file is NOT a native Google type (caller falls back
+	 *   to download_binary()).
+	 * - [] (empty array) if it IS a native type but not exportable as
+	 *   text (Forms, Sites, etc.).
+	 * - non-empty list of candidate MIMEs otherwise.
+	 *
+	 * @param string $mime Source MIME.
+	 * @return string[]|null
+	 */
+	public static function export_candidates_for_native( string $mime ): ?array {
+		switch ( $mime ) {
+			case 'application/vnd.google-apps.document':
+				// Markdown is the LLM-preferred format. Drive added it as a
+				// Docs export target in 2024 but older project credentials
+				// can still 4xx on it — fall back to text/plain.
+				return array( 'text/markdown', 'text/plain' );
+			case 'application/vnd.google-apps.spreadsheet':
+				return array( 'text/csv' );
+			case 'application/vnd.google-apps.presentation':
+				return array( 'text/plain' );
+			case 'application/vnd.google-apps.form':
+			case 'application/vnd.google-apps.site':
+			case 'application/vnd.google-apps.drawing':
+			case 'application/vnd.google-apps.map':
+			case 'application/vnd.google-apps.shortcut':
+			case 'application/vnd.google-apps.folder':
+				return array();
+		}
+
+		if ( 0 === strpos( $mime, 'application/vnd.google-apps.' ) ) {
+			// Unknown native type — refuse rather than guess.
+			return array();
+		}
+
+		return null;
+	}
+
+	/**
+	 * True when the given MIME is a native Google type (Doc/Sheet/Slide/etc.).
+	 */
+	public static function is_native_google_type( string $mime ): bool {
+		return 0 === strpos( $mime, 'application/vnd.google-apps.' );
+	}
+
+	/**
+	 * True when the given file record represents a Drive folder.
+	 *
+	 * @param array $file Raw Drive file record.
+	 */
+	public static function is_folder( array $file ): bool {
+		return ( $file['mimeType'] ?? '' ) === 'application/vnd.google-apps.folder';
+	}
+
+	/**
+	 * Stream a binary Drive file to disk at the given destination path.
+	 *
+	 * Native Google types are NOT supported here — the caller is
+	 * expected to route them through export_native(). Caller owns the
+	 * destination path (parent directory must exist and be writable).
+	 *
+	 * @param string $file_id          Drive file ID.
+	 * @param string $destination_path Absolute path to write to.
+	 * @param array  $logs             Logs reference.
+	 * @return array|\WP_Error         { size, local_path } on success.
+	 */
+	public function download_binary( string $file_id, string $destination_path, array &$logs ) {
+		$parent_dir = dirname( $destination_path );
+		if ( ! is_dir( $parent_dir ) || ! is_writable( $parent_dir ) ) {
+			return new \WP_Error(
+				'googledrive_dir_not_writable',
+				sprintf( 'Destination directory is not writable: %s', $parent_dir )
+			);
+		}
+
+		$url      = self::API_BASE . '/files/' . rawurlencode( $file_id );
+		$temp     = trailingslashit( get_temp_dir() ) . wp_unique_filename( get_temp_dir(), 'gdrive-' . $file_id );
+		$response = wp_remote_get(
+			add_query_arg(
+				array(
+					'alt'               => 'media',
+					'supportsAllDrives' => 'true',
+				),
+				$url
+			),
+			array(
+				'timeout'  => 60,
+				'headers'  => array(
+					'Authorization' => 'Bearer ' . $this->access_token,
+				),
+				// Stream to avoid loading the full binary into PHP memory.
+				'stream'   => true,
+				'filename' => $temp,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+		$temp_path   = $response['filename'] ?? $temp;
+
+		if ( 200 !== $status_code ) {
+			if ( $temp_path && file_exists( $temp_path ) ) {
+				wp_delete_file( $temp_path );
+			}
+			return $this->error_from_status( $status_code, $response );
+		}
+
+		if ( '' === $temp_path || ! file_exists( $temp_path ) ) {
+			return new \WP_Error( 'googledrive_stream_failed', 'Drive returned 200 but temp file is missing.' );
+		}
+
+		$fs = \DataMachine\Core\FilesRepository\FilesystemHelper::get();
+		if ( $fs ) {
+			$moved = $fs->copy( $temp_path, $destination_path, true );
+		} else {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Filesystem API unavailable, native move fallback.
+			$moved = @rename( $temp_path, $destination_path );
+		}
+
+		if ( file_exists( $temp_path ) ) {
+			wp_delete_file( $temp_path );
+		}
+
+		if ( ! $moved || ! file_exists( $destination_path ) ) {
+			return new \WP_Error( 'googledrive_move_failed', 'Failed to move downloaded file to destination.' );
+		}
+
+		$logs[] = array(
+			'level'   => 'debug',
+			'message' => 'GoogleDrive: Binary file downloaded.',
+			'data'    => array( 'file_id' => $file_id, 'destination' => $destination_path ),
+		);
+
+		return array(
+			'local_path' => $destination_path,
+			'size'       => filesize( $destination_path ),
+		);
+	}
+
+	/**
+	 * Extract a folder ID from a Drive URL, or return a raw ID unchanged.
+	 *
+	 * Accepts:
+	 * - `1abc...xyz` → returned as-is after stripping non-ID chars.
+	 * - `https://drive.google.com/drive/folders/1abc...xyz` → `1abc...xyz`
+	 * - `https://drive.google.com/drive/folders/1abc...xyz?usp=sharing` → `1abc...xyz`
+	 *
+	 * @param string $input Raw folder ID or full Drive URL.
+	 * @return string Folder ID, or empty string when nothing usable was provided.
+	 */
+	public static function extract_folder_id( string $input ): string {
+		$input = trim( $input );
+		if ( '' === $input ) {
+			return '';
+		}
+
+		if ( preg_match( self::FOLDER_URL_PATTERN, $input, $matches ) ) {
+			return $matches[1];
+		}
+
+		// Strip query strings accidentally appended to raw IDs and keep
+		// only the canonical Drive ID character class.
+		$cleaned = preg_replace( '/[^a-zA-Z0-9_-]/', '', $input );
+		return is_string( $cleaned ) ? $cleaned : '';
+	}
+
+	/**
+	 * Extract a file ID from a Drive file URL, or return a raw ID unchanged.
+	 *
+	 * Accepts:
+	 * - `1abc...xyz` → returned as-is after stripping non-ID chars.
+	 * - `https://docs.google.com/document/d/1abc...xyz/edit` → `1abc...xyz`
+	 * - `https://drive.google.com/file/d/1abc...xyz/view` → `1abc...xyz`
+	 * - `https://docs.google.com/spreadsheets/d/1abc...xyz/edit` → `1abc...xyz`
+	 * - `https://docs.google.com/presentation/d/1abc...xyz/edit` → `1abc...xyz`
+	 *
+	 * @param string $input Raw file ID or full Drive URL.
+	 * @return string File ID, or empty string when nothing usable was provided.
+	 */
+	public static function extract_file_id( string $input ): string {
+		$input = trim( $input );
+		if ( '' === $input ) {
+			return '';
+		}
+
+		if ( preg_match( self::FILE_URL_PATTERN, $input, $matches ) ) {
+			return $matches[1];
+		}
+
+		$cleaned = preg_replace( '/[^a-zA-Z0-9_-]/', '', $input );
+		return is_string( $cleaned ) ? $cleaned : '';
+	}
+
+	// ---------------------------------------------------------------------
+	// Internal helpers.
+	// ---------------------------------------------------------------------
+
+	/**
+	 * @param string   $folder_id
+	 * @param bool     $recursive
+	 * @param string[] $mime_filter
+	 * @param string   $modified_since
+	 * @param int      $depth
+	 * @param array    $visited
+	 * @param array    $logs
+	 * @return array|\WP_Error
+	 */
+	private function list_folder_recursive(
+		string $folder_id,
+		bool $recursive,
+		array $mime_filter,
+		string $modified_since,
+		int $depth,
+		array &$visited,
+		array &$logs
+	) {
+		if ( isset( $visited[ $folder_id ] ) ) {
+			return array();
+		}
+		$visited[ $folder_id ] = true;
+
+		if ( $depth > self::MAX_RECURSION ) {
+			$logs[] = array(
+				'level'   => 'warning',
+				'message' => 'GoogleDrive: Max recursion depth reached, skipping deeper folders.',
+				'data'    => array( 'folder_id' => $folder_id, 'depth' => $depth ),
+			);
+			return array();
+		}
+
+		$query_parts = array(
+			sprintf( "'%s' in parents", $this->escape_query_literal( $folder_id ) ),
+			'trashed = false',
+		);
+
+		if ( '' !== $modified_since ) {
+			$query_parts[] = sprintf( "modifiedTime > '%s'", $this->escape_query_literal( $modified_since ) );
+		}
+
+		$page_token = '';
+		$collected  = array();
+
+		do {
+			$params = array(
+				'q'                         => implode( ' and ', $query_parts ),
+				'pageSize'                  => self::PAGE_SIZE,
+				'fields'                    => self::LIST_FIELDS,
+				'supportsAllDrives'         => 'true',
+				'includeItemsFromAllDrives' => 'true',
+			);
+			if ( '' !== $page_token ) {
+				$params['pageToken'] = $page_token;
+			}
+
+			$response = $this->drive_get( self::API_BASE . '/files', $params, $logs );
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
+
+			$files      = $response['files'] ?? array();
+			$page_token = $response['nextPageToken'] ?? '';
+
+			foreach ( $files as $file ) {
+				if ( self::is_folder( $file ) ) {
+					if ( $recursive ) {
+						$nested = $this->list_folder_recursive(
+							$file['id'] ?? '',
+							$recursive,
+							$mime_filter,
+							$modified_since,
+							$depth + 1,
+							$visited,
+							$logs
+						);
+						if ( is_wp_error( $nested ) ) {
+							return $nested;
+						}
+						foreach ( $nested as $nested_file ) {
+							$collected[] = $nested_file;
+						}
+					}
+					continue;
+				}
+
+				if ( ! empty( $mime_filter ) ) {
+					$file_mime = $file['mimeType'] ?? '';
+					if ( ! in_array( $file_mime, $mime_filter, true ) ) {
+						continue;
+					}
+				}
+
+				$collected[] = $file;
+			}
+		} while ( '' !== $page_token );
+
+		return $collected;
+	}
+
+	/**
+	 * GET a JSON-returning Drive API endpoint.
+	 *
+	 * @return array|\WP_Error Decoded JSON on success.
+	 */
+	private function drive_get( string $url, array $params, array &$logs ) {
+		$full_url = add_query_arg( $params, $url );
+		$response = wp_remote_get(
+			$full_url,
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $this->access_token,
+					'Accept'        => 'application/json',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+		$body        = wp_remote_retrieve_body( $response );
+
+		if ( 200 !== $status_code ) {
+			return $this->error_from_status( $status_code, $response, $body );
+		}
+
+		$decoded = json_decode( $body, true );
+		if ( ! is_array( $decoded ) ) {
+			return new \WP_Error( 'googledrive_decode_failed', 'Drive returned an unparseable response body.' );
+		}
+
+		return $decoded;
+	}
+
+	/**
+	 * GET a Drive API endpoint that returns raw (non-JSON) content.
+	 *
+	 * Used for files.export.
+	 *
+	 * @return string|\WP_Error Raw body on success.
+	 */
+	private function drive_get_raw( string $url, array $params, array &$logs ) {
+		$full_url = add_query_arg( $params, $url );
+		$response = wp_remote_get(
+			$full_url,
+			array(
+				'timeout' => 60,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $this->access_token,
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+		$body        = (string) wp_remote_retrieve_body( $response );
+
+		if ( 200 !== $status_code ) {
+			return $this->error_from_status( $status_code, $response, $body );
+		}
+
+		return $body;
+	}
+
+	/**
+	 * Translate a non-200 Drive response into a WP_Error.
+	 *
+	 * Distinguishes scope-missing (403 with insufficient-scope reason),
+	 * forbidden (403 otherwise), not-found (404), rate-limited (429
+	 * with Retry-After respect), and generic HTTP errors.
+	 *
+	 * @param int          $status_code HTTP status.
+	 * @param array|object $response    wp_remote_* response.
+	 * @param string|null  $body        Body string if already retrieved.
+	 * @return \WP_Error
+	 */
+	private function error_from_status( int $status_code, $response, ?string $body = null ): \WP_Error {
+		if ( null === $body ) {
+			$body = (string) wp_remote_retrieve_body( $response );
+		}
+
+		$decoded = json_decode( $body, true );
+		$message = '';
+		$reason  = '';
+		if ( is_array( $decoded ) && isset( $decoded['error'] ) ) {
+			$message = (string) ( $decoded['error']['message'] ?? '' );
+			$errors  = $decoded['error']['errors'] ?? array();
+			if ( is_array( $errors ) && ! empty( $errors[0]['reason'] ) ) {
+				$reason = (string) $errors[0]['reason'];
+			}
+		}
+
+		if ( 401 === $status_code ) {
+			return new \WP_Error(
+				'googledrive_unauthorized',
+				'Google Drive returned 401 Unauthorized. Re-authenticate the Google integration.'
+			);
+		}
+
+		if ( 403 === $status_code ) {
+			if ( in_array( $reason, array( 'insufficientPermissions', 'insufficientScopes', 'forbidden' ), true )
+				&& false !== stripos( $message . ' ' . $reason, 'scope' )
+			) {
+				return new \WP_Error(
+					'googledrive_scope_missing',
+					sprintf(
+						'Google Drive denied the request because the OAuth token lacks the required scope (%s). Disconnect and reconnect the Google integration to grant Drive access.',
+						self::REQUIRED_SCOPE
+					)
+				);
+			}
+			return new \WP_Error(
+				'googledrive_forbidden',
+				$message ?: 'Google Drive denied access to this resource. The authenticated user may not have permission to view the folder.'
+			);
+		}
+
+		if ( 404 === $status_code ) {
+			return new \WP_Error( 'googledrive_not_found', $message ?: 'Drive resource not found.' );
+		}
+
+		if ( 429 === $status_code ) {
+			$retry_after = (int) wp_remote_retrieve_header( $response, 'retry-after' );
+			if ( $retry_after > 0 ) {
+				$retry_after = min( $retry_after, self::RETRY_AFTER_CAP );
+				return new \WP_Error(
+					'googledrive_rate_limited',
+					sprintf( 'Google Drive rate limit hit. Retry after %d seconds.', $retry_after ),
+					array( 'retry_after' => $retry_after )
+				);
+			}
+			return new \WP_Error( 'googledrive_rate_limited', 'Google Drive rate limit hit.' );
+		}
+
+		return new \WP_Error(
+			'googledrive_http_error',
+			sprintf( 'Google Drive API returned HTTP %d: %s', $status_code, $message ?: 'Unknown error' )
+		);
+	}
+
+	/**
+	 * Escape a literal for inclusion inside a Drive `q=` query string.
+	 *
+	 * Drive's query language quotes literals with single quotes and
+	 * escapes single quotes and backslashes inside them.
+	 */
+	private function escape_query_literal( string $value ): string {
+		return str_replace( array( '\\', "'" ), array( '\\\\', "\\'" ), $value );
+	}
+}


### PR DESCRIPTION
## Summary

Issue [#10](https://github.com/Extra-Chill/data-machine-business/issues/10) called for one-shot Google Drive abilities (list, read-doc, download) on top of the Drive client that PR #8 shipped. This PR does that, plus the prerequisite refactor of the Drive HTTP / pagination / export / download / URL-parsing logic into a shared helper class so all four abilities (the existing `datamachine/fetch-googledrive` plus the three new ones) share exactly one implementation.

PR #8 landed the Drive API logic **inline** inside `FetchGoogleDriveAbility` (731 lines, one file, doing everything). It was not yet extracted into a shared helper. The first commit here factors it out — pipeline ability + three new one-shot abilities now all call into `GoogleDriveClient` with zero duplicated HTTP / pagination / OAuth code.

## What landed

Four commits, each atomic and scoped:

1. **`refactor(google-drive): extract Drive client into shared helper`** — Introduces `inc/Handlers/GoogleDrive/GoogleDriveClient.php` (stateless, takes an access token in the constructor) and `inc/Abilities/GoogleDrive/AuthHelper.php` (centralizes provider lookup + scope check + token refresh). `FetchGoogleDriveAbility` is refactored to delegate every Drive API call to the client; the pipeline-shaped binary-download path (flow-scoped uploads via `DirectoryManager`) stays in the ability. Output shape and error codes are byte-for-byte compatible with PR #8 — no behavior change.

2. **`feat(google-drive): add list-googledrive-files ability`** — `datamachine/list-googledrive-files`. Drains all pagination pages server-side and returns a flat array of file records.

3. **`feat(google-drive): add read-googledrive-doc ability`** — `datamachine/read-googledrive-doc`. Exports a native Google file as markdown / text / CSV. Refuses native binary files with `googledrive_not_a_document` and routes the caller to `download-googledrive`.

4. **`feat(google-drive): add download-googledrive ability`** — `datamachine/download-googledrive`. Streams a binary file to disk under `<wp-uploads>/drive-imports/<YYYY>/<MM>/` by default. Refuses native Google types with `googledrive_not_a_binary` and routes the caller to `read-googledrive-doc`. Refuses to overwrite existing files unless `overwrite=true`, returning `googledrive_file_exists` with the resolved path.

## Ability naming

Issue #10's body uses `data-machine-business/google-drive-list-files` etc. The existing abilities in this plugin are namespaced `datamachine/<verb>-<provider>` (`datamachine/fetch-googlesheets`, `datamachine/publish-googlesheets`, `datamachine/fetch-googledrive`). Issue #10's own text also says "matching the namespace convention established in `inc/Abilities/`" — so the issue body contradicts itself. I followed the **existing codebase convention** and registered the new abilities as:

- `datamachine/list-googledrive-files`
- `datamachine/read-googledrive-doc`
- `datamachine/download-googledrive`

If the reviewer prefers the `data-machine-business/...` prefix, this is a single-line rename in three `wp_register_ability()` calls.

## OAuth filter slug

PR #8's body mentioned `datamachine_googlesheets_oauth_scopes`. In the actual merged code the filter was renamed to `datamachine_google_oauth_scopes` (and the provider slug is `google`, not `googlesheets`). No filter change was needed for this PR — the existing wiring in `data-machine-business.php` already contributes the Drive scopes to the unified Google credential.

## Permission gating

All three new abilities use the same `PermissionHelper::can_manage()` permission callback as the existing Drive and Sheets abilities. No new permission model was introduced. Agent capability ceilings apply automatically because the WordPress Abilities API surfaces the permission callback to every transport (CLI, REST, MCP, chat).

## Layer purity

Every Drive-specific name, scope, regex, ability slug, and MIME mapping lives in this plugin only. Nothing under `/var/lib/datamachine/workspace/data-machine` (the generic core) was touched. The Abilities API in WP core stays generic.

## Acceptance criteria from #10

- [x] Drive client logic extracted into a shared helper class (first commit) — `GoogleDriveClient` owns every HTTP / pagination / export / download / error-mapping / URL-parsing call. `FetchGoogleDriveAbility` and the three new abilities all call into it. **Zero duplicated HTTP / pagination / OAuth code.**
- [x] All abilities registered with input/output JSON schemas suitable for LLM consumption. Descriptions are written for an agent reader, not a human dev (example: `"description": "Google Drive folder ID or full folder URL (e.g. https://drive.google.com/drive/folders/1abc...xyz). Accepts either form; the URL is parsed server-side."`).
- [ ] Each ability appears in `wp help abilities` / `wp ability run` / REST / chat — **not verified on a live install in this PR.** `data-machine-business` is not currently installed on extrachill.com production (`wp plugin list` confirms), same as PR #8. Reviewer needs to install the plugin and configure Google OAuth before the smoke tests below will work. See the test plan.
- [ ] Smoke test: `wp ability run datamachine/list-googledrive-files --input='{"folder":"1dnNfeWM6J-d1l6nw8zWqBrX_B3vsC5kR"}'` returns both interview Docs as JSON — **gated on the reviewer running the prerequisites below.**
- [ ] Smoke test: same ability discoverable as a chat tool in `wp datamachine chat` against the EC bot, invokable via natural language — **gated on the reviewer.**
- [ ] Smoke test: same ability callable via `curl` against the REST endpoint with a valid bearer token — **gated on the reviewer.**
- [x] Error path: ability called when Google OAuth is not configured or Drive scope is missing returns a clear `WP_Error` with re-auth instructions, not a stack trace. `AuthHelper::get_access_token()` surfaces `googledrive_auth_unavailable`, `googledrive_scope_missing`, or `googledrive_token_missing` before any HTTP call is made.
- [x] Agent permission gating: all three abilities use `PermissionHelper::can_manage()` (same as every other DM ability). Low-capability agents are blocked at the permission callback.

## Test plan

> **Before any of the smoke tests below work, Google OAuth must be configured on the install.** On extrachill.com production at PR time, it is not configured yet.

### Prerequisite: configure + connect Google OAuth

```bash
# 1. Install / activate this branch on a DM-equipped site
wp --allow-root plugin install /path/to/data-machine-business.zip --activate
# or symlink the worktree under wp-content/plugins on a dev box

# 2. Configure the Google OAuth client (one-time, network admin)
wp --allow-root --path=/var/www/extrachill.com \
  datamachine auth config google \
  --client_id='<your-client-id>.apps.googleusercontent.com' \
  --client_secret='<your-client-secret>'

# 3. Connect a Google account (prints a consent URL to visit)
wp --allow-root --path=/var/www/extrachill.com \
  datamachine auth connect google
```

The consent screen will request both Sheets and Drive scopes (Drive scopes were unioned in PR #8 via `datamachine_google_oauth_scopes`).

### Smoke tests

Test folder: `1dnNfeWM6J-d1l6nw8zWqBrX_B3vsC5kR` (from issue #7 — contains the two interview Docs).

```bash
# A) List the test folder. Should return both interview Docs.
wp --allow-root --path=/var/www/extrachill.com \
  ability run datamachine/list-googledrive-files \
  --input='{"folder":"1dnNfeWM6J-d1l6nw8zWqBrX_B3vsC5kR"}'

# A.1) Same call with the full Drive URL — should parse to the same ID.
wp --allow-root --path=/var/www/extrachill.com \
  ability run datamachine/list-googledrive-files \
  --input='{"folder":"https://drive.google.com/drive/folders/1dnNfeWM6J-d1l6nw8zWqBrX_B3vsC5kR"}'

# A.2) MIME filter — only Google Docs.
wp --allow-root --path=/var/www/extrachill.com \
  ability run datamachine/list-googledrive-files \
  --input='{"folder":"1dnNfeWM6J-d1l6nw8zWqBrX_B3vsC5kR","mime_filter":"application/vnd.google-apps.document"}'

# B) Read one of the interview Docs as markdown (replace <FILE_ID> with one from A's output).
wp --allow-root --path=/var/www/extrachill.com \
  ability run datamachine/read-googledrive-doc \
  --input='{"file":"<FILE_ID>","format":"markdown"}'

# B.1) Same Doc as plain text.
wp --allow-root --path=/var/www/extrachill.com \
  ability run datamachine/read-googledrive-doc \
  --input='{"file":"<FILE_ID>","format":"text"}'

# B.2) Try to read-doc a binary file → should return error_code googledrive_not_a_document.
wp --allow-root --path=/var/www/extrachill.com \
  ability run datamachine/read-googledrive-doc \
  --input='{"file":"<BINARY_FILE_ID>"}'

# C) Download a binary file to the default uploads location.
wp --allow-root --path=/var/www/extrachill.com \
  ability run datamachine/download-googledrive \
  --input='{"file":"<BINARY_FILE_ID>"}'

# C.1) Repeat without overwrite=true → should return error_code googledrive_file_exists.
wp --allow-root --path=/var/www/extrachill.com \
  ability run datamachine/download-googledrive \
  --input='{"file":"<BINARY_FILE_ID>"}'

# C.2) Repeat with overwrite=true → should replace the file.
wp --allow-root --path=/var/www/extrachill.com \
  ability run datamachine/download-googledrive \
  --input='{"file":"<BINARY_FILE_ID>","overwrite":true}'

# C.3) Try to download an interview Doc → should return error_code googledrive_not_a_binary.
wp --allow-root --path=/var/www/extrachill.com \
  ability run datamachine/download-googledrive \
  --input='{"file":"<DOC_FILE_ID>"}'

# D) Chat smoke test — confirm discovery as a tool.
wp --allow-root --path=/var/www/extrachill.com \
  datamachine chat --agent=extra-chill-bot \
  --message='Use the Drive abilities to list files in folder 1dnNfeWM6J-d1l6nw8zWqBrX_B3vsC5kR and read the first Doc.'

# E) REST smoke test (bearer token required — agent token from `datamachine agent token ...`).
curl -X POST \
  -H 'Authorization: Bearer <agent-token>' \
  -H 'Content-Type: application/json' \
  -d '{"input":{"folder":"1dnNfeWM6J-d1l6nw8zWqBrX_B3vsC5kR"}}' \
  https://extrachill.com/wp-json/wp-abilities/v1/abilities/datamachine/list-googledrive-files/run
```

### Error-path smoke test (no Google connection)

Without running the prerequisites above, every ability should return a clean `WP_Error`:

```bash
wp --allow-root --path=/var/www/extrachill.com \
  ability run datamachine/list-googledrive-files \
  --input='{"folder":"anything"}'
# Expect: error googledrive_auth_unavailable or googledrive_scope_missing
# (depending on whether the Google provider is registered yet).
```

## JSON schemas

### `datamachine/list-googledrive-files`

```json
{
  "input_schema": {
    "type": "object",
    "required": ["folder"],
    "properties": {
      "folder": {
        "type": "string",
        "description": "Google Drive folder ID or full folder URL (e.g. https://drive.google.com/drive/folders/1abc...xyz). Accepts either form; the URL is parsed server-side."
      },
      "recursive": {
        "type": "boolean",
        "default": false,
        "description": "When true, recurse into subfolders and return files from every level. When false (default), only return immediate children of the folder."
      },
      "mime_filter": {
        "type": "string",
        "description": "Optional comma-separated list of MIME types to include (e.g. \"application/pdf,audio/mpeg\"). Filter is applied after pagination so subfolders are not excluded during recursion. Leave empty to include every MIME type."
      },
      "modified_since": {
        "type": "string",
        "description": "Optional ISO-8601 timestamp (e.g. \"2026-01-01T00:00:00Z\"). When set, only files with modifiedTime greater than this value are returned."
      }
    }
  },
  "output_schema": {
    "type": "object",
    "properties": {
      "success": { "type": "boolean" },
      "data": {
        "type": "object",
        "properties": {
          "folder_id": { "type": "string" },
          "count":     { "type": "integer" },
          "files": {
            "type": "array",
            "items": {
              "type": "object",
              "properties": {
                "id":            { "type": "string" },
                "name":          { "type": "string" },
                "mime_type":     { "type": "string" },
                "modified_time": { "type": "string" },
                "web_view_link": { "type": "string" },
                "size":          { "type": ["integer", "null"] },
                "parents":       { "type": "array", "items": { "type": "string" } }
              }
            }
          }
        }
      },
      "error": { "type": "string" },
      "logs":  { "type": "array" }
    }
  }
}
```

### `datamachine/read-googledrive-doc`

```json
{
  "input_schema": {
    "type": "object",
    "required": ["file"],
    "properties": {
      "file": {
        "type": "string",
        "description": "Google Drive file ID or full Drive URL (e.g. https://docs.google.com/document/d/1abc...xyz/edit, https://docs.google.com/spreadsheets/d/..., https://drive.google.com/file/d/...). Accepts either form; the URL is parsed server-side."
      },
      "format": {
        "type": "string",
        "enum": ["markdown", "text", "csv"],
        "default": "markdown",
        "description": "Preferred export format. \"markdown\" exports Google Docs as text/markdown (falling back to text/plain on older Drive credentials) and is treated as CSV for Google Sheets. \"text\" exports Docs/Slides as text/plain. \"csv\" forces text/csv export and is only meaningful for Google Sheets."
      }
    }
  },
  "output_schema": {
    "type": "object",
    "properties": {
      "success": { "type": "boolean" },
      "data": {
        "type": "object",
        "properties": {
          "id":            { "type": "string" },
          "name":          { "type": "string" },
          "mime_type":     { "type": "string" },
          "export_mime":   { "type": "string" },
          "text":          { "type": "string" },
          "modified_time": { "type": "string" },
          "web_view_link": { "type": "string" }
        }
      },
      "error": { "type": "string" },
      "logs":  { "type": "array" }
    }
  }
}
```

### `datamachine/download-googledrive`

```json
{
  "input_schema": {
    "type": "object",
    "required": ["file"],
    "properties": {
      "file": {
        "type": "string",
        "description": "Google Drive file ID or full Drive URL (e.g. https://drive.google.com/file/d/1abc...xyz/view). Accepts either form; the URL is parsed server-side."
      },
      "destination": {
        "type": "string",
        "description": "Optional destination. Accepts an absolute server path (resolves to a directory the downloaded file is placed inside) OR a subdirectory relative to the WordPress uploads root. When omitted, the file lands in <wp-uploads>/drive-imports/<YYYY>/<MM>/."
      },
      "overwrite": {
        "type": "boolean",
        "default": false,
        "description": "When false (default), the ability refuses to overwrite an existing file at the resolved destination and returns googledrive_file_exists. When true, the existing file is replaced."
      }
    }
  },
  "output_schema": {
    "type": "object",
    "properties": {
      "success": { "type": "boolean" },
      "data": {
        "type": "object",
        "properties": {
          "id":            { "type": "string" },
          "name":          { "type": "string" },
          "mime_type":     { "type": "string" },
          "size":          { "type": ["integer", "null"] },
          "local_path":    { "type": "string" },
          "web_view_link": { "type": "string" }
        }
      },
      "error": { "type": "string" },
      "logs":  { "type": "array" }
    }
  }
}
```

Closes #10

cc <@532385681268408341>
