### PR TITLE
feat: add Amazon affiliate link tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This plugin extends Data Machine with business-focused integrations including:
 - **Google Sheets**: Fetch data from spreadsheets and append data for reporting
 - **Slack**: Post messages and fetch conversations from channels
 - **Discord**: Post messages and fetch messages from server channels
+- **Amazon Affiliate Link**: Search Amazon products and return affiliate links using the Amazon Creators API
 
 ## Requirements
 
@@ -151,6 +152,19 @@ Fetches messages from a configured Discord channel with:
 ### Abilities (REST API / Chat Tools)
 - `datamachine/post-message-discord` — Post a message to any channel
 - `datamachine/fetch-messages-discord` — Fetch messages from any channel
+
+## Amazon Affiliate Link Tool
+
+The `amazon_affiliate_link` AI tool searches Amazon products and returns an affiliate URL, product title, thumbnail, and ASIN. It is available in Data Machine chat and pipeline contexts when Data Machine Business is active.
+
+Existing credentials saved by older Data Machine core versions are adopted automatically because the extension uses the same `datamachine_amazon_config` site option.
+
+### Amazon Setup
+
+1. Join or open Amazon Associates.
+2. Create Amazon Creators API credentials.
+3. In Data Machine tool settings, configure Credential ID, Credential Secret, Partner Tag, and Marketplace.
+4. Use `amazon_affiliate_link` only for genuinely relevant product references.
 
 ## License
 

--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -22,8 +22,26 @@ define( 'DATAMACHINE_BUSINESS_VERSION', '0.2.0' );
 define( 'DATAMACHINE_BUSINESS_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DATAMACHINE_BUSINESS_URL', plugin_dir_url( __FILE__ ) );
 
-// PSR-4 Autoloading
-require_once __DIR__ . '/vendor/autoload.php';
+// PSR-4 Autoloading.
+$datamachine_business_autoloader = __DIR__ . '/vendor/autoload.php';
+if ( file_exists( $datamachine_business_autoloader ) ) {
+	require_once $datamachine_business_autoloader;
+} else {
+	spl_autoload_register(
+		function ( string $class_name ): void {
+			$prefix = 'DataMachineBusiness\\';
+			if ( 0 !== strpos( $class_name, $prefix ) ) {
+				return;
+			}
+
+			$relative_class = substr( $class_name, strlen( $prefix ) );
+			$file           = DATAMACHINE_BUSINESS_PATH . 'inc/' . str_replace( '\\', '/', $relative_class ) . '.php';
+			if ( is_readable( $file ) ) {
+				require_once $file;
+			}
+		}
+	);
+}
 
 /**
  * Load and instantiate business handlers and abilities.
@@ -76,6 +94,9 @@ function datamachine_business_load_handlers() {
 	// Discord Handlers
 	new \DataMachineBusiness\Handlers\Discord\DiscordPublish();
 	new \DataMachineBusiness\Handlers\Discord\DiscordFetch();
+
+	// Business AI tools
+	new \DataMachineBusiness\Tools\AmazonAffiliateLink();
 }
 
 // Hook into plugins_loaded to ensure Data Machine core is loaded first

--- a/docs/amazon-affiliate-link.md
+++ b/docs/amazon-affiliate-link.md
@@ -1,0 +1,21 @@
+# Amazon Affiliate Link
+
+`amazon_affiliate_link` searches Amazon products via the Amazon Creators API and returns an affiliate URL, product title, thumbnail URL, and ASIN.
+
+| Field | Value |
+| --- | --- |
+| Modes | chat, pipeline |
+| Mutation risk | Read-only |
+| Registered in | Data Machine Business via `DataMachineBusiness\Tools\AmazonAffiliateLink` |
+| Access | Admin |
+| Config option | `datamachine_amazon_config` |
+
+## Inputs
+
+- `query`: specific product search query.
+
+## Configuration
+
+Configure Credential ID, Credential Secret, Partner Tag, and Marketplace in Data Machine tool settings. Data Machine Business uses the former core option key, `datamachine_amazon_config`, so credentials saved before extraction continue to work after activating this extension.
+
+Use this tool only when a product reference is genuinely useful to the reader.

--- a/inc/Tools/AmazonAffiliateLink.php
+++ b/inc/Tools/AmazonAffiliateLink.php
@@ -1,0 +1,448 @@
+<?php
+/**
+ * Amazon Affiliate Link tool via Amazon Creators API.
+ *
+ * Searches Amazon products and returns affiliate links for AI content generation.
+ * Uses OAuth 2.0 client_credentials flow via regional AWS Cognito endpoints.
+ *
+ * @package DataMachineBusiness\Tools
+ */
+
+namespace DataMachineBusiness\Tools;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Core\HttpClient;
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+class AmazonAffiliateLink extends BaseTool {
+
+	/**
+	 * Config option name. Kept identical to the former core option so existing
+	 * Amazon Creators API credentials are adopted when this extension is active.
+	 *
+	 * @var string
+	 */
+	private const CONFIG_OPTION = 'datamachine_amazon_config';
+
+	/**
+	 * Token transient name.
+	 *
+	 * @var string
+	 */
+	private const TOKEN_TRANSIENT = 'datamachine_amazon_access_token';
+
+	/**
+	 * API base URL.
+	 *
+	 * @var string
+	 */
+	private const API_BASE = 'https://creatorsapi.amazon';
+
+	/**
+	 * Marketplace to region mapping.
+	 *
+	 * @var array<string, string>
+	 */
+	private const REGION_MAP = array(
+		'www.amazon.com'    => 'NA',
+		'www.amazon.ca'     => 'NA',
+		'www.amazon.com.mx' => 'NA',
+		'www.amazon.com.br' => 'NA',
+		'www.amazon.co.uk'  => 'EU',
+		'www.amazon.de'     => 'EU',
+		'www.amazon.fr'     => 'EU',
+		'www.amazon.it'     => 'EU',
+		'www.amazon.es'     => 'EU',
+		'www.amazon.in'     => 'EU',
+		'www.amazon.co.jp'  => 'FE',
+		'www.amazon.com.au' => 'FE',
+	);
+
+	/**
+	 * Region configuration: version and Cognito token endpoint.
+	 *
+	 * @var array<string, array{version: string, token_endpoint: string}>
+	 */
+	private const REGION_CONFIG = array(
+		'NA' => array(
+			'version'        => '2.1',
+			'token_endpoint' => 'https://creatorsapi.auth.us-east-1.amazoncognito.com/oauth2/token',
+		),
+		'EU' => array(
+			'version'        => '2.2',
+			'token_endpoint' => 'https://creatorsapi.auth.eu-south-2.amazoncognito.com/oauth2/token',
+		),
+		'FE' => array(
+			'version'        => '2.3',
+			'token_endpoint' => 'https://creatorsapi.auth.us-west-2.amazoncognito.com/oauth2/token',
+		),
+	);
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->registerConfigurationHandlers( 'amazon_affiliate_link' );
+		$this->registerTool( 'amazon_affiliate_link', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'access_level' => 'admin' ) );
+	}
+
+	/**
+	 * Execute Amazon product search and return affiliate link.
+	 *
+	 * @param array $parameters Contains 'query' for product search.
+	 * @param array $tool_def   Tool definition (unused).
+	 * @return array Search result with affiliate link or error.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		if ( empty( $parameters['query'] ) ) {
+			return $this->buildErrorResponse(
+				'Amazon Affiliate Link tool requires a product search query.',
+				'amazon_affiliate_link'
+			);
+		}
+
+		$config = self::get_config();
+
+		if ( empty( $config['client_id'] ) || empty( $config['client_secret'] ) || empty( $config['partner_tag'] ) ) {
+			return $this->buildErrorResponse(
+				'Amazon Affiliate Link tool not configured. Please add Creators API credentials and partner tag.',
+				'amazon_affiliate_link'
+			);
+		}
+
+		$marketplace = $config['marketplace'] ?? 'www.amazon.com';
+		$region      = self::REGION_MAP[ $marketplace ] ?? 'NA';
+
+		$token = $this->getAccessToken( $config, $region );
+
+		if ( ! $token ) {
+			return $this->buildErrorResponse(
+				'Failed to obtain Amazon Creators API access token. Check credentials.',
+				'amazon_affiliate_link'
+			);
+		}
+
+		$region_config = self::REGION_CONFIG[ $region ];
+		$query         = sanitize_text_field( $parameters['query'] );
+
+		$result = HttpClient::post(
+			self::API_BASE . '/catalog/v1/searchItems',
+			array(
+				'timeout' => 15,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $token . ', Version ' . $region_config['version'],
+					'Content-Type'  => 'application/json',
+					'x-marketplace' => $marketplace,
+				),
+				'body'    => wp_json_encode(
+					array(
+						'keywords'    => $query,
+						'searchIndex' => 'All',
+						'itemCount'   => 1,
+						'marketplace' => $marketplace,
+						'partnerTag'  => $config['partner_tag'],
+						'resources'   => array(
+							'images.primary.small',
+							'itemInfo.title',
+						),
+					)
+				),
+				'context' => 'Amazon Creators API SearchItems',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return $this->buildErrorResponse(
+				'Amazon product search failed: ' . ( $result['error'] ?? 'Unknown error' ),
+				'amazon_affiliate_link'
+			);
+		}
+
+		$data = json_decode( $result['data'], true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return $this->buildErrorResponse(
+				'Failed to parse Amazon API response.',
+				'amazon_affiliate_link'
+			);
+		}
+
+		$items = $data['itemsResult']['items'] ?? array();
+
+		if ( empty( $items ) ) {
+			return array(
+				'success'   => true,
+				'data'      => array(
+					'message' => "No Amazon products found for \"{$query}\". Try a more specific product name.",
+				),
+				'tool_name' => 'amazon_affiliate_link',
+			);
+		}
+
+		$item          = $items[0];
+		$product_title = $item['itemInfo']['title']['displayValue'] ?? 'Unknown Product';
+		$affiliate_url = $item['detailPageURL'] ?? '';
+		$thumbnail_url = $item['images']['primary']['small']['url'] ?? '';
+		$asin          = $item['asin'] ?? '';
+
+		return array(
+			'success'   => true,
+			'data'      => array(
+				'product_title' => $product_title,
+				'affiliate_url' => $affiliate_url,
+				'thumbnail_url' => $thumbnail_url,
+				'asin'          => $asin,
+			),
+			'tool_name' => 'amazon_affiliate_link',
+		);
+	}
+
+	/**
+	 * Get OAuth 2.0 access token, using cached transient when available.
+	 *
+	 * @param array  $config Amazon configuration.
+	 * @param string $region Region identifier (NA, EU, FE).
+	 * @return string|null Access token or null on failure.
+	 */
+	private function getAccessToken( array $config, string $region ): ?string {
+		$cached = get_transient( self::TOKEN_TRANSIENT );
+
+		if ( $cached ) {
+			return $cached;
+		}
+
+		$region_config = self::REGION_CONFIG[ $region ] ?? self::REGION_CONFIG['NA'];
+
+		$result = HttpClient::post(
+			$region_config['token_endpoint'],
+			array(
+				'timeout' => 10,
+				'headers' => array(
+					'Content-Type' => 'application/x-www-form-urlencoded',
+				),
+				'body'    => http_build_query(
+					array(
+						'grant_type'    => 'client_credentials',
+						'client_id'     => $config['client_id'],
+						'client_secret' => $config['client_secret'],
+						'scope'         => 'creatorsapi/default',
+					)
+				),
+				'context' => 'Amazon Creators API Token',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Failed to fetch Amazon Creators API token',
+				array(
+					'error'  => $result['error'] ?? 'Unknown',
+					'region' => $region,
+				)
+			);
+			return null;
+		}
+
+		$token_data = json_decode( $result['data'], true );
+
+		if ( empty( $token_data['access_token'] ) ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Amazon Creators API token response missing access_token',
+				array( 'response' => $result['data'] )
+			);
+			return null;
+		}
+
+		$expires_in = (int) ( $token_data['expires_in'] ?? 3600 );
+		set_transient( self::TOKEN_TRANSIENT, $token_data['access_token'], $expires_in - 100 );
+
+		return $token_data['access_token'];
+	}
+
+	/**
+	 * Get tool definition for AI agent registration.
+	 *
+	 * @return array Tool definition array.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'           => __CLASS__,
+			'method'          => 'handle_tool_call',
+			'description'     => 'Search Amazon products and return an affiliate link with the product title, URL, and thumbnail. Use when content mentions a specific product the reader might want to buy. Only use for genuinely relevant product references, not every noun.',
+			'requires_config' => true,
+			'parameters'      => array(
+				'type'       => 'object',
+				'properties' => array(
+					'query' => array(
+						'type'        => 'string',
+						'description' => 'Product search query (e.g., "Lodge cast iron Dutch oven", "KitchenAid stand mixer"). Be specific for best results.',
+					),
+				),
+				'required'   => array( 'query' ),
+			),
+		);
+	}
+
+	/**
+	 * Check if Amazon Affiliate Link tool is configured.
+	 *
+	 * @return bool True if all required credentials are present.
+	 */
+	public static function is_configured(): bool {
+		$config = self::get_config();
+
+		return ! empty( $config['client_id'] )
+			&& ! empty( $config['client_secret'] )
+			&& ! empty( $config['partner_tag'] );
+	}
+
+	/**
+	 * Get stored Amazon configuration.
+	 *
+	 * @return array Configuration array.
+	 */
+	public static function get_config(): array {
+		return get_site_option( self::CONFIG_OPTION, array() );
+	}
+
+	/**
+	 * Check configuration status via filter.
+	 *
+	 * @param bool   $configured Current status.
+	 * @param string $tool_id    Tool identifier.
+	 * @return bool True if configured.
+	 */
+	public function check_configuration( $configured, $tool_id ) {
+		if ( 'amazon_affiliate_link' !== $tool_id ) {
+			return $configured;
+		}
+
+		return self::is_configured();
+	}
+
+	/**
+	 * Get configuration via filter.
+	 *
+	 * @param mixed  $config  Current config.
+	 * @param string $tool_id Tool identifier.
+	 * @return array Configuration array.
+	 */
+	public function get_configuration( $config, $tool_id ) {
+		if ( 'amazon_affiliate_link' !== $tool_id ) {
+			return $config;
+		}
+
+		return self::get_config();
+	}
+
+	/**
+	 * Get the option name used to store Amazon configuration.
+	 *
+	 * @return string Option name.
+	 */
+	protected function get_config_option_name(): string {
+		return self::CONFIG_OPTION;
+	}
+
+	/**
+	 * Validate and build Amazon configuration.
+	 *
+	 * @param array $config_data Configuration data from form.
+	 * @return array{config: array, message: string}|array{error: string}
+	 */
+	protected function validate_and_build_config( array $config_data ): array {
+		$client_id     = sanitize_text_field( $config_data['client_id'] ?? '' );
+		$client_secret = sanitize_text_field( $config_data['client_secret'] ?? '' );
+		$partner_tag   = sanitize_text_field( $config_data['partner_tag'] ?? '' );
+		$marketplace   = sanitize_text_field( $config_data['marketplace'] ?? 'www.amazon.com' );
+
+		if ( empty( $client_id ) || empty( $client_secret ) || empty( $partner_tag ) ) {
+			return array( 'error' => __( 'Credential ID, Credential Secret, and Partner Tag are required.', 'data-machine-business' ) );
+		}
+
+		if ( ! isset( self::REGION_MAP[ $marketplace ] ) ) {
+			return array( 'error' => __( 'Invalid marketplace selected.', 'data-machine-business' ) );
+		}
+
+		return array(
+			'config'  => array(
+				'client_id'     => $client_id,
+				'client_secret' => $client_secret,
+				'partner_tag'   => $partner_tag,
+				'marketplace'   => $marketplace,
+			),
+			'message' => __( 'Amazon Affiliate configuration saved successfully.', 'data-machine-business' ),
+		);
+	}
+
+	/**
+	 * Clear cached Amazon access token before saving configuration.
+	 *
+	 * @param array $config_data Configuration data from form.
+	 */
+	protected function before_config_save( array $config_data ): void {
+		delete_transient( self::TOKEN_TRANSIENT );
+	}
+
+	/**
+	 * Get configuration field definitions for settings UI.
+	 *
+	 * @param array  $fields  Current fields.
+	 * @param string $tool_id Tool identifier.
+	 * @return array Field definitions.
+	 */
+	public function get_config_fields( $fields = array(), $tool_id = '' ) {
+		if ( ! empty( $tool_id ) && 'amazon_affiliate_link' !== $tool_id ) {
+			return $fields;
+		}
+
+		return array(
+			'client_id'     => array(
+				'type'        => 'text',
+				'label'       => __( 'Credential ID', 'data-machine-business' ),
+				'placeholder' => __( 'Enter your Amazon Creators API Credential ID', 'data-machine-business' ),
+				'required'    => true,
+				'description' => __( 'From Amazon Associates -> Creators API credentials.', 'data-machine-business' ),
+			),
+			'client_secret' => array(
+				'type'        => 'password',
+				'label'       => __( 'Credential Secret', 'data-machine-business' ),
+				'placeholder' => __( 'Enter your Amazon Creators API Credential Secret', 'data-machine-business' ),
+				'required'    => true,
+				'description' => __( 'Keep this secret. Never expose in client-side code.', 'data-machine-business' ),
+			),
+			'partner_tag'   => array(
+				'type'        => 'text',
+				'label'       => __( 'Partner Tag', 'data-machine-business' ),
+				'placeholder' => __( 'e.g., mysite-20', 'data-machine-business' ),
+				'required'    => true,
+				'description' => __( 'Your Amazon Associates tracking tag.', 'data-machine-business' ),
+			),
+			'marketplace'   => array(
+				'type'        => 'select',
+				'label'       => __( 'Marketplace', 'data-machine-business' ),
+				'required'    => true,
+				'description' => __( 'Amazon marketplace for product searches. Region and API version are auto-detected.', 'data-machine-business' ),
+				'options'     => array(
+					'www.amazon.com'    => 'United States (amazon.com)',
+					'www.amazon.ca'     => 'Canada (amazon.ca)',
+					'www.amazon.com.mx' => 'Mexico (amazon.com.mx)',
+					'www.amazon.com.br' => 'Brazil (amazon.com.br)',
+					'www.amazon.co.uk'  => 'United Kingdom (amazon.co.uk)',
+					'www.amazon.de'     => 'Germany (amazon.de)',
+					'www.amazon.fr'     => 'France (amazon.fr)',
+					'www.amazon.it'     => 'Italy (amazon.it)',
+					'www.amazon.es'     => 'Spain (amazon.es)',
+					'www.amazon.in'     => 'India (amazon.in)',
+					'www.amazon.co.jp'  => 'Japan (amazon.co.jp)',
+					'www.amazon.com.au' => 'Australia (amazon.com.au)',
+				),
+			),
+		);
+	}
+}

--- a/tests/amazon-affiliate-tool-smoke.php
+++ b/tests/amazon-affiliate-tool-smoke.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Pure-PHP smoke test for Amazon affiliate tool registration and config adoption.
+ *
+ * Run with: php tests/amazon-affiliate-tool-smoke.php
+ *
+ * @package DataMachineBusiness\Tests
+ */
+
+namespace DataMachine\Engine\AI\Tools {
+	abstract class BaseTool {
+		protected string $config_tool_id = '';
+
+		protected function registerTool( string $toolName, array|callable $toolDefinition, array $modes = array(), array $meta = array() ): void {
+			\add_filter(
+				'datamachine_tools',
+				function ( $tools ) use ( $toolName, $toolDefinition, $modes, $meta ) {
+					$tools[ $toolName ] = array(
+						'_callable'       => $toolDefinition,
+						'modes'           => $modes,
+						'requires_opt_in' => ! empty( $meta['requires_opt_in'] ),
+					);
+
+					if ( ! empty( $meta['access_level'] ) ) {
+						$tools[ $toolName ]['access_level'] = $meta['access_level'];
+					}
+
+					return $tools;
+				}
+			);
+		}
+
+		protected function registerConfigurationHandlers( string $tool_id ): void {
+			$this->config_tool_id = $tool_id;
+			\add_filter( 'datamachine_tool_configured', array( $this, 'check_configuration' ), 10, 2 );
+			\add_filter( 'datamachine_get_tool_config', array( $this, 'get_configuration' ), 10, 2 );
+			\add_filter( 'datamachine_get_tool_config_fields', array( $this, 'get_config_fields' ), 10, 2 );
+			\add_filter( 'datamachine_save_tool_config', array( $this, 'save_configuration' ), 10, 3 );
+		}
+
+		public function save_configuration( $result, $tool_id, $config_data ) {
+			if ( $this->config_tool_id !== $tool_id ) {
+				return $result;
+			}
+
+			$validated = $this->validate_and_build_config( $config_data );
+			if ( isset( $validated['error'] ) ) {
+				return array( 'success' => false );
+			}
+
+			$this->before_config_save( $config_data );
+			\update_site_option( $this->get_config_option_name(), $validated['config'] );
+
+			return array( 'success' => true );
+		}
+
+		protected function get_config_option_name(): string {
+			return '';
+		}
+
+		protected function validate_and_build_config( array $config_data ): array {
+			return array( 'config' => $config_data );
+		}
+
+		protected function before_config_save( array $config_data ): void {}
+
+		protected function buildErrorResponse( string $message, string $tool_name ): array {
+			return array(
+				'success'   => false,
+				'error'     => $message,
+				'tool_name' => $tool_name,
+			);
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$test_filters = array();
+	$test_options = array();
+	$test_deleted_transients = array();
+
+	function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		global $test_filters;
+		$test_filters[ $tag ][ $priority ][] = $callback;
+	}
+
+	function apply_filters( string $tag, $value, ...$args ) {
+		global $test_filters;
+		if ( empty( $test_filters[ $tag ] ) ) {
+			return $value;
+		}
+
+		ksort( $test_filters[ $tag ] );
+		foreach ( $test_filters[ $tag ] as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				$value = $callback( $value, ...$args );
+			}
+		}
+
+		return $value;
+	}
+
+	function __( string $text, string $domain = 'default' ): string {
+		return $text;
+	}
+
+	function sanitize_text_field( $value ): string {
+		return trim( (string) $value );
+	}
+
+	function get_site_option( string $option, $default = false ) {
+		global $test_options;
+		return $test_options[ $option ] ?? $default;
+	}
+
+	function update_site_option( string $option, $value ): bool {
+		global $test_options;
+		$test_options[ $option ] = $value;
+		return true;
+	}
+
+	function get_transient( string $transient ) {
+		return false;
+	}
+
+	function set_transient( string $transient, $value, int $expiration = 0 ): bool {
+		return true;
+	}
+
+	function delete_transient( string $transient ): bool {
+		global $test_deleted_transients;
+		$test_deleted_transients[] = $transient;
+		return true;
+	}
+
+	function wp_json_encode( $value ) {
+		return json_encode( $value );
+	}
+
+	function do_action( string $tag, ...$args ): void {}
+
+	require_once __DIR__ . '/../inc/Tools/AmazonAffiliateLink.php';
+
+	$failures = array();
+	$passes   = 0;
+
+	function assert_true_for_amazon_tool( bool $condition, string $name, array &$failures, int &$passes ): void {
+		if ( $condition ) {
+			$passes++;
+			echo "  OK {$name}\n";
+			return;
+		}
+
+		$failures[] = $name;
+		echo "  FAIL {$name}\n";
+	}
+
+	echo "Amazon affiliate tool smoke\n";
+	echo "---------------------------\n";
+
+	new \DataMachineBusiness\Tools\AmazonAffiliateLink();
+
+	$tools = apply_filters( 'datamachine_tools', array() );
+	assert_true_for_amazon_tool( isset( $tools['amazon_affiliate_link'] ), 'tool registers with Data Machine registry', $failures, $passes );
+	assert_true_for_amazon_tool( in_array( 'chat', $tools['amazon_affiliate_link']['modes'] ?? array(), true ), 'tool is chat-visible', $failures, $passes );
+	assert_true_for_amazon_tool( in_array( 'pipeline', $tools['amazon_affiliate_link']['modes'] ?? array(), true ), 'tool is pipeline-visible', $failures, $passes );
+	assert_true_for_amazon_tool( 'admin' === ( $tools['amazon_affiliate_link']['access_level'] ?? '' ), 'tool remains admin-only', $failures, $passes );
+
+	$config = array(
+		'client_id'     => 'credential-id',
+		'client_secret' => 'credential-secret',
+		'partner_tag'   => 'example-20',
+		'marketplace'   => 'www.amazon.com',
+	);
+
+	$result = apply_filters( 'datamachine_save_tool_config', null, 'amazon_affiliate_link', $config );
+	assert_true_for_amazon_tool( true === ( $result['success'] ?? false ), 'configuration saves successfully', $failures, $passes );
+	assert_true_for_amazon_tool( $config === get_site_option( 'datamachine_amazon_config' ), 'configuration uses former core option key', $failures, $passes );
+	assert_true_for_amazon_tool( in_array( 'datamachine_amazon_access_token', $test_deleted_transients, true ), 'configuration clears former core token transient', $failures, $passes );
+	assert_true_for_amazon_tool( true === apply_filters( 'datamachine_tool_configured', false, 'amazon_affiliate_link' ), 'configuration status reads adopted option', $failures, $passes );
+
+	$fields = apply_filters( 'datamachine_get_tool_config_fields', array(), 'amazon_affiliate_link' );
+	assert_true_for_amazon_tool( isset( $fields['client_id'], $fields['client_secret'], $fields['partner_tag'], $fields['marketplace'] ), 'settings fields are registered', $failures, $passes );
+
+	if ( ! empty( $failures ) ) {
+		echo "\nFAILURES:\n";
+		foreach ( $failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\n{$passes} assertions passed.\n";
+}


### PR DESCRIPTION
## Summary
- Adds the `amazon_affiliate_link` AI tool to Data Machine Business for chat and pipeline contexts.
- Preserves the former Data Machine core option and transient names (`datamachine_amazon_config`, `datamachine_amazon_access_token`) so existing credentials are adopted when the extension is active.
- Adds docs and a pure-PHP smoke test for registration, admin access, settings fields, and config adoption.

## Dependency
- Supports Extra-Chill/data-machine#2143.
- Companion core removal PR: Extra-Chill/data-machine#2147.
- Merge this before or alongside the Data Machine core removal PR so the tool remains available through Data Machine Business.

## Verification
- `php -l data-machine-business.php`
- `php -l inc/Tools/AmazonAffiliateLink.php`
- `php tests/amazon-affiliate-tool-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine-business@feature-amazon-affiliate-tool --extension wordpress`
- `homeboy lint --path /Users/chubes/Developer/data-machine-business@feature-amazon-affiliate-tool --extension wordpress --changed-since origin/main`

Note: full lint has existing unrelated repo-wide findings. Changed-file PHPCS/PHPStan passed, but Homeboy returned a stale local `data-machine` dependency warning because the registered primary checkout is behind `origin/main`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the extraction implementation, tests, docs, and verification commands for Chris to review.