### PR TITLE
feat: add pagespeed integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Business and enterprise integrations for Data Machine.
 This plugin extends Data Machine with business-focused integrations including:
 
 - **Google Sheets**: Fetch data from spreadsheets and append data for reporting
+- **PageSpeed Insights**: Run Lighthouse audits for performance, SEO, accessibility, and optimization opportunities
 - **Slack**: Post messages and fetch conversations from channels
 - **Discord**: Post messages and fetch messages from server channels
 
@@ -32,6 +33,45 @@ This plugin extends Data Machine with business-focused integrations including:
 5. Add your site's URL as authorized redirect URI
 6. Copy Client ID and Client Secret to Data Machine settings
 7. Authenticate the handler
+
+## PageSpeed Insights
+
+PageSpeed Insights runs Google Lighthouse audits against any URL. It works without an API key, but Google may rate-limit anonymous requests. Add an optional Google API key in the Data Machine tool settings under **PageSpeed** for higher limits.
+
+Data Machine Business registers the same PageSpeed surfaces that previously lived in Data Machine core:
+
+- AI tool: `pagespeed`
+- Ability: `datamachine/pagespeed`
+- REST endpoint: `POST /wp-json/datamachine/v1/analytics/pagespeed`
+- WP-CLI command: `wp datamachine analytics pagespeed <action>`
+
+Existing PageSpeed API-key config is adopted automatically because the integration continues to use the `datamachine_pagespeed_config` site option.
+
+### PageSpeed Actions
+
+| Action | Description |
+|--------|-------------|
+| `analyze` | Full Lighthouse audit with category scores and key metrics |
+| `performance` | Focused performance score and Core Web Vitals metrics |
+| `opportunities` | Optimization opportunities sorted by estimated savings |
+
+### PageSpeed CLI Examples
+
+```bash
+wp datamachine analytics pagespeed analyze --page-url="https://example.com" --strategy=mobile
+wp datamachine analytics pagespeed performance --page-url="https://example.com" --strategy=desktop
+wp datamachine analytics pagespeed opportunities --page-url="https://example.com" --format=json
+```
+
+### PageSpeed REST Example
+
+```bash
+curl -X POST https://example.com/wp-json/datamachine/v1/analytics/pagespeed \
+  -H "Content-Type: application/json" \
+  -H "X-WP-Nonce: {nonce}" \
+  --cookie "{auth_cookie}" \
+  -d '{"action":"analyze","url":"https://example.com/","strategy":"desktop"}'
+```
 
 ## Usage
 

--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Data Machine Business
  * Plugin URI: https://github.com/Extra-Chill/data-machine-business
- * Description: Business and enterprise integrations for Data Machine. Adds support for Google Sheets, Slack, Discord, and other business tools.
+ * Description: Business and enterprise integrations for Data Machine. Adds support for Google Sheets, Slack, Discord, PageSpeed Insights, and other business tools.
  * Version: 0.2.0
  * Requires at least: 6.9
  * Requires PHP: 8.2
@@ -22,8 +22,24 @@ define( 'DATAMACHINE_BUSINESS_VERSION', '0.2.0' );
 define( 'DATAMACHINE_BUSINESS_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DATAMACHINE_BUSINESS_URL', plugin_dir_url( __FILE__ ) );
 
-// PSR-4 Autoloading
-require_once __DIR__ . '/vendor/autoload.php';
+// PSR-4 Autoloading. Composer is preferred for packaged builds, while source
+// checkouts and test runners can load the plugin without a generated vendor dir.
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+} else {
+	spl_autoload_register( function ( string $class ): void {
+		$prefix = 'DataMachineBusiness\\';
+		if ( 0 !== strpos( $class, $prefix ) ) {
+			return;
+		}
+
+		$relative_class = substr( $class, strlen( $prefix ) );
+		$file           = __DIR__ . '/inc/' . str_replace( '\\', '/', $relative_class ) . '.php';
+		if ( file_exists( $file ) ) {
+			require_once $file;
+		}
+	} );
+}
 
 /**
  * Load and instantiate business handlers and abilities.
@@ -60,6 +76,15 @@ function datamachine_business_load_handlers() {
 	// Google Drive (shares the unified GoogleAuth credential — see scope union below)
 	new \DataMachineBusiness\Abilities\GoogleDrive\FetchGoogleDriveAbility();
 	new \DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveFetch();
+
+	// PageSpeed Insights
+	new \DataMachineBusiness\Abilities\PageSpeed\PageSpeedAbility();
+	new \DataMachineBusiness\Tools\PageSpeedTool();
+	\DataMachineBusiness\Api\PageSpeedAnalytics::register();
+
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		\WP_CLI::add_command( 'datamachine analytics pagespeed', \DataMachineBusiness\Cli\PageSpeedCommand::class );
+	}
 
 	// Slack
 	new \DataMachineBusiness\Abilities\Slack\PostMessageSlackAbility();

--- a/inc/Abilities/PageSpeed/PageSpeedAbility.php
+++ b/inc/Abilities/PageSpeed/PageSpeedAbility.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * PageSpeed Insights ability.
+ *
+ * @package DataMachineBusiness\Abilities\PageSpeed
+ */
+
+namespace DataMachineBusiness\Abilities\PageSpeed;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+
+defined( 'ABSPATH' ) || exit;
+
+class PageSpeedAbility {
+
+	const CONFIG_OPTION = 'datamachine_pagespeed_config';
+	const API_ENDPOINT  = 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed';
+	const CATEGORIES    = array( 'performance', 'accessibility', 'best-practices', 'seo' );
+	const STRATEGIES    = array( 'mobile', 'desktop' );
+
+	const PERFORMANCE_METRICS = array(
+		'FIRST_CONTENTFUL_PAINT'    => 'first_contentful_paint',
+		'LARGEST_CONTENTFUL_PAINT'  => 'largest_contentful_paint',
+		'TOTAL_BLOCKING_TIME'       => 'total_blocking_time',
+		'CUMULATIVE_LAYOUT_SHIFT'   => 'cumulative_layout_shift',
+		'SPEED_INDEX'               => 'speed_index',
+		'INTERACTION_TO_NEXT_PAINT' => 'interaction_to_next_paint',
+	);
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->register_abilities();
+		self::$registered = true;
+	}
+
+	private function register_abilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/pagespeed',
+				array(
+					'label'               => __( 'PageSpeed Insights', 'data-machine-business' ),
+					'description'         => __( 'Run Lighthouse audits via PageSpeed Insights API for performance, accessibility, SEO, and best practices scores', 'data-machine-business' ),
+					'category'            => 'datamachine-analytics',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'action' ),
+						'properties' => array(
+							'action'   => array(
+								'type'        => 'string',
+								'description' => __( 'Action to perform: analyze, performance, or opportunities.', 'data-machine-business' ),
+							),
+							'url'      => array(
+								'type'        => 'string',
+								'description' => __( 'URL to analyze. Defaults to the WordPress site home URL.', 'data-machine-business' ),
+							),
+							'strategy' => array(
+								'type'        => 'string',
+								'description' => __( 'Device strategy: mobile or desktop.', 'data-machine-business' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'       => array( 'type' => 'boolean' ),
+							'action'        => array( 'type' => 'string' ),
+							'url'           => array( 'type' => 'string' ),
+							'strategy'      => array( 'type' => 'string' ),
+							'scores'        => array( 'type' => 'object' ),
+							'metrics'       => array( 'type' => 'object' ),
+							'opportunities' => array( 'type' => 'array' ),
+							'error'         => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'run_audit' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	public static function run_audit( array $input ): array {
+		$action = sanitize_text_field( $input['action'] ?? '' );
+
+		$valid_actions = array( 'analyze', 'performance', 'opportunities' );
+		if ( empty( $action ) || ! in_array( $action, $valid_actions, true ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Invalid action. Must be one of: ' . implode( ', ', $valid_actions ),
+			);
+		}
+
+		$url      = ! empty( $input['url'] ) ? esc_url_raw( $input['url'] ) : home_url( '/' );
+		$strategy = ! empty( $input['strategy'] ) ? sanitize_text_field( $input['strategy'] ) : 'mobile';
+
+		if ( ! in_array( $strategy, self::STRATEGIES, true ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Invalid strategy. Must be mobile or desktop.',
+			);
+		}
+
+		$config     = self::get_config();
+		$query_args = array(
+			'url'      => $url,
+			'strategy' => $strategy,
+		);
+
+		if ( 'performance' === $action ) {
+			$query_args['category'] = 'performance';
+		} else {
+			$categories = self::CATEGORIES;
+		}
+
+		if ( ! empty( $config['api_key'] ) ) {
+			$query_args['key'] = $config['api_key'];
+		}
+
+		$api_url = self::API_ENDPOINT . '?' . http_build_query( $query_args );
+		if ( isset( $categories ) ) {
+			foreach ( $categories as $category ) {
+				$api_url .= '&category=' . rawurlencode( $category );
+			}
+		}
+
+		$result = HttpClient::get(
+			$api_url,
+			array(
+				'timeout' => 60,
+				'context' => 'PageSpeed Insights API',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			$error_msg   = $result['error'] ?? 'Unknown error';
+			$status_code = $result['status_code'] ?? 0;
+			if ( 429 === $status_code || false !== strpos( $error_msg, '429' ) ) {
+				$error_msg = ! empty( $config['api_key'] )
+					? 'PageSpeed API rate limit exceeded even with an API key. Wait a few minutes and try again, or check your Google Cloud Console quota.'
+					: 'PageSpeed API rate limit exceeded. Configure a Google API key in Data Machine settings (Tools -> PageSpeed) for higher limits. Get a free key at https://console.cloud.google.com/apis/credentials (enable PageSpeed Insights API).';
+			}
+
+			return array(
+				'success' => false,
+				'error'   => $error_msg,
+			);
+		}
+
+		$data = json_decode( $result['data'], true );
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to parse PageSpeed Insights API response.',
+			);
+		}
+
+		if ( ! empty( $data['error'] ) ) {
+			$error_message = $data['error']['message'] ?? 'Unknown API error';
+			return array(
+				'success' => false,
+				'error'   => 'PageSpeed API error: ' . $error_message,
+			);
+		}
+
+		$lighthouse = $data['lighthouseResult'] ?? array();
+		if ( empty( $lighthouse ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No Lighthouse results returned.',
+			);
+		}
+
+		if ( 'analyze' === $action ) {
+			return self::format_analyze_response( $lighthouse, $url, $strategy );
+		}
+
+		if ( 'performance' === $action ) {
+			return self::format_performance_response( $lighthouse, $url, $strategy );
+		}
+
+		return self::format_opportunities_response( $lighthouse, $url, $strategy );
+	}
+
+	private static function format_analyze_response( array $lighthouse, string $url, string $strategy ): array {
+		$categories = $lighthouse['categories'] ?? array();
+		$audits     = $lighthouse['audits'] ?? array();
+		$scores     = array();
+
+		foreach ( $categories as $key => $category ) {
+			$scores[ $key ] = isset( $category['score'] ) ? (int) round( $category['score'] * 100 ) : null;
+		}
+
+		return array(
+			'success'  => true,
+			'action'   => 'analyze',
+			'url'      => $url,
+			'strategy' => $strategy,
+			'scores'   => $scores,
+			'metrics'  => self::extract_performance_metrics( $audits ),
+		);
+	}
+
+	private static function format_performance_response( array $lighthouse, string $url, string $strategy ): array {
+		$categories = $lighthouse['categories'] ?? array();
+		$audits     = $lighthouse['audits'] ?? array();
+		$score      = isset( $categories['performance']['score'] ) ? (int) round( $categories['performance']['score'] * 100 ) : null;
+
+		return array(
+			'success'           => true,
+			'action'            => 'performance',
+			'url'               => $url,
+			'strategy'          => $strategy,
+			'performance_score' => $score,
+			'metrics'           => self::extract_performance_metrics( $audits ),
+		);
+	}
+
+	private static function format_opportunities_response( array $lighthouse, string $url, string $strategy ): array {
+		$categories    = $lighthouse['categories'] ?? array();
+		$audits        = $lighthouse['audits'] ?? array();
+		$scores        = array();
+		$opportunities = array();
+
+		foreach ( $categories as $key => $category ) {
+			$scores[ $key ] = isset( $category['score'] ) ? (int) round( $category['score'] * 100 ) : null;
+		}
+
+		foreach ( $audits as $audit_id => $audit ) {
+			if ( ! isset( $audit['score'] ) || $audit['score'] >= 1 ) {
+				continue;
+			}
+
+			if ( empty( $audit['details']['type'] ) || 'opportunity' !== $audit['details']['type'] ) {
+				continue;
+			}
+
+			$opportunity = array(
+				'id'          => $audit_id,
+				'title'       => $audit['title'] ?? '',
+				'description' => $audit['description'] ?? '',
+				'score'       => isset( $audit['score'] ) ? (int) round( $audit['score'] * 100 ) : null,
+			);
+
+			if ( ! empty( $audit['details']['overallSavingsMs'] ) ) {
+				$opportunity['savings_ms'] = (int) round( $audit['details']['overallSavingsMs'] );
+			}
+
+			if ( ! empty( $audit['details']['overallSavingsBytes'] ) ) {
+				$opportunity['savings_bytes'] = (int) $audit['details']['overallSavingsBytes'];
+			}
+
+			$opportunities[] = $opportunity;
+		}
+
+		usort( $opportunities, fn( $a, $b ) => ( $b['savings_ms'] ?? 0 ) - ( $a['savings_ms'] ?? 0 ) );
+
+		return array(
+			'success'       => true,
+			'action'        => 'opportunities',
+			'url'           => $url,
+			'strategy'      => $strategy,
+			'scores'        => $scores,
+			'results_count' => count( $opportunities ),
+			'results'       => $opportunities,
+		);
+	}
+
+	private static function extract_performance_metrics( array $audits ): array {
+		$metrics = array();
+
+		foreach ( self::PERFORMANCE_METRICS as $audit_key => $metric_key ) {
+			$audit_id = strtolower( str_replace( '_', '-', $audit_key ) );
+			$audit    = $audits[ $audit_id ] ?? null;
+
+			if ( ! $audit ) {
+				continue;
+			}
+
+			$metrics[ $metric_key ] = array(
+				'value'   => $audit['displayValue'] ?? null,
+				'numeric' => $audit['numericValue'] ?? null,
+				'score'   => isset( $audit['score'] ) ? (int) round( $audit['score'] * 100 ) : null,
+			);
+		}
+
+		return $metrics;
+	}
+
+	public static function is_configured(): bool {
+		return true;
+	}
+
+	public static function get_config(): array {
+		$config = get_site_option( self::CONFIG_OPTION, array() );
+		return is_array( $config ) ? $config : array();
+	}
+}

--- a/inc/Api/PageSpeedAnalytics.php
+++ b/inc/Api/PageSpeedAnalytics.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * PageSpeed REST API endpoint.
+ *
+ * @package DataMachineBusiness\Api
+ */
+
+namespace DataMachineBusiness\Api;
+
+use DataMachine\Abilities\PermissionHelper;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+class PageSpeedAnalytics {
+
+	public static function register(): void {
+		add_action( 'rest_api_init', array( self::class, 'register_routes' ) );
+	}
+
+	public static function register_routes(): void {
+		register_rest_route(
+			'datamachine/v1',
+			'/analytics/pagespeed',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( self::class, 'handle_request' ),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'args'                => array(
+					'action' => array(
+						'required'    => true,
+						'type'        => 'string',
+						'description' => __( 'The PageSpeed action to perform.', 'data-machine-business' ),
+					),
+				),
+			)
+		);
+	}
+
+	public static function check_permission( $request ) {
+		$request;
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to access analytics data.', 'data-machine-business' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	public static function handle_request( $request ) {
+		$ability = wp_get_ability( 'datamachine/pagespeed' );
+
+		if ( ! $ability ) {
+			return new \WP_Error(
+				'ability_not_found',
+				__( 'PageSpeed ability not registered. Ensure Data Machine Business is active and WordPress 6.9+ is available.', 'data-machine-business' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$input  = $request->get_json_params();
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_Error( 'analytics_error', $result->get_error_message(), array( 'status' => 500 ) );
+		}
+
+		if ( ! empty( $result['error'] ) ) {
+			return new \WP_Error( 'analytics_error', $result['error'], array( 'status' => 400 ) );
+		}
+
+		return rest_ensure_response( $result );
+	}
+}

--- a/inc/Cli/PageSpeedCommand.php
+++ b/inc/Cli/PageSpeedCommand.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * PageSpeed WP-CLI command.
+ *
+ * @package DataMachineBusiness\Cli
+ */
+
+namespace DataMachineBusiness\Cli;
+
+use DataMachine\Cli\BaseCommand;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+class PageSpeedCommand extends BaseCommand {
+
+	/**
+	 * Run PageSpeed Insights (Lighthouse) audits.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Action to perform: analyze (full audit), performance (Core Web Vitals), opportunities (optimization suggestions).
+	 *
+	 * [--page-url=<url>]
+	 * : URL to analyze. Defaults to the site home URL.
+	 *
+	 * [--strategy=<strategy>]
+	 * : Device strategy: mobile or desktop (default: mobile).
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine analytics pagespeed analyze
+	 *     wp datamachine analytics pagespeed performance --strategy=desktop
+	 *     wp datamachine analytics pagespeed opportunities --page-url=https://example.com/
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$input = array(
+			'action' => $args[0] ?? '',
+		);
+
+		if ( isset( $assoc_args['page-url'] ) ) {
+			$input['url'] = $assoc_args['page-url'];
+		}
+
+		if ( isset( $assoc_args['strategy'] ) ) {
+			$input['strategy'] = $assoc_args['strategy'];
+		}
+
+		$ability = wp_get_ability( 'datamachine/pagespeed' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'PageSpeed ability not registered. Ensure Data Machine Business is active and WordPress 6.9+ is available.' );
+			return;
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Unknown error.' );
+			return;
+		}
+
+		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$items = $result['results'] ?? array();
+		if ( empty( $items ) ) {
+			$items = array( $this->flatten_result( $result ) );
+		}
+
+		$items = array_filter( $items );
+		if ( empty( $items ) ) {
+			WP_CLI::success( 'No results.' );
+			return;
+		}
+
+		$this->format_items( $items, array_keys( reset( $items ) ), $assoc_args );
+	}
+
+	private function flatten_result( array $result ): array {
+		$flat = array();
+
+		foreach ( $result as $key => $value ) {
+			if ( in_array( $key, array( 'success', 'tool_name' ), true ) ) {
+				continue;
+			}
+
+			if ( ! is_array( $value ) ) {
+				$flat[ $key ] = $value;
+				continue;
+			}
+
+			foreach ( $value as $nested_key => $nested_value ) {
+				if ( is_array( $nested_value ) ) {
+					$flat[ $key . '_' . $nested_key ] = wp_json_encode( $nested_value );
+				} else {
+					$flat[ $key . '_' . $nested_key ] = $nested_value;
+				}
+			}
+		}
+
+		return $flat;
+	}
+}

--- a/inc/Tools/PageSpeedTool.php
+++ b/inc/Tools/PageSpeedTool.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * PageSpeed Insights AI tool.
+ *
+ * @package DataMachineBusiness\Tools
+ */
+
+namespace DataMachineBusiness\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachineBusiness\Abilities\PageSpeed\PageSpeedAbility;
+
+defined( 'ABSPATH' ) || exit;
+
+class PageSpeedTool extends BaseTool {
+
+	public function __construct() {
+		$this->registerConfigurationHandlers( 'pagespeed' );
+		$this->registerTool( 'pagespeed', array( $this, 'get_tool_definition' ), array( 'chat', 'pipeline' ), array( 'ability' => 'datamachine/pagespeed' ) );
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_def;
+		$ability = wp_get_ability( 'datamachine/pagespeed' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'PageSpeed ability not registered. Ensure Data Machine Business is active and WordPress 6.9+ is available.',
+				'pagespeed'
+			);
+		}
+
+		$result = $ability->execute( $parameters );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'pagespeed' );
+		}
+
+		if ( ! empty( $result['error'] ) ) {
+			return $this->buildErrorResponse( $result['error'], 'pagespeed' );
+		}
+
+		$result['tool_name'] = 'pagespeed';
+		return $result;
+	}
+
+	public function get_tool_definition(): array {
+		return array(
+			'class'           => __CLASS__,
+			'method'          => 'handle_tool_call',
+			'description'     => 'Run Google PageSpeed Insights (Lighthouse) audits on any URL. Get performance scores, Core Web Vitals (LCP, CLS, INP, FCP, TTFB), accessibility and SEO scores, and actionable optimization opportunities with estimated savings. Use to audit page speed, monitor site health, and identify performance improvements.',
+			'requires_config' => false,
+			'parameters'      => array(
+				'type'       => 'object',
+				'properties' => array(
+					'action'   => array(
+						'type'        => 'string',
+						'description' => 'Action to perform: analyze (full Lighthouse audit with all category scores and key metrics), performance (focused Core Web Vitals and performance metrics), opportunities (optimization suggestions sorted by estimated savings).',
+					),
+					'url'      => array(
+						'type'        => 'string',
+						'description' => 'URL to analyze. Defaults to the WordPress site home URL.',
+					),
+					'strategy' => array(
+						'type'        => 'string',
+						'description' => 'Device strategy: mobile (default) or desktop.',
+					),
+				),
+				'required'   => array( 'action' ),
+			),
+		);
+	}
+
+	public static function is_configured(): bool {
+		return PageSpeedAbility::is_configured();
+	}
+
+	public static function get_config(): array {
+		return PageSpeedAbility::get_config();
+	}
+
+	public function check_configuration( $configured, $tool_id ) {
+		if ( 'pagespeed' !== $tool_id ) {
+			return $configured;
+		}
+
+		return self::is_configured();
+	}
+
+	public function get_configuration( $config, $tool_id ) {
+		if ( 'pagespeed' !== $tool_id ) {
+			return $config;
+		}
+
+		return self::get_config();
+	}
+
+	protected function get_config_option_name(): string {
+		return PageSpeedAbility::CONFIG_OPTION;
+	}
+
+	protected function validate_and_build_config( array $config_data ): array {
+		return array(
+			'config'  => array(
+				'api_key' => sanitize_text_field( $config_data['api_key'] ?? '' ),
+			),
+			'message' => __( 'PageSpeed Insights configuration saved successfully', 'data-machine-business' ),
+		);
+	}
+
+	public function get_config_fields( $fields = array(), $tool_id = '' ) {
+		if ( ! empty( $tool_id ) && 'pagespeed' !== $tool_id ) {
+			return $fields;
+		}
+
+		return array(
+			'api_key' => array(
+				'type'        => 'password',
+				'label'       => __( 'Google API Key', 'data-machine-business' ),
+				'placeholder' => __( 'Optional - increases rate limits', 'data-machine-business' ),
+				'required'    => false,
+				'description' => __( 'Optional API key for higher rate limits. PageSpeed Insights works without a key but may be rate-limited.', 'data-machine-business' ),
+			),
+		);
+	}
+}

--- a/tests/pagespeed-ownership-smoke.php
+++ b/tests/pagespeed-ownership-smoke.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Static smoke checks for the PageSpeed integration ownership surface.
+ */
+
+$root     = dirname( __DIR__ );
+$failures = array();
+
+$required_files = array(
+	'inc/Abilities/PageSpeed/PageSpeedAbility.php',
+	'inc/Tools/PageSpeedTool.php',
+	'inc/Api/PageSpeedAnalytics.php',
+	'inc/Cli/PageSpeedCommand.php',
+);
+
+foreach ( $required_files as $relative_path ) {
+	if ( ! file_exists( $root . '/' . $relative_path ) ) {
+		$failures[] = "Missing {$relative_path}";
+	}
+}
+
+$plugin_file = file_get_contents( $root . '/data-machine-business.php' );
+$readme      = file_get_contents( $root . '/README.md' );
+
+foreach ( array( 'PageSpeedAbility', 'PageSpeedTool', 'PageSpeedAnalytics', 'PageSpeedCommand' ) as $symbol ) {
+	if ( false === strpos( $plugin_file, $symbol ) ) {
+		$failures[] = "Plugin bootstrap does not reference {$symbol}";
+	}
+}
+
+foreach ( array( 'datamachine/pagespeed', 'datamachine_pagespeed_config', 'wp datamachine analytics pagespeed' ) as $expected ) {
+	if ( false === strpos( $readme, $expected ) ) {
+		$failures[] = "README does not document {$expected}";
+	}
+}
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( PHP_EOL, $failures ) . PHP_EOL );
+	exit( 1 );
+}
+
+echo "PageSpeed ownership smoke checks passed.\n";


### PR DESCRIPTION
## Summary
- Adds the PageSpeed Insights ability, AI tool/config handler, REST endpoint, and WP-CLI command to Data Machine Business.
- Reuses the existing `datamachine_pagespeed_config` site option so API-key config is adopted from prior Data Machine core installs.
- Adds source-checkout autoload fallback so the plugin can activate in test/source installs without a generated Composer vendor directory.

## Dependency
- Companion Data Machine core removal PR: https://github.com/Extra-Chill/data-machine/pull/2146
- This should be merged/deployed with the Data Machine core removal so PageSpeed is owned by one active plugin at a time.

Related: https://github.com/Extra-Chill/data-machine/issues/2142

## Verification
- `php tests/pagespeed-ownership-smoke.php`
- `php -l data-machine-business.php`
- `php -l inc/Abilities/PageSpeed/PageSpeedAbility.php`
- `php -l inc/Tools/PageSpeedTool.php`
- `php -l inc/Api/PageSpeedAnalytics.php`
- `php -l inc/Cli/PageSpeedCommand.php`
- `git diff --check`
- `homeboy test --path /Users/chubes/Developer/data-machine-business@feat-pagespeed-tooling --extension wordpress --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the PageSpeed extraction implementation, docs, smoke checks, and verification commands for Chris to review/test.