### PR TITLE
Add Google Search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Business and enterprise integrations for Data Machine.
 
 This plugin extends Data Machine with business-focused integrations including:
 
+- **Google Search**: Search the web through Google Custom Search API as an AI tool
 - **Google Sheets**: Fetch data from spreadsheets and append data for reporting
 - **Slack**: Post messages and fetch conversations from channels
 - **Discord**: Post messages and fetch messages from server channels
@@ -22,6 +23,22 @@ This plugin extends Data Machine with business-focused integrations including:
 2. Upload and activate this plugin
 3. Configure Google Sheets authentication in Data Machine settings
 4. Create flows using the Google Sheets handlers
+
+## Google Search Tool
+
+Data Machine Business registers the `google_search` AI tool for chat and pipeline contexts. It uses the Google Custom Search API endpoint and the same `datamachine_search_config` site option previously used by Data Machine core, so existing saved API keys and Custom Search Engine IDs continue to work after this plugin is activated.
+
+### Google Search Setup
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Enable the Custom Search API for your project
+3. Create or select an API key with access to the Custom Search API
+4. Create a Programmable Search Engine and copy its Search Engine ID
+5. Save the API key and Search Engine ID in Data Machine tool settings for `google_search`
+
+### Google Search Usage
+
+The tool accepts a required `query` parameter and an optional `site_restrict` domain. It returns up to 10 structured results with title, link, snippet, and display link fields.
 
 ## Google Sheets Setup
 

--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -61,6 +61,9 @@ function datamachine_business_load_handlers() {
 	new \DataMachineBusiness\Abilities\GoogleDrive\FetchGoogleDriveAbility();
 	new \DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveFetch();
 
+	// Google Custom Search API tool.
+	new \DataMachineBusiness\Tools\GoogleSearch();
+
 	// Slack
 	new \DataMachineBusiness\Abilities\Slack\PostMessageSlackAbility();
 	new \DataMachineBusiness\Abilities\Slack\FetchMessagesSlackAbility();

--- a/inc/Tools/GoogleSearch.php
+++ b/inc/Tools/GoogleSearch.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * Google Custom Search API integration with site restrictions and result limits.
+ *
+ * @package DataMachineBusiness\Tools
+ */
+
+namespace DataMachineBusiness\Tools;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Core\HttpClient;
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+class GoogleSearch extends BaseTool {
+
+	public function __construct() {
+		$this->registerConfigurationHandlers( 'google_search' );
+		$this->registerTool( 'google_search', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'access_level' => 'admin' ) );
+	}
+
+	/**
+	 * Execute Google search with site restrictions and result limiting.
+	 *
+	 * @param array $parameters Contains 'query' and optional 'site_restrict'.
+	 * @param array $tool_def Tool definition (unused).
+	 * @return array Search results with success status.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+
+		if ( empty( $parameters['query'] ) ) {
+			return array(
+				'success'   => false,
+				'error'     => 'Google Search tool call missing required query parameter',
+				'tool_name' => 'google_search',
+			);
+		}
+
+		$config        = get_site_option( 'datamachine_search_config', array() );
+		$google_config = $config['google_search'] ?? array();
+
+		if ( empty( $google_config['api_key'] ) || empty( $google_config['search_engine_id'] ) ) {
+			return array(
+				'success'   => false,
+				'error'     => 'Google Search tool not configured. Please configure API key and Search Engine ID.',
+				'tool_name' => 'google_search',
+			);
+		}
+
+		$query         = sanitize_text_field( $parameters['query'] );
+		$max_results   = 10;
+		$site_restrict = ! empty( $parameters['site_restrict'] ) ? sanitize_text_field( $parameters['site_restrict'] ) : '';
+
+		$search_url    = 'https://www.googleapis.com/customsearch/v1';
+		$search_params = array(
+			'key'  => $google_config['api_key'],
+			'cx'   => $google_config['search_engine_id'],
+			'q'    => $query,
+			'num'  => $max_results,
+			'safe' => 'active',
+		);
+
+		if ( $site_restrict ) {
+			$search_params['siteSearch'] = $site_restrict;
+		}
+
+		$request_url = add_query_arg( $search_params, $search_url );
+
+		$result = HttpClient::get(
+			$request_url,
+			array(
+				'timeout' => 10,
+				'headers' => array(
+					'Accept' => 'application/json',
+				),
+				'context' => 'Google Search Tool',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success'   => false,
+				'error'     => 'Failed to connect to Google Search API: ' . ( $result['error'] ?? 'Unknown error' ),
+				'tool_name' => 'google_search',
+			);
+		}
+
+		$search_data = json_decode( $result['data'], true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array(
+				'success'   => false,
+				'error'     => 'Failed to parse Google Search API response',
+				'tool_name' => 'google_search',
+			);
+		}
+
+		$results = array();
+		if ( ! empty( $search_data['items'] ) ) {
+			foreach ( $search_data['items'] as $item ) {
+				$results[] = array(
+					'title'       => $item['title'] ?? '',
+					'link'        => $item['link'] ?? '',
+					'snippet'     => $item['snippet'] ?? '',
+					'displayLink' => $item['displayLink'] ?? '',
+				);
+			}
+		}
+
+		$search_info   = $search_data['searchInformation'] ?? array();
+		$total_results = $search_info['totalResults'] ?? '0';
+		$search_time   = $search_info['searchTime'] ?? 0;
+
+		$result_count = count( $results );
+		$message      = $result_count > 0
+			? "SEARCH COMPLETE: Found {$result_count} results for \"{$query}\".\nSearch Results:"
+			: "SEARCH COMPLETE: No results found for \"{$query}\".";
+
+		return array(
+			'success'   => true,
+			'data'      => array(
+				'message'         => $message,
+				'query'           => $query,
+				'results_count'   => $result_count,
+				'total_available' => $total_results,
+				'search_time'     => $search_time,
+				'results'         => $results,
+			),
+			'tool_name' => 'google_search',
+		);
+	}
+
+	/**
+	 * Get Google Search tool definition.
+	 * Called lazily when tool is first accessed to ensure translations are loaded.
+	 *
+	 * @return array Tool definition array.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'           => __CLASS__,
+			'method'          => 'handle_tool_call',
+			'description'     => 'Search the web using Google Custom Search and return 1-10 structured JSON results with titles, links, and snippets. Best for discovering external information when you don\'t have specific URLs. Use for current events, factual verification, or broad topic research. Returns complete web search data in JSON format with title, link, snippet for each result.',
+			'requires_config' => true,
+			'parameters'      => array(
+				'type'       => 'object',
+				'properties' => array(
+					'query'         => array(
+						'type'        => 'string',
+						'description' => 'Search query for external web information. Returns JSON with "results" array containing web search results.',
+					),
+					'site_restrict' => array(
+						'type'        => 'string',
+						'description' => 'Restrict search to specific domain (e.g., "wikipedia.org" for Wikipedia only)',
+					),
+				),
+				'required'   => array( 'query' ),
+			),
+		);
+	}
+
+	public static function is_configured(): bool {
+		$config        = get_site_option( 'datamachine_search_config', array() );
+		$google_config = $config['google_search'] ?? array();
+
+		return ! empty( $google_config['api_key'] ) && ! empty( $google_config['search_engine_id'] );
+	}
+
+	public static function get_config(): array {
+		$config = get_site_option( 'datamachine_search_config', array() );
+		return $config['google_search'] ?? array();
+	}
+
+	/**
+	 * Check if Google Search tool is properly configured.
+	 *
+	 * @param bool   $configured Current configuration status.
+	 * @param string $tool_id Tool identifier to check.
+	 * @return bool True if configured, false otherwise.
+	 */
+	public function check_configuration( $configured, $tool_id ) {
+		if ( 'google_search' !== $tool_id ) {
+			return $configured;
+		}
+
+		return self::is_configured();
+	}
+
+	public function get_configuration( $config, $tool_id ) {
+		if ( 'google_search' !== $tool_id ) {
+			return $config;
+		}
+
+		return self::get_config();
+	}
+
+	/**
+	 * GoogleSearch uses a nested key inside a shared option, so it overrides
+	 * save_configuration() directly instead of using the base flow.
+	 *
+	 * @param array|null $result      Previous handler result.
+	 * @param string     $tool_id     Tool identifier.
+	 * @param array      $config_data Sanitized configuration data.
+	 * @return array|null
+	 */
+	public function save_configuration( $result, $tool_id, $config_data ) {
+		if ( 'google_search' !== $tool_id ) {
+			return $result;
+		}
+
+		$api_key          = sanitize_text_field( $config_data['api_key'] ?? '' );
+		$search_engine_id = sanitize_text_field( $config_data['search_engine_id'] ?? '' );
+
+		if ( empty( $api_key ) || empty( $search_engine_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => __( 'API Key and Search Engine ID are required', 'data-machine-business' ),
+			);
+		}
+
+		$stored_config                  = get_site_option( 'datamachine_search_config', array() );
+		$stored_config['google_search'] = array(
+			'api_key'          => $api_key,
+			'search_engine_id' => $search_engine_id,
+		);
+
+		if ( update_site_option( 'datamachine_search_config', $stored_config ) ) {
+			return array(
+				'success' => true,
+				'message' => __( 'Google Search configuration saved successfully', 'data-machine-business' ),
+			);
+		}
+
+		return array(
+			'success' => false,
+			'error'   => __( 'Failed to save configuration', 'data-machine-business' ),
+		);
+	}
+
+	public function get_config_fields( $fields = array(), $tool_id = '' ) {
+		if ( ! empty( $tool_id ) && 'google_search' !== $tool_id ) {
+			return $fields;
+		}
+
+		return array(
+			'api_key'          => array(
+				'type'        => 'text',
+				'label'       => __( 'Google Search API Key', 'data-machine-business' ),
+				'placeholder' => __( 'Enter your Google Search API key', 'data-machine-business' ),
+				'required'    => true,
+				'description' => __( 'Get your API key from Google Cloud Console -> APIs & Services -> Credentials', 'data-machine-business' ),
+			),
+			'search_engine_id' => array(
+				'type'        => 'text',
+				'label'       => __( 'Custom Search Engine ID', 'data-machine-business' ),
+				'placeholder' => __( 'Enter your Search Engine ID', 'data-machine-business' ),
+				'required'    => true,
+				'description' => __( 'Create a Custom Search Engine and copy the Search Engine ID (cx parameter)', 'data-machine-business' ),
+			),
+		);
+	}
+}

--- a/tests/google-search-tool-smoke.php
+++ b/tests/google-search-tool-smoke.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Static smoke checks for the Google Search tool extraction.
+ *
+ * @package DataMachineBusiness\Tests
+ */
+
+$root = dirname( __DIR__ );
+
+$plugin_file = file_get_contents( $root . '/data-machine-business.php' );
+$tool_file   = file_get_contents( $root . '/inc/Tools/GoogleSearch.php' );
+
+$checks = array(
+	'plugin instantiates Google Search tool' => str_contains( $plugin_file, 'new \\DataMachineBusiness\\Tools\\GoogleSearch();' ),
+	'tool registers google_search slug'      => str_contains( $tool_file, "registerTool( 'google_search'" ),
+	'tool keeps existing config option'      => str_contains( $tool_file, "get_site_option( 'datamachine_search_config'" ),
+	'tool uses Custom Search API endpoint'   => str_contains( $tool_file, 'https://www.googleapis.com/customsearch/v1' ),
+);
+
+$failures = array();
+
+foreach ( $checks as $label => $passed ) {
+	if ( ! $passed ) {
+		$failures[] = $label;
+	}
+}
+
+if ( $failures ) {
+	fwrite( STDERR, "Google Search tool smoke failed:\n- " . implode( "\n- ", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo "Google Search tool smoke passed (" . count( $checks ) . " assertions).\n";


### PR DESCRIPTION
## Summary
- Adds the `google_search` AI tool to Data Machine Business as the home for the Google Custom Search API integration.
- Preserves the existing `datamachine_search_config[google_search]` option shape so configured API keys and Custom Search Engine IDs continue to work when the extension is active.
- Adds a static smoke test covering registration, option adoption, and the Custom Search endpoint.

## Dependency
- Paired with the Data Machine core extraction PR: https://github.com/Extra-Chill/data-machine/pull/2145
- Issue: https://github.com/Extra-Chill/data-machine/issues/2144

## Verification
- `php -l inc/Tools/GoogleSearch.php && php -l data-machine-business.php`
- `php -l tests/google-search-tool-smoke.php && php tests/google-search-tool-smoke.php`
- `composer validate --no-check-publish` (valid; existing warning about the `version` field)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing the existing Data Machine Google Search tool, moving the implementation into Data Machine Business, updating docs/tests, and running verification. Chris remains responsible for review and merge.