### PR TITLE
feat: register GA4 tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This plugin extends Data Machine with business-focused integrations including:
 
 - **Google Search**: Search the web through Google Custom Search API as an AI tool
 - **Google Sheets**: Fetch data from spreadsheets and append data for reporting
+- **Google Analytics (GA4)**: Fetch visitor analytics, realtime, engagement, and comparison metrics
 - **Slack**: Post messages and fetch conversations from channels
 - **Discord**: Post messages and fetch messages from server channels
 - **Amazon Affiliate Link**: Search Amazon products and return affiliate links using the Amazon Creators API
@@ -40,6 +41,25 @@ Data Machine Business registers the `google_search` AI tool for chat and pipelin
 ### Google Search Usage
 
 The tool accepts a required `query` parameter and an optional `site_restrict` domain. It returns up to 10 structured results with title, link, snippet, and display link fields.
+
+## Google Analytics (GA4) Setup
+
+Data Machine Business registers the `datamachine/google-analytics` ability and `google_analytics` chat/pipeline tool. Data Machine core keeps the compatible REST and WP-CLI dispatchers (`/analytics/ga` and `wp datamachine analytics ga`), which work when this plugin is active.
+
+Existing Data Machine GA4 settings are adopted automatically because this plugin uses the same option key, `datamachine_ga_config`, and token transient, `datamachine_ga_access_token`.
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Enable the Google Analytics Data API
+3. Create a service account and download its JSON key
+4. Grant the service account access to the GA4 property
+5. Configure the Service Account JSON and GA4 Property ID in Data Machine tool settings
+
+### GA4 Ability And Tool
+
+- `datamachine/google-analytics` — Fetches GA4 reports and realtime analytics
+- `google_analytics` — Chat and pipeline tool wrapper for AI agents
+
+Supported actions include `page_stats`, `traffic_sources`, `date_stats`, `realtime`, `top_events`, `user_demographics`, `landing_pages`, `engagement`, and `new_vs_returning`.
 
 ## Google Sheets Setup
 

--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Data Machine Business
  * Plugin URI: https://github.com/Extra-Chill/data-machine-business
- * Description: Business and enterprise integrations for Data Machine. Adds support for Google Sheets, Slack, Discord, and other business tools.
+ * Description: Business and enterprise integrations for Data Machine. Adds support for Google Analytics, Google Sheets, Slack, Discord, and other business tools.
  * Version: 0.2.0
  * Requires at least: 6.9
  * Requires PHP: 8.2
@@ -67,6 +67,11 @@ function datamachine_business_load_handlers() {
 	}
 
 	// Load Abilities (they self-register)
+	new \DataMachineBusiness\Abilities\Analytics\GoogleAnalyticsAbilities();
+
+	// Global AI tools.
+	new \DataMachineBusiness\Engine\AI\Tools\Global\GoogleAnalytics();
+
 	// Google Sheets
 	new \DataMachineBusiness\Abilities\GoogleSheets\FetchGoogleSheetsAbility();
 	new \DataMachineBusiness\Abilities\GoogleSheets\PublishGoogleSheetsAbility();

--- a/docs/google-analytics.md
+++ b/docs/google-analytics.md
@@ -1,0 +1,37 @@
+# Google Analytics (GA4)
+
+Data Machine Business provides the Google Analytics (GA4) integration that previously lived in Data Machine core.
+
+## Runtime Surfaces
+
+| Surface | Identifier |
+| --- | --- |
+| Ability | `datamachine/google-analytics` |
+| AI tool | `google_analytics` |
+| REST route | `POST /wp-json/datamachine/v1/analytics/ga` |
+| WP-CLI | `wp datamachine analytics ga <action>` |
+
+The REST route and WP-CLI command are provided by Data Machine core for compatibility. They execute successfully when Data Machine Business is active and has registered the GA4 ability.
+
+## Configuration Adoption
+
+Existing GA4 installations do not need a migration step. Data Machine Business uses the same stored configuration keys as the former core implementation:
+
+- `datamachine_ga_config` for service account JSON and property ID
+- `datamachine_ga_access_token` for the cached access token transient
+
+## Supported Actions
+
+- `page_stats`
+- `traffic_sources`
+- `date_stats`
+- `realtime`
+- `top_events`
+- `user_demographics`
+- `landing_pages`
+- `engagement`
+- `new_vs_returning`
+
+## Authentication
+
+GA4 uses a Google service account with the `https://www.googleapis.com/auth/analytics.readonly` scope. Grant the service account access to the target GA4 property, then configure the service account JSON and numeric property ID in the `google_analytics` tool settings.

--- a/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
+++ b/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
@@ -1,0 +1,757 @@
+<?php
+/**
+ * Google Analytics (GA4) Abilities
+ *
+ * Primitive ability for Google Analytics Data API (GA4).
+ * All GA4 data — tools, CLI, REST, chat — flows through this ability.
+ *
+ * Uses the GA4 Data API v1beta to fetch visitor analytics:
+ * page performance, traffic sources, daily trends, real-time data,
+ * top events, and user demographics.
+ *
+ * Authentication uses the same service account JWT flow as Google Search Console.
+ *
+ * @package DataMachineBusiness\Abilities\Analytics
+ * @since 0.31.0
+ */
+
+namespace DataMachineBusiness\Abilities\Analytics;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+
+defined( 'ABSPATH' ) || exit;
+
+class GoogleAnalyticsAbilities {
+
+	/**
+	 * Option key for storing GA configuration.
+	 *
+	 * @var string
+	 */
+	const CONFIG_OPTION = 'datamachine_ga_config';
+
+	/**
+	 * Transient key for cached access token.
+	 *
+	 * @var string
+	 */
+	const TOKEN_TRANSIENT = 'datamachine_ga_access_token';
+
+	/**
+	 * GA4 Data API base URL.
+	 *
+	 * @var string
+	 */
+	const API_BASE = 'https://analyticsdata.googleapis.com/v1beta/properties/';
+
+	/**
+	 * Default result limit.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_LIMIT = 25;
+
+	/**
+	 * Maximum result limit.
+	 *
+	 * @var int
+	 */
+	const MAX_LIMIT = 10000;
+
+	/**
+	 * Action-to-report configuration mapping.
+	 *
+	 * Each action defines the dimensions and metrics for its GA4 report request.
+	 *
+	 * @var array
+	 */
+	const ACTION_REPORTS = array(
+		'page_stats'        => array(
+			'dimensions' => array( 'pagePath', 'pageTitle' ),
+			'metrics'    => array( 'screenPageViews', 'sessions', 'bounceRate', 'averageSessionDuration', 'activeUsers' ),
+		),
+		'traffic_sources'   => array(
+			'dimensions' => array( 'sessionSource', 'sessionMedium' ),
+			'metrics'    => array( 'sessions', 'activeUsers', 'screenPageViews', 'bounceRate' ),
+		),
+		'date_stats'        => array(
+			'dimensions' => array( 'date' ),
+			'metrics'    => array( 'sessions', 'screenPageViews', 'activeUsers', 'bounceRate', 'averageSessionDuration' ),
+		),
+		'top_events'        => array(
+			'dimensions' => array( 'eventName' ),
+			'metrics'    => array( 'eventCount', 'eventCountPerUser' ),
+		),
+		'user_demographics' => array(
+			'dimensions' => array( 'country', 'deviceCategory' ),
+			'metrics'    => array( 'sessions', 'activeUsers', 'screenPageViews' ),
+		),
+		'landing_pages'     => array(
+			'dimensions' => array( 'landingPage' ),
+			'metrics'    => array( 'sessions', 'activeUsers', 'bounceRate', 'averageSessionDuration', 'engagementRate' ),
+		),
+		'engagement'        => array(
+			'dimensions' => array( 'pagePath', 'pageTitle' ),
+			'metrics'    => array( 'engagementRate', 'averageSessionDuration', 'engagedSessions', 'sessionsPerUser', 'screenPageViewsPerSession', 'userEngagementDuration' ),
+		),
+		'new_vs_returning'  => array(
+			'dimensions' => array( 'newVsReturning' ),
+			'metrics'    => array( 'sessions', 'activeUsers', 'engagementRate', 'screenPageViewsPerSession', 'averageSessionDuration' ),
+		),
+	);
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/google-analytics',
+				array(
+					'label'               => 'Google Analytics',
+					'description'         => 'Fetch visitor analytics data from Google Analytics (GA4) Data API',
+					'category'            => 'datamachine-analytics',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'action' ),
+						'properties' => array(
+							'action'      => array(
+								'type'        => 'string',
+								'description' => 'Action to perform: page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics, landing_pages, engagement, new_vs_returning.',
+							),
+							'property_id' => array(
+								'type'        => 'string',
+								'description' => 'GA4 property ID (numeric). Defaults to configured property ID.',
+							),
+							'start_date'  => array(
+								'type'        => 'string',
+								'description' => 'Start date in YYYY-MM-DD format (defaults to 28 days ago). Not used for realtime.',
+							),
+							'end_date'    => array(
+								'type'        => 'string',
+								'description' => 'End date in YYYY-MM-DD format (defaults to yesterday). Not used for realtime.',
+							),
+							'limit'       => array(
+								'type'        => 'integer',
+								'description' => 'Row limit (default: 25, max: 10000).',
+							),
+							'page_filter' => array(
+								'type'        => 'string',
+								'description' => 'Filter results to pages with paths containing this string.',
+							),
+							'hostname'    => array(
+								'type'        => 'string',
+								'description' => 'Filter to pages on this hostname (for multisite GA4 properties).',
+							),
+							'sort_by'     => array(
+								'type'        => 'string',
+								'description' => 'Sort results by this metric or dimension field name.',
+							),
+							'order'       => array(
+								'type'        => 'string',
+								'description' => 'Sort direction: asc or desc (default: desc).',
+							),
+							'compare'     => array(
+								'type'        => 'boolean',
+								'description' => 'Compare against the previous period of equal length. Adds delta columns.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'       => array( 'type' => 'boolean' ),
+							'action'        => array( 'type' => 'string' ),
+							'results_count' => array( 'type' => 'integer' ),
+							'results'       => array( 'type' => 'array' ),
+							'error'         => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'fetchStats' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Fetch stats from Google Analytics Data API.
+	 *
+	 * @param array $input Ability input.
+	 * @return array Ability response.
+	 */
+	public static function fetchStats( array $input ): array {
+		$action = sanitize_text_field( $input['action'] ?? '' );
+
+		$valid_actions = array_merge( array_keys( self::ACTION_REPORTS ), array( 'realtime' ) );
+		if ( empty( $action ) || ! in_array( $action, $valid_actions, true ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Invalid action. Must be one of: ' . implode( ', ', $valid_actions ),
+			);
+		}
+
+		$config = self::get_config();
+
+		if ( empty( $config['service_account_json'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Google Analytics not configured. Add service account JSON in Settings.',
+			);
+		}
+
+		$service_account = json_decode( $config['service_account_json'], true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE || empty( $service_account['client_email'] ) || empty( $service_account['private_key'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Invalid service account JSON. Ensure it contains client_email and private_key.',
+			);
+		}
+
+		$access_token = self::get_access_token( $service_account );
+
+		if ( is_wp_error( $access_token ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to authenticate: ' . $access_token->get_error_message(),
+			);
+		}
+
+		$property_id = ! empty( $input['property_id'] ) ? sanitize_text_field( $input['property_id'] ) : ( $config['property_id'] ?? '' );
+
+		if ( empty( $property_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No GA4 property ID configured or provided.',
+			);
+		}
+
+		// Route to realtime handler.
+		if ( 'realtime' === $action ) {
+			return self::fetchRealtime( $access_token, $property_id );
+		}
+
+		return self::fetchReport( $input, $action, $access_token, $property_id );
+	}
+
+	/**
+	 * Build the GA4 runReport request body from ability input.
+	 *
+	 * Public for unit testing — request body construction is the testable surface
+	 * for filter / sort / pagination behavior without needing an HTTP round-trip.
+	 *
+	 * @param array  $input  Ability input.
+	 * @param string $action Report action (must be a key in self::ACTION_REPORTS).
+	 * @return array Request body for the GA4 runReport endpoint.
+	 */
+	public static function buildReportRequestBody( array $input, string $action ): array {
+		$report_config = self::ACTION_REPORTS[ $action ];
+
+		$start_date = ! empty( $input['start_date'] ) ? sanitize_text_field( $input['start_date'] ) : gmdate( 'Y-m-d', strtotime( '-28 days' ) );
+		$end_date   = ! empty( $input['end_date'] ) ? sanitize_text_field( $input['end_date'] ) : gmdate( 'Y-m-d', strtotime( '-1 day' ) );
+		$limit      = ! empty( $input['limit'] ) ? min( (int) $input['limit'], self::MAX_LIMIT ) : self::DEFAULT_LIMIT;
+		$compare    = ! empty( $input['compare'] );
+
+		$dimensions = array_map(
+			function ( $dim ) {
+				return array( 'name' => $dim );
+			},
+			$report_config['dimensions']
+		);
+
+		$metrics = array_map(
+			function ( $met ) {
+				return array( 'name' => $met );
+			},
+			$report_config['metrics']
+		);
+
+		// Build date ranges — add comparison period if requested.
+		$date_ranges = array(
+			array(
+				'startDate' => $start_date,
+				'endDate'   => $end_date,
+			),
+		);
+
+		if ( $compare ) {
+			$period_length    = (int) ( ( strtotime( $end_date ) - strtotime( $start_date ) ) / 86400 );
+			$compare_end_ts   = strtotime( $start_date ) - 86400;
+			$compare_start_ts = $compare_end_ts - ( $period_length * 86400 );
+			$date_ranges[]    = array(
+				'startDate' => gmdate( 'Y-m-d', $compare_start_ts ),
+				'endDate'   => gmdate( 'Y-m-d', $compare_end_ts ),
+			);
+		}
+
+		$request_body = array(
+			'dateRanges' => $date_ranges,
+			'dimensions' => $dimensions,
+			'metrics'    => $metrics,
+			'limit'      => $limit,
+		);
+
+		// Build dimension filters.
+		$filters = array();
+
+		// Page path filter. GA4 supports pagePath/landingPage as filter dimensions
+		// even when they aren't part of the report's dimensions array, so the filter
+		// applies to every action — not just those that group by page.
+		if ( ! empty( $input['page_filter'] ) ) {
+			// Prefer landingPage when the report groups by it (so the filter matches
+			// the dimension being returned); otherwise filter by pagePath, which
+			// scopes any action (date_stats, traffic_sources, top_events, etc.) to
+			// hits/sessions that touched matching paths.
+			$path_dim = in_array( 'landingPage', $report_config['dimensions'], true )
+				? 'landingPage'
+				: 'pagePath';
+
+			$filters[] = array(
+				'filter' => array(
+					'fieldName'    => $path_dim,
+					'stringFilter' => array(
+						'matchType' => 'CONTAINS',
+						'value'     => sanitize_text_field( $input['page_filter'] ),
+					),
+				),
+			);
+		}
+
+		// Hostname filter for multisite properties.
+		if ( ! empty( $input['hostname'] ) ) {
+			$filters[] = array(
+				'filter' => array(
+					'fieldName'    => 'hostName',
+					'stringFilter' => array(
+						'matchType' => 'EXACT',
+						'value'     => sanitize_text_field( $input['hostname'] ),
+					),
+				),
+			);
+		}
+
+		if ( count( $filters ) === 1 ) {
+			$request_body['dimensionFilter'] = $filters[0];
+		} elseif ( count( $filters ) > 1 ) {
+			$request_body['dimensionFilter'] = array(
+				'andGroup' => array(
+					'expressions' => $filters,
+				),
+			);
+		}
+
+		// Sort order.
+		if ( ! empty( $input['sort_by'] ) ) {
+			$sort_field  = sanitize_text_field( $input['sort_by'] );
+			$sort_order  = 'asc' === strtolower( $input['order'] ?? 'desc' ) ? 'ASCENDING' : 'DESCENDING';
+			$all_metrics = $report_config['metrics'];
+			$all_dims    = $report_config['dimensions'];
+
+			if ( in_array( $sort_field, $all_metrics, true ) ) {
+				$request_body['orderBys'] = array(
+					array(
+						'metric' => array( 'metricName' => $sort_field ),
+						'desc'   => 'DESCENDING' === $sort_order,
+					),
+				);
+			} elseif ( in_array( $sort_field, $all_dims, true ) ) {
+				$request_body['orderBys'] = array(
+					array(
+						'dimension' => array(
+							'dimensionName' => $sort_field,
+							'orderType'     => 'ALPHANUMERIC',
+						),
+						'desc'      => 'DESCENDING' === $sort_order,
+					),
+				);
+			}
+		}
+
+		return $request_body;
+	}
+
+	/**
+	 * Fetch a standard GA4 report.
+	 *
+	 * @param array  $input        Ability input.
+	 * @param string $action       Report action.
+	 * @param string $access_token OAuth2 access token.
+	 * @param string $property_id  GA4 property ID.
+	 * @return array
+	 */
+	private static function fetchReport( array $input, string $action, string $access_token, string $property_id ): array {
+		$request_body = self::buildReportRequestBody( $input, $action );
+
+		// Pull values needed for response shaping back out of the request body
+		// so we don't have to recompute defaults / comparison logic in two places.
+		$compare     = ! empty( $input['compare'] );
+		$date_ranges = $request_body['dateRanges'];
+		$start_date  = $date_ranges[0]['startDate'];
+		$end_date    = $date_ranges[0]['endDate'];
+
+		$api_url = self::API_BASE . $property_id . ':runReport';
+
+		$result = HttpClient::post(
+			$api_url,
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Content-Type'  => 'application/json',
+				),
+				'body'    => wp_json_encode( $request_body ),
+				'context' => 'Google Analytics Data API',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to connect to Google Analytics API: ' . ( $result['error'] ?? 'Unknown error' ),
+			);
+		}
+
+		$data = json_decode( $result['data'], true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to parse Google Analytics API response.',
+			);
+		}
+
+		if ( ! empty( $data['error'] ) ) {
+			$error_message = $data['error']['message'] ?? 'Unknown API error';
+			return array(
+				'success' => false,
+				'error'   => 'GA4 API error: ' . $error_message,
+			);
+		}
+
+		$rows = $compare
+			? self::formatComparisonRows( $data)
+			: self::formatReportRows( $data);
+
+		$response = array(
+			'success'       => true,
+			'action'        => $action,
+			'date_range'    => array(
+				'start_date' => $start_date,
+				'end_date'   => $end_date,
+			),
+			'results_count' => count( $rows ),
+			'results'       => $rows,
+		);
+
+		if ( $compare ) {
+			$response['compare_date_range'] = array(
+				'start_date' => $date_ranges[1]['startDate'],
+				'end_date'   => $date_ranges[1]['endDate'],
+			);
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Fetch real-time analytics data.
+	 *
+	 * @param string $access_token OAuth2 access token.
+	 * @param string $property_id  GA4 property ID.
+	 * @return array
+	 */
+	private static function fetchRealtime( string $access_token, string $property_id ): array {
+		$request_body = array(
+			'dimensions' => array(
+				array( 'name' => 'unifiedScreenName' ),
+			),
+			'metrics'    => array(
+				array( 'name' => 'activeUsers' ),
+				array( 'name' => 'screenPageViews' ),
+			),
+			'limit'      => 25,
+		);
+
+		$api_url = self::API_BASE . $property_id . ':runRealtimeReport';
+
+		$result = HttpClient::post(
+			$api_url,
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Content-Type'  => 'application/json',
+				),
+				'body'    => wp_json_encode( $request_body ),
+				'context' => 'Google Analytics Realtime API',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to connect to Google Analytics Realtime API: ' . ( $result['error'] ?? 'Unknown error' ),
+			);
+		}
+
+		$data = json_decode( $result['data'], true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to parse Google Analytics Realtime response.',
+			);
+		}
+
+		if ( ! empty( $data['error'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'GA4 Realtime API error: ' . ( $data['error']['message'] ?? 'Unknown' ),
+			);
+		}
+
+		$dimension_headers = wp_list_pluck( $data['dimensionHeaders'] ?? array(), 'name' );
+		$metric_headers    = wp_list_pluck( $data['metricHeaders'] ?? array(), 'name' );
+
+		$total_active_users = 0;
+		$total_page_views   = 0;
+		$pages              = array();
+
+		foreach ( ( $data['rows'] ?? array() ) as $row ) {
+			$dim_values    = wp_list_pluck( $row['dimensionValues'] ?? array(), 'value' );
+			$metric_values = wp_list_pluck( $row['metricValues'] ?? array(), 'value' );
+
+			$page_data = array();
+			foreach ( $dimension_headers as $i => $name ) {
+				$page_data[ $name ] = $dim_values[ $i ] ?? '';
+			}
+			foreach ( $metric_headers as $i => $name ) {
+				$page_data[ $name ] = (int) ( $metric_values[ $i ] ?? 0 );
+			}
+
+			$total_active_users += $page_data['activeUsers'] ?? 0;
+			$total_page_views   += $page_data['screenPageViews'] ?? 0;
+
+			$pages[] = $page_data;
+		}
+
+		return array(
+			'success'            => true,
+			'action'             => 'realtime',
+			'total_active_users' => $total_active_users,
+			'total_page_views'   => $total_page_views,
+			'results_count'      => count( $pages ),
+			'results'            => $pages,
+		);
+	}
+
+	/**
+	 * Format GA4 report rows into a flat, readable structure.
+	 *
+	 * @param array $data          Raw GA4 API response.
+	 * @param array $report_config Report configuration with dimension/metric names.
+	 * @return array Formatted rows.
+	 */
+	private static function formatReportRows( array $data): array {
+		$dimension_headers = wp_list_pluck( $data['dimensionHeaders'] ?? array(), 'name' );
+		$metric_headers    = wp_list_pluck( $data['metricHeaders'] ?? array(), 'name' );
+
+		$rows = array();
+
+		foreach ( ( $data['rows'] ?? array() ) as $row ) {
+			$dim_values    = wp_list_pluck( $row['dimensionValues'] ?? array(), 'value' );
+			$metric_values = wp_list_pluck( $row['metricValues'] ?? array(), 'value' );
+
+			$formatted = array();
+			foreach ( $dimension_headers as $i => $name ) {
+				$formatted[ $name ] = $dim_values[ $i ] ?? '';
+			}
+			foreach ( $metric_headers as $i => $name ) {
+				$value = $metric_values[ $i ] ?? '0';
+				// Cast numeric strings to appropriate types.
+				if ( is_numeric( $value ) ) {
+					$formatted[ $name ] = strpos( $value, '.' ) !== false ? (float) $value : (int) $value;
+				} else {
+					$formatted[ $name ] = $value;
+				}
+			}
+
+			$rows[] = $formatted;
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Format GA4 comparison rows with delta columns.
+	 *
+	 * When two date ranges are used, the API returns rows with metricValues
+	 * containing values for each date range. This interleaves current and
+	 * previous values, then computes percentage deltas.
+	 *
+	 * @param array $data          Raw GA4 API response.
+	 * @param array $report_config Report configuration.
+	 * @return array Formatted rows with delta columns.
+	 */
+	private static function formatComparisonRows( array $data): array {
+		$dimension_headers = wp_list_pluck( $data['dimensionHeaders'] ?? array(), 'name' );
+		$metric_headers    = wp_list_pluck( $data['metricHeaders'] ?? array(), 'name' );
+		$metric_count      = count( $metric_headers );
+
+		$rows = array();
+
+		foreach ( ( $data['rows'] ?? array() ) as $row ) {
+			$dim_values    = wp_list_pluck( $row['dimensionValues'] ?? array(), 'value' );
+			$metric_values = wp_list_pluck( $row['metricValues'] ?? array(), 'value' );
+
+			$formatted = array();
+			foreach ( $dimension_headers as $i => $name ) {
+				// Skip the dateRange dimension GA4 adds for multi-range requests.
+				if ( 'dateRange' === $name ) {
+					continue;
+				}
+				$formatted[ $name ] = $dim_values[ $i ] ?? '';
+			}
+
+			// GA4 returns metric values as [current_m1, current_m2, ..., previous_m1, previous_m2, ...].
+			for ( $i = 0; $i < $metric_count; $i++ ) {
+				$name     = $metric_headers[ $i ];
+				$current  = $metric_values[ $i ] ?? '0';
+				$previous = $metric_values[ $i + $metric_count ] ?? '0';
+
+				$current_num  = is_numeric( $current ) ? (float) $current : 0;
+				$previous_num = is_numeric( $previous ) ? (float) $previous : 0;
+
+				// Format current value.
+				if ( is_numeric( $current ) ) {
+					$formatted[ $name ] = strpos( $current, '.' ) !== false ? (float) $current : (int) $current;
+				} else {
+					$formatted[ $name ] = $current;
+				}
+
+				// Compute delta percentage.
+				if ( 0.0 !== $previous_num ) {
+					$delta                            = ( ( $current_num - $previous_num ) / $previous_num ) * 100;
+					$sign                             = $delta >= 0 ? '+' : '';
+					$formatted[ "\xCE\x94 " . $name ] = $sign . round( $delta, 1 ) . '%';
+				} else {
+					$formatted[ "\xCE\x94 " . $name ] = $current_num > 0 ? 'new' : '-';
+				}
+			}
+
+			$rows[] = $formatted;
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Get an OAuth2 access token using service account JWT flow.
+	 *
+	 * @param array $service_account Parsed service account JSON.
+	 * @return string|\WP_Error Access token or error.
+	 */
+	private static function get_access_token( array $service_account ) {
+		$cached = get_transient( self::TOKEN_TRANSIENT );
+
+		if ( ! empty( $cached ) ) {
+			return $cached;
+		}
+
+		$header = self::base64url_encode( wp_json_encode( array(
+			'alg' => 'RS256',
+			'typ' => 'JWT',
+		) ) );
+		$now    = time();
+		$claims = self::base64url_encode( wp_json_encode( array(
+			'iss'   => $service_account['client_email'],
+			'scope' => 'https://www.googleapis.com/auth/analytics.readonly',
+			'aud'   => 'https://oauth2.googleapis.com/token',
+			'iat'   => $now,
+			'exp'   => $now + 3600,
+		) ) );
+
+		$unsigned = $header . '.' . $claims;
+
+		$sign_result = openssl_sign( $unsigned, $signature, $service_account['private_key'], 'SHA256' );
+
+		if ( ! $sign_result ) {
+			return new \WP_Error( 'ga_jwt_sign_failed', 'Failed to sign JWT. Check private key in service account JSON.' );
+		}
+
+		$jwt = $unsigned . '.' . self::base64url_encode( $signature );
+
+		$response = wp_remote_post(
+			'https://oauth2.googleapis.com/token',
+			array(
+				'timeout' => 15,
+				'body'    => array(
+					'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+					'assertion'  => $jwt,
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( empty( $body['access_token'] ) ) {
+			$error_desc = $body['error_description'] ?? ( $body['error'] ?? 'Unknown token error' );
+			return new \WP_Error( 'ga_token_failed', 'Failed to get access token: ' . $error_desc );
+		}
+
+		set_transient( self::TOKEN_TRANSIENT, $body['access_token'], 3500 );
+
+		return $body['access_token'];
+	}
+
+	/**
+	 * Base64url encode (RFC 7515).
+	 *
+	 * @param string $data Data to encode.
+	 * @return string Base64url encoded string.
+	 */
+	private static function base64url_encode( string $data ): string {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions -- Required for API authentication, not obfuscation.
+		return rtrim( strtr( base64_encode( $data ), '+/', '-_' ), '=' );
+	}
+
+	/**
+	 * Check if Google Analytics is configured.
+	 *
+	 * @return bool
+	 */
+	public static function is_configured(): bool {
+		$config = self::get_config();
+		return ! empty( $config['service_account_json'] ) && ! empty( $config['property_id'] );
+	}
+
+	/**
+	 * Get stored configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_config(): array {
+		return get_site_option( self::CONFIG_OPTION, array() );
+	}
+}

--- a/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
+++ b/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Google Analytics — AI agent wrapper for the google-analytics ability.
+ *
+ * Provides the AI-callable tool interface and settings page configuration.
+ * Delegates actual data fetching to the datamachine/google-analytics ability.
+ *
+ * @package DataMachineBusiness\Engine\AI\Tools\Global
+ * @since 0.31.0
+ */
+
+namespace DataMachineBusiness\Engine\AI\Tools\Global;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachineBusiness\Abilities\Analytics\GoogleAnalyticsAbilities;
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+class GoogleAnalytics extends BaseTool {
+
+	public function __construct() {
+		$this->registerConfigurationHandlers( 'google_analytics' );
+		$this->registerTool( 'google_analytics', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'ability' => 'datamachine/google-analytics' ) );
+	}
+
+	/**
+	 * Execute Google Analytics query by delegating to the ability.
+	 *
+	 * @param array $parameters Contains 'action' and optional parameters.
+	 * @param array $tool_def   Tool definition (unused).
+	 * @return array Result from the ability.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$ability = wp_get_ability( 'datamachine/google-analytics' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'Google Analytics ability not registered. Ensure WordPress 6.9+ and GoogleAnalyticsAbilities is loaded.',
+				'google_analytics'
+			);
+		}
+
+		$result = $ability->execute( $parameters );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse(
+				$result->get_error_message(),
+				'google_analytics'
+			);
+		}
+
+		if ( ! empty( $result['error'] ) ) {
+			return $this->buildErrorResponse(
+				$result['error'],
+				'google_analytics'
+			);
+		}
+
+		$result['tool_name'] = 'google_analytics';
+		return $result;
+	}
+
+	/**
+	 * Get tool definition for AI agents.
+	 *
+	 * @return array Tool definition array.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'           => __CLASS__,
+			'method'          => 'handle_tool_call',
+			'description'     => 'Fetch visitor analytics from Google Analytics (GA4). Get page performance metrics, traffic sources, daily trends, real-time active users, top events, user demographics, landing pages, engagement metrics, and new-vs-returning user breakdown. Supports sorting, hostname filtering for multisite, and period-over-period comparison.',
+			'requires_config' => true,
+			'parameters'      => array(
+				'type'       => 'object',
+				'properties' => array(
+					'action'      => array(
+					'type'        => 'string',
+					'description' => 'Action to perform: page_stats (per-page views, sessions, bounce rate), traffic_sources (where visitors come from), date_stats (daily trends over time), realtime (active users right now), top_events (most triggered events), user_demographics (visitor country and device breakdown), landing_pages (entry pages with session metrics), engagement (engagement rate, session quality, pages/session), new_vs_returning (new vs returning user comparison).',
+				),
+					'property_id' => array(
+					'type'        => 'string',
+					'description' => 'GA4 property ID (numeric). Defaults to the configured property ID.',
+				),
+					'start_date'  => array(
+					'type'        => 'string',
+					'description' => 'Start date in YYYY-MM-DD format (defaults to 28 days ago). Not used for realtime action.',
+				),
+					'end_date'    => array(
+					'type'        => 'string',
+					'description' => 'End date in YYYY-MM-DD format (defaults to yesterday). Not used for realtime action.',
+				),
+					'limit'       => array(
+					'type'        => 'integer',
+					'description' => 'Row limit (default: 25, max: 10000).',
+				),
+					'page_filter' => array(
+					'type'        => 'string',
+					'description' => 'Filter results to pages with paths containing this string.',
+				),
+					'hostname'    => array(
+					'type'        => 'string',
+					'description' => 'Filter to pages on this hostname (for multisite GA4 properties).',
+				),
+					'sort_by'     => array(
+					'type'        => 'string',
+					'description' => 'Sort results by this metric or dimension field name (e.g. bounceRate, sessions, engagementRate).',
+				),
+					'order'       => array(
+					'type'        => 'string',
+					'description' => 'Sort direction: asc or desc (default: desc).',
+				),
+					'compare'     => array(
+					'type'        => 'boolean',
+					'description' => 'Compare against the previous period of equal length. Adds delta percentage columns.',
+				),
+				),
+				'required'   => array( 'action' ),
+			),
+		);
+	}
+
+	/**
+	 * Check if Google Analytics is configured.
+	 *
+	 * @return bool
+	 */
+	public static function is_configured(): bool {
+		return GoogleAnalyticsAbilities::is_configured();
+	}
+
+	/**
+	 * Get stored configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_config(): array {
+		return GoogleAnalyticsAbilities::get_config();
+	}
+
+	/**
+	 * Check if this tool is configured.
+	 *
+	 * @param bool   $configured Current status.
+	 * @param string $tool_id    Tool identifier.
+	 * @return bool
+	 */
+	public function check_configuration( $configured, $tool_id ) {
+		if ( 'google_analytics' !== $tool_id ) {
+			return $configured;
+		}
+
+		return self::is_configured();
+	}
+
+	/**
+	 * Get current configuration.
+	 *
+	 * @param array  $config  Current config.
+	 * @param string $tool_id Tool identifier.
+	 * @return array
+	 */
+	public function get_configuration( $config, $tool_id ) {
+		if ( 'google_analytics' !== $tool_id ) {
+			return $config;
+		}
+
+		return self::get_config();
+	}
+
+	/**
+	 * Save configuration from settings page.
+	 *
+	 * @param string $tool_id     Tool identifier.
+	 * @param array  $config_data Configuration data.
+	 */
+	protected function get_config_option_name(): string {
+		return GoogleAnalyticsAbilities::CONFIG_OPTION;
+	}
+
+	protected function validate_and_build_config( array $config_data ): array {
+		$service_account_json = $config_data['service_account_json'] ?? '';
+		$property_id          = sanitize_text_field( $config_data['property_id'] ?? '' );
+
+		if ( empty( $service_account_json ) ) {
+			return array( 'error' => __( 'Service Account JSON is required', 'data-machine-business' ) );
+		}
+
+		if ( empty( $property_id ) ) {
+			return array( 'error' => __( 'GA4 Property ID is required', 'data-machine-business' ) );
+		}
+
+		$parsed = json_decode( $service_account_json, true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array( 'error' => __( 'Invalid JSON in Service Account field', 'data-machine-business' ) );
+		}
+
+		if ( empty( $parsed['client_email'] ) || empty( $parsed['private_key'] ) ) {
+			return array( 'error' => __( 'Service Account JSON must contain client_email and private_key', 'data-machine-business' ) );
+		}
+
+		return array(
+			'config'  => array(
+				'service_account_json' => $service_account_json,
+				'property_id'          => $property_id,
+			),
+			'message' => __( 'Google Analytics configuration saved successfully', 'data-machine-business' ),
+		);
+	}
+
+	protected function before_config_save( array $config_data ): void {
+		delete_transient( GoogleAnalyticsAbilities::TOKEN_TRANSIENT );
+	}
+
+	/**
+	 * Get configuration field definitions for the settings page.
+	 *
+	 * @param array  $fields  Current fields.
+	 * @param string $tool_id Tool identifier.
+	 * @return array
+	 */
+	public function get_config_fields( $fields = array(), $tool_id = '' ) {
+		if ( ! empty( $tool_id ) && 'google_analytics' !== $tool_id ) {
+			return $fields;
+		}
+
+		return array(
+			'service_account_json' => array(
+				'type'        => 'textarea',
+				'label'       => __( 'Service Account JSON', 'data-machine-business' ),
+				'placeholder' => __( 'Paste your Google service account JSON key...', 'data-machine-business' ),
+				'required'    => true,
+				'description' => __( 'The full JSON key file contents for a service account with Google Analytics Data API access. Can be the same service account used for Search Console.', 'data-machine-business' ),
+			),
+			'property_id'          => array(
+				'type'        => 'text',
+				'label'       => __( 'GA4 Property ID', 'data-machine-business' ),
+				'placeholder' => '123456789',
+				'required'    => true,
+				'description' => __( 'Numeric GA4 property ID. Found in Google Analytics Admin > Property Settings.', 'data-machine-business' ),
+			),
+		);
+	}
+}

--- a/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Unit tests for GoogleAnalyticsAbilities request body construction.
+ *
+ * Covers the bug where --page-filter (page_filter input) was silently dropped
+ * for any GA4 action whose dimensions did not include pagePath/landingPage —
+ * meaning date_stats, traffic_sources, top_events, user_demographics, and
+ * new_vs_returning all returned site-wide data even when the caller asked for
+ * a specific page. Fix is to always emit a pagePath CONTAINS dimensionFilter
+ * when page_filter is provided.
+ *
+ * @package DataMachine\Tests\Unit\Abilities\Analytics
+ */
+
+namespace DataMachine\Tests\Unit\Abilities\Analytics;
+
+use DataMachineBusiness\Abilities\Analytics\GoogleAnalyticsAbilities;
+use WP_UnitTestCase;
+
+class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * page_filter must produce a dimensionFilter for every action, including
+	 * actions whose dimensions don't include pagePath/landingPage.
+	 *
+	 * @dataProvider all_filterable_actions
+	 */
+	public function test_page_filter_applied_to_all_actions( string $action ): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '/the-history-of-extra-chill',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			$action
+		);
+
+		$this->assertArrayHasKey(
+			'dimensionFilter',
+			$body,
+			"Action '{$action}' must apply page_filter as a dimensionFilter"
+		);
+
+		$filter = $body['dimensionFilter']['filter'] ?? null;
+		$this->assertNotNull(
+			$filter,
+			"Action '{$action}' must produce a single (not nested) filter when only page_filter is set"
+		);
+		$this->assertSame( 'CONTAINS', $filter['stringFilter']['matchType'] );
+		$this->assertSame( '/the-history-of-extra-chill', $filter['stringFilter']['value'] );
+	}
+
+	/**
+	 * Actions that group by pagePath (page_stats, engagement) filter on pagePath.
+	 *
+	 * @dataProvider page_path_grouped_actions
+	 */
+	public function test_page_filter_uses_pagepath_when_grouped_by_pagepath( string $action ): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '/about/',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			$action
+		);
+
+		$this->assertSame( 'pagePath', $body['dimensionFilter']['filter']['fieldName'] );
+	}
+
+	/**
+	 * landing_pages action filters on landingPage so the filter matches the
+	 * dimension actually being returned in the response.
+	 */
+	public function test_page_filter_uses_landingpage_for_landing_pages_action(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '/about/',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			'landing_pages'
+		);
+
+		$this->assertSame( 'landingPage', $body['dimensionFilter']['filter']['fieldName'] );
+	}
+
+	/**
+	 * Actions without pagePath/landingPage in their dimensions still filter on
+	 * pagePath (the regression case). GA4 supports pagePath as a filter-only
+	 * dimension, so the request scopes to hits matching that path.
+	 *
+	 * @dataProvider non_page_grouped_actions
+	 */
+	public function test_page_filter_uses_pagepath_for_non_page_grouped_actions( string $action ): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '/about/',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			$action
+		);
+
+		$this->assertArrayHasKey(
+			'dimensionFilter',
+			$body,
+			"Regression: action '{$action}' previously dropped page_filter silently"
+		);
+		$this->assertSame( 'pagePath', $body['dimensionFilter']['filter']['fieldName'] );
+	}
+
+	/**
+	 * Without page_filter, no dimensionFilter is emitted at all.
+	 */
+	public function test_no_filter_when_page_filter_absent(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'start_date' => '2026-01-01',
+				'end_date'   => '2026-01-31',
+			),
+			'date_stats'
+		);
+
+		$this->assertArrayNotHasKey( 'dimensionFilter', $body );
+	}
+
+	/**
+	 * page_filter + hostname combine into an andGroup with both filters.
+	 */
+	public function test_page_filter_and_hostname_combine_into_and_group(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '/about/',
+				'hostname'    => 'extrachill.com',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			'date_stats'
+		);
+
+		$this->assertArrayHasKey( 'andGroup', $body['dimensionFilter'] );
+		$expressions = $body['dimensionFilter']['andGroup']['expressions'];
+		$this->assertCount( 2, $expressions );
+
+		$field_names = array_map(
+			static fn( $e ) => $e['filter']['fieldName'],
+			$expressions
+		);
+		$this->assertContains( 'pagePath', $field_names );
+		$this->assertContains( 'hostName', $field_names );
+	}
+
+	/**
+	 * Empty page_filter string should not produce a dimensionFilter (empty()
+	 * check semantics).
+	 */
+	public function test_empty_page_filter_does_not_emit_filter(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			'date_stats'
+		);
+
+		$this->assertArrayNotHasKey( 'dimensionFilter', $body );
+	}
+
+	public static function all_filterable_actions(): array {
+		return array(
+			'page_stats'        => array( 'page_stats' ),
+			'traffic_sources'   => array( 'traffic_sources' ),
+			'date_stats'        => array( 'date_stats' ),
+			'top_events'        => array( 'top_events' ),
+			'user_demographics' => array( 'user_demographics' ),
+			'landing_pages'     => array( 'landing_pages' ),
+			'engagement'        => array( 'engagement' ),
+			'new_vs_returning'  => array( 'new_vs_returning' ),
+		);
+	}
+
+	public static function page_path_grouped_actions(): array {
+		return array(
+			'page_stats' => array( 'page_stats' ),
+			'engagement' => array( 'engagement' ),
+		);
+	}
+
+	public static function non_page_grouped_actions(): array {
+		return array(
+			'date_stats'        => array( 'date_stats' ),
+			'traffic_sources'   => array( 'traffic_sources' ),
+			'top_events'        => array( 'top_events' ),
+			'user_demographics' => array( 'user_demographics' ),
+			'new_vs_returning'  => array( 'new_vs_returning' ),
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Registers the Google Analytics / GA4 ability and `google_analytics` AI tool from Data Machine Business.
- Preserves existing GA4 config adoption by keeping `datamachine_ga_config` and `datamachine_ga_access_token`.
- Adds GA4 docs and moves the existing request-body regression coverage into this repo.

## Dependency
- Companion core PR: Extra-Chill/data-machine#2148 removes Data Machine's built-in GA4 registration while keeping compatible CLI/REST dispatch routes.
- Tracks Extra-Chill/data-machine#2140.

## Verification
- `php -l data-machine-business.php && php -l inc/Abilities/Analytics/GoogleAnalyticsAbilities.php && php -l inc/Engine/AI/Tools/Global/GoogleAnalytics.php && php -l tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php`
- `/Users/chubes/Developer/data-machine@fix-extract-ga4-business/vendor/bin/phpcs data-machine-business.php inc/Abilities/Analytics/GoogleAnalyticsAbilities.php inc/Engine/AI/Tools/Global/GoogleAnalytics.php tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php`
- `homeboy test --path /Users/chubes/Developer/data-machine-business@fix-extract-ga4-business --extension wordpress --filter GoogleAnalyticsAbilitiesTest --force-hot` (19 passed, 0 skipped)

## Lint
- `homeboy lint --path /Users/chubes/Developer/data-machine-business@fix-extract-ga4-business --extension wordpress --force-hot` still reports existing unrelated findings in pre-existing Slack/Discord/Google Sheets files. Changed GA4 PHP files pass PHPCS directly.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Moving the GA4 ability/tool implementation from Data Machine core into Data Machine Business, updating docs/tests, and running verification. Chris remains responsible for review and merge decisions.