### PR TITLE
feat: add search console integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This plugin extends Data Machine with business-focused integrations including:
 - **Google Search**: Search the web through Google Custom Search API as an AI tool
 - **Google Sheets**: Fetch data from spreadsheets and append data for reporting
 - **Google Analytics (GA4)**: Fetch visitor analytics, realtime, engagement, and comparison metrics
+- **Google Search Console**: Read search analytics, inspect URLs, and manage sitemaps
 - **Slack**: Post messages and fetch conversations from channels
 - **Discord**: Post messages and fetch messages from server channels
 - **Amazon Affiliate Link**: Search Amazon products and return affiliate links using the Amazon Creators API
@@ -70,6 +71,25 @@ Supported actions include `page_stats`, `traffic_sources`, `date_stats`, `realti
 5. Add your site's URL as authorized redirect URI
 6. Copy Client ID and Client Secret to Data Machine settings
 7. Authenticate the handler
+
+## Google Search Console Setup
+
+Google Search Console uses a Google service account, not the shared Google OAuth user credential.
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create or select a project with the Search Console APIs enabled
+3. Create a service account and JSON key
+4. Add the service account email as a user on the Search Console property
+5. Configure the `google_search_console` tool in Data Machine settings with the JSON key and property URL
+
+Existing Data Machine core installations keep using the same `datamachine_gsc_config` option, so activating Data Machine Business adopts previously saved Search Console configuration automatically.
+
+### Google Search Console Usage
+
+- AI tool: `google_search_console`
+- Ability: `datamachine/google-search-console`
+- REST: `POST /wp-json/datamachine/v1/analytics/gsc`
+- WP-CLI: `wp datamachine analytics gsc query_stats`
 
 ## Usage
 

--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -75,6 +75,7 @@ function datamachine_business_load_handlers() {
 	// Google Sheets
 	new \DataMachineBusiness\Abilities\GoogleSheets\FetchGoogleSheetsAbility();
 	new \DataMachineBusiness\Abilities\GoogleSheets\PublishGoogleSheetsAbility();
+	new \DataMachineBusiness\Abilities\Analytics\GoogleSearchConsoleAbilities();
 
 	// Google Sheets Handlers
 	new \DataMachineBusiness\Handlers\GoogleSheets\GoogleSheetsFetch();
@@ -86,6 +87,15 @@ function datamachine_business_load_handlers() {
 
 	// Google Custom Search API tool.
 	new \DataMachineBusiness\Tools\GoogleSearch();
+
+	// Google Search Console global tool. Uses the legacy core option key so
+	// existing service-account configuration is adopted without migration.
+	new \DataMachineBusiness\Tools\GoogleSearchConsole();
+	\DataMachineBusiness\Api\GoogleSearchConsoleAnalytics::register();
+
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		\WP_CLI::add_command( 'datamachine analytics gsc', \DataMachineBusiness\Cli\GoogleSearchConsoleCommand::class );
+	}
 
 	// Slack
 	new \DataMachineBusiness\Abilities\Slack\PostMessageSlackAbility();

--- a/docs/ai-tools/google-search-console.md
+++ b/docs/ai-tools/google-search-console.md
@@ -1,0 +1,246 @@
+# Google Search Console Tool
+
+**Tool ID**: `google_search_console`
+
+**Ability**: `datamachine/google-search-console`
+
+**File Locations**:
+- Tool: `inc/Tools/GoogleSearchConsole.php`
+- Ability: `inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php`
+- REST route: `inc/Api/GoogleSearchConsoleAnalytics.php`
+- WP-CLI command: `inc/Cli/GoogleSearchConsoleCommand.php`
+
+**Registration**: Data Machine Business registers the tool with the core `datamachine_tools` filter (available to all AI agents — pipeline + chat)
+
+**@since**: 0.25.0
+
+Fetches search analytics data from Google Search Console. Provides search query performance, page-level stats, URL inspection, and sitemap management.
+
+## Architecture
+
+Two-layer pattern shared by all analytics tools:
+
+1. **Ability** (`GoogleSearchConsoleAbilities`) — business logic, API calls, JWT authentication. Registered as a WordPress ability (`datamachine/google-search-console`).
+2. **Tool** (`GoogleSearchConsole`) — AI agent wrapper, settings UI, configuration management. Delegates execution to the ability via `wp_get_ability()`.
+
+All access layers (AI tool, CLI, REST) route through the ability. The option key remains `datamachine_gsc_config`, so existing Data Machine core Search Console settings are adopted automatically after activating Data Machine Business.
+
+## Configuration
+
+### Required Setup
+
+**Service Account JSON**
+- Purpose: Authenticates via JWT to Google APIs (RS256 signed)
+- Source: Google Cloud Console → IAM & Admin → Service Accounts → Keys
+- Format: Full JSON key file contents
+- Required fields: `client_email`, `private_key`
+- Scope: `https://www.googleapis.com/auth/webmasters`
+- The service account email must be added as a user in GSC property settings
+
+**Site URL**
+- Purpose: Identifies the Search Console property to query
+- Format: `sc-domain:example.com` (domain property) or `https://example.com/` (URL prefix)
+
+### Configuration Storage
+
+**Option Key**: `datamachine_gsc_config`
+
+**Structure**:
+```php
+[
+    'service_account_json' => '{"client_email":"...","private_key":"..."}',
+    'site_url'             => 'sc-domain:chubes.net',
+]
+```
+
+### Authentication Flow
+
+1. Build RS256 JWT with `client_email` as issuer and `webmasters` scope
+2. Exchange JWT for OAuth2 access token at `https://oauth2.googleapis.com/token`
+3. Cache access token in transient (`datamachine_gsc_access_token`) for ~58 minutes
+4. Include Bearer token in all API requests
+
+## Tool Parameters
+
+### Required
+
+**action** (string)
+
+Search Analytics actions:
+- `query_stats` — Top search queries with clicks, impressions, CTR, position
+- `page_stats` — Per-page search performance
+- `query_page_stats` — Combined query + page breakdown
+- `date_stats` — Daily search performance trends
+
+URL & Sitemap actions:
+- `inspect_url` — Check indexing status of a specific URL (requires `url` parameter)
+- `list_sitemaps` — List all submitted sitemaps
+- `get_sitemap` — Get details for a specific sitemap (requires `sitemap_url` parameter)
+- `submit_sitemap` — Submit a sitemap to Google (requires `sitemap_url` parameter)
+
+### Optional
+
+**site_url** (string)
+- Override the configured site URL
+- Default: Value from `datamachine_gsc_config`
+
+**start_date** (string)
+- Format: `YYYY-MM-DD`
+- Default: 28 days ago
+
+**end_date** (string)
+- Format: `YYYY-MM-DD`
+- Default: 3 days ago (for finalized data)
+
+**limit** (integer)
+- Default: 25
+- Maximum: 25,000
+
+**url_filter** (string)
+- Filter results to URLs containing this string
+
+**query_filter** (string)
+- Filter results to queries containing this string
+
+**url** (string)
+- Required for `inspect_url` action — the full URL to inspect
+
+**sitemap_url** (string)
+- Required for `get_sitemap` and `submit_sitemap` actions
+
+## API Integration
+
+### Search Analytics API
+
+**Endpoint**: `POST https://www.googleapis.com/webmasters/v3/sites/{site_url}/searchAnalytics/query`
+
+**Action-to-Dimensions Mapping**:
+
+| Action | Dimensions |
+|--------|-----------|
+| `query_stats` | `query` |
+| `page_stats` | `page` |
+| `query_page_stats` | `query`, `page` |
+| `date_stats` | `date` |
+
+All search analytics responses include: `clicks`, `impressions`, `ctr`, `position` per row, plus dimension keys.
+
+### URL Inspection API
+
+**Endpoint**: `POST https://searchconsole.googleapis.com/v1/urlInspection/index:inspect`
+
+Returns indexing status, mobile usability, and rich results information for a specific URL.
+
+### Sitemaps API
+
+**List**: `GET https://www.googleapis.com/webmasters/v3/sites/{site_url}/sitemaps`
+**Get**: `GET https://www.googleapis.com/webmasters/v3/sites/{site_url}/sitemaps/{sitemap_url}`
+**Submit**: `PUT https://www.googleapis.com/webmasters/v3/sites/{site_url}/sitemaps/{sitemap_url}`
+
+### Response Format
+
+**Search analytics**:
+```php
+[
+    'success'       => true,
+    'action'        => 'query_stats',
+    'results_count' => 25,
+    'results'       => [
+        [
+            'keys'        => ['wordpress analytics'],
+            'clicks'      => 45,
+            'impressions' => 1200,
+            'ctr'         => 0.0375,
+            'position'    => 8.2,
+        ],
+    ],
+]
+```
+
+**URL inspection**:
+```php
+[
+    'success'          => true,
+    'action'           => 'inspect_url',
+    'url'              => 'https://chubes.net/about/',
+    'index_status'     => [
+        'verdict'          => 'PASS',
+        'coverage_state'   => 'Submitted and indexed',
+        'indexing_state'   => 'INDEXING_ALLOWED',
+        'last_crawl_time'  => '2026-02-20T10:30:00Z',
+        'page_fetch_state' => 'SUCCESSFUL',
+        'google_canonical' => 'https://chubes.net/about/',
+        'user_canonical'   => 'https://chubes.net/about/',
+        'crawled_as'       => 'DESKTOP',
+        'robots_txt_state' => 'ALLOWED',
+        'referring_urls'   => [],
+        'sitemap'          => [],
+    ],
+    'mobile_usability' => ['verdict' => 'PASS', 'issues' => []],
+    'rich_results'     => ['verdict' => 'PASS', 'detected_items' => []],
+]
+```
+
+## CLI Usage
+
+```bash
+# Top search queries
+wp datamachine analytics gsc query_stats --allow-root
+
+# Page stats with URL filter
+wp datamachine analytics gsc page_stats --url-filter=/blog/ --limit=50 --allow-root
+
+# Daily trends as JSON
+wp datamachine analytics gsc date_stats --format=json --allow-root
+
+# Inspect a URL
+wp datamachine analytics gsc inspect_url --url=https://chubes.net/about/ --allow-root
+
+# List sitemaps
+wp datamachine analytics gsc list_sitemaps --allow-root
+
+# Submit a sitemap
+wp datamachine analytics gsc submit_sitemap --sitemap-url=https://chubes.net/sitemap.xml --allow-root
+```
+
+**Flags**: `--start-date`, `--end-date`, `--limit`, `--url-filter`, `--query-filter`, `--url`, `--sitemap-url`, `--format` (table|json|csv)
+
+## REST API
+
+```
+POST /wp-json/datamachine/v1/analytics/gsc
+```
+
+**Authentication**: Requires `manage_options` capability.
+
+**Request Body**:
+```json
+{
+    "action": "query_stats",
+    "start_date": "2026-01-01",
+    "end_date": "2026-02-24",
+    "limit": 50,
+    "query_filter": "wordpress"
+}
+```
+
+## Error Handling
+
+**Configuration Errors**:
+- Missing service account JSON → `"Google Search Console not configured. Add service account JSON in Settings."`
+- Invalid JSON → `"Invalid service account JSON. Ensure it contains client_email and private_key."`
+- Missing site URL → `"No site URL configured or provided."`
+
+**Authentication Errors**:
+- JWT signing failure → `"Failed to sign JWT. Check private key."`
+- Token exchange failure → `"Failed to get access token: {reason}"`
+
+**API Errors**:
+- Network failure → `"Failed to connect to Google Search Console API: {error}"`
+- GSC API error → `"GSC API error: {message}"`
+
+## Performance
+
+**Token Caching**: Access tokens cached for ~58 minutes (3500s transient)
+**Timeout**: 30 seconds per API request
+**Data Freshness**: GSC data is finalized ~3 days after collection (default end_date is 3 days ago)

--- a/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php
+++ b/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php
@@ -1,0 +1,678 @@
+<?php
+/**
+ * Google Search Console Abilities
+ *
+ * Primitive ability for Google Search Console Search Analytics API.
+ * All GSC data — tools, CLI, REST, chat — flows through this ability.
+ *
+ * @package DataMachineBusiness\Abilities\Analytics
+ * @since 0.25.0
+ */
+
+namespace DataMachineBusiness\Abilities\Analytics;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+
+defined( 'ABSPATH' ) || exit;
+
+class GoogleSearchConsoleAbilities {
+
+	/**
+	 * Option key for storing GSC configuration.
+	 *
+	 * @var string
+	 */
+	const CONFIG_OPTION = 'datamachine_gsc_config';
+
+	/**
+	 * Transient key for cached access token.
+	 *
+	 * @var string
+	 */
+	const TOKEN_TRANSIENT = 'datamachine_gsc_access_token';
+
+	/**
+	 * Action-to-dimensions mapping.
+	 *
+	 * @var array
+	 */
+	const ACTION_DIMENSIONS = array(
+		'query_stats'      => array( 'query' ),
+		'page_stats'       => array( 'page' ),
+		'query_page_stats' => array( 'query', 'page' ),
+		'date_stats'       => array( 'date' ),
+	);
+
+	/**
+	 * Default result limit.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_LIMIT = 25;
+
+	/**
+	 * Maximum result limit.
+	 *
+	 * @var int
+	 */
+	const MAX_LIMIT = 25000;
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/google-search-console',
+				array(
+					'label'               => __( 'Google Search Console', 'data-machine-business' ),
+					'description'         => __( 'Fetch search analytics data from Google Search Console API', 'data-machine-business' ),
+					'category'            => 'datamachine-analytics',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'action' ),
+						'properties' => array(
+							'action'       => array(
+								'type'        => 'string',
+								'description' => 'Action to perform: query_stats, page_stats, query_page_stats, date_stats, inspect_url, list_sitemaps, get_sitemap, submit_sitemap.',
+							),
+							'url'          => array(
+								'type'        => 'string',
+								'description' => 'Full URL to inspect (required for inspect_url action).',
+							),
+							'sitemap_url'  => array(
+								'type'        => 'string',
+								'description' => 'Sitemap URL (required for get_sitemap and submit_sitemap actions).',
+							),
+							'site_url'     => array(
+								'type'        => 'string',
+								'description' => 'Site URL (sc-domain: or https://). Defaults to configured site URL.',
+							),
+							'start_date'   => array(
+								'type'        => 'string',
+								'description' => 'Start date in YYYY-MM-DD format (defaults to 28 days ago).',
+							),
+							'end_date'     => array(
+								'type'        => 'string',
+								'description' => 'End date in YYYY-MM-DD format (defaults to 3 days ago for final data).',
+							),
+							'limit'        => array(
+								'type'        => 'integer',
+								'description' => 'Row limit (default: 25, max: 25000).',
+							),
+							'url_filter'   => array(
+								'type'        => 'string',
+								'description' => 'Filter results to URLs containing this string.',
+							),
+							'query_filter' => array(
+								'type'        => 'string',
+								'description' => 'Filter results to queries containing this string.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'       => array( 'type' => 'boolean' ),
+							'action'        => array( 'type' => 'string' ),
+							'results_count' => array( 'type' => 'integer' ),
+							'results'       => array( 'type' => 'array' ),
+							'error'         => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'fetchStats' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Fetch stats from Google Search Console API.
+	 *
+	 * @param array $input Ability input.
+	 * @return array Ability response.
+	 */
+	public static function fetchStats( array $input ): array {
+		$action = sanitize_text_field( $input['action'] ?? '' );
+
+		$valid_actions = array_merge(
+			array_keys( self::ACTION_DIMENSIONS ),
+			array( 'inspect_url', 'list_sitemaps', 'get_sitemap', 'submit_sitemap' )
+		);
+		if ( empty( $action ) || ! in_array( $action, $valid_actions, true ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Invalid action. Must be one of: ' . implode( ', ', $valid_actions ),
+			);
+		}
+
+		$config = self::get_config();
+
+		if ( empty( $config['service_account_json'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Google Search Console not configured. Add service account JSON in Settings.',
+			);
+		}
+
+		$service_account = json_decode( $config['service_account_json'], true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE || empty( $service_account['client_email'] ) || empty( $service_account['private_key'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Invalid service account JSON. Ensure it contains client_email and private_key.',
+			);
+		}
+
+		$access_token = self::get_access_token( $service_account );
+
+		if ( is_wp_error( $access_token ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to authenticate: ' . $access_token->get_error_message(),
+			);
+		}
+
+		$site_url = ! empty( $input['site_url'] ) ? sanitize_text_field( $input['site_url'] ) : ( $config['site_url'] ?? '' );
+
+		// Route to specialized handlers for non-analytics actions.
+		if ( 'inspect_url' === $action ) {
+			return self::inspectUrl( $input, $access_token, $site_url );
+		}
+		if ( 'list_sitemaps' === $action ) {
+			return self::listSitemaps( $access_token, $site_url );
+		}
+		if ( 'get_sitemap' === $action ) {
+			return self::getSitemap( $input, $access_token, $site_url );
+		}
+		if ( 'submit_sitemap' === $action ) {
+			return self::submitSitemap( $input, $access_token, $site_url );
+		}
+
+		$start_date = ! empty( $input['start_date'] ) ? sanitize_text_field( $input['start_date'] ) : gmdate( 'Y-m-d', strtotime( '-28 days' ) );
+		$end_date   = ! empty( $input['end_date'] ) ? sanitize_text_field( $input['end_date'] ) : gmdate( 'Y-m-d', strtotime( '-3 days' ) );
+		$limit      = ! empty( $input['limit'] ) ? min( (int) $input['limit'], self::MAX_LIMIT ) : self::DEFAULT_LIMIT;
+		$dimensions = self::ACTION_DIMENSIONS[ $action ];
+
+		if ( empty( $site_url ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No site URL configured or provided.',
+			);
+		}
+
+		$request_body = array(
+			'startDate'  => $start_date,
+			'endDate'    => $end_date,
+			'dimensions' => $dimensions,
+			'rowLimit'   => $limit,
+			'dataState'  => 'final',
+		);
+
+		// Build dimension filter groups if filters provided.
+		$filters = array();
+
+		if ( ! empty( $input['url_filter'] ) ) {
+			$filters[] = array(
+				'dimension'  => 'page',
+				'operator'   => 'contains',
+				'expression' => sanitize_text_field( $input['url_filter'] ),
+			);
+		}
+
+		if ( ! empty( $input['query_filter'] ) ) {
+			$filters[] = array(
+				'dimension'  => 'query',
+				'operator'   => 'contains',
+				'expression' => sanitize_text_field( $input['query_filter'] ),
+			);
+		}
+
+		if ( ! empty( $filters ) ) {
+			$request_body['dimensionFilterGroups'] = array(
+				array(
+					'groupType' => 'and',
+					'filters'   => $filters,
+				),
+			);
+		}
+
+		$encoded_site_url = rawurlencode( $site_url );
+		$api_url          = "https://www.googleapis.com/webmasters/v3/sites/{$encoded_site_url}/searchAnalytics/query";
+
+		$result = HttpClient::post(
+			$api_url,
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Content-Type'  => 'application/json',
+				),
+				'body'    => wp_json_encode( $request_body ),
+				'context' => 'Google Search Console Ability',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to connect to Google Search Console API: ' . ( $result['error'] ?? 'Unknown error' ),
+			);
+		}
+
+		$data = json_decode( $result['data'], true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to parse Google Search Console API response.',
+			);
+		}
+
+		if ( ! empty( $data['error'] ) ) {
+			$error_message = $data['error']['message'] ?? 'Unknown API error';
+			return array(
+				'success' => false,
+				'error'   => 'GSC API error: ' . $error_message,
+			);
+		}
+
+		$rows = $data['rows'] ?? array();
+
+		return array(
+			'success'       => true,
+			'action'        => $action,
+			'results_count' => count( $rows ),
+			'results'       => $rows,
+		);
+	}
+
+	/**
+	 * Inspect a URL via the URL Inspection API.
+	 *
+	 * @param array  $input        Ability input containing 'url'.
+	 * @param string $access_token OAuth2 access token.
+	 * @param string $site_url     GSC property URL.
+	 * @return array
+	 */
+	private static function inspectUrl( array $input, string $access_token, string $site_url ): array {
+		$url = sanitize_text_field( $input['url'] ?? '' );
+		if ( empty( $url ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'URL is required for inspect_url action.',
+			);
+		}
+
+		$api_url = 'https://searchconsole.googleapis.com/v1/urlInspection/index:inspect';
+
+		$result = HttpClient::post(
+			$api_url,
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Content-Type'  => 'application/json',
+				),
+				'body'    => wp_json_encode( array(
+					'inspectionUrl' => $url,
+					'siteUrl'       => $site_url,
+					'languageCode'  => 'en-US',
+				) ),
+				'context' => 'Google Search Console URL Inspection',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'URL Inspection API failed: ' . ( $result['error'] ?? 'Unknown error' ),
+			);
+		}
+
+		$data = json_decode( $result['data'], true );
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to parse URL Inspection response.',
+			);
+		}
+
+		if ( ! empty( $data['error'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'GSC API error: ' . ( $data['error']['message'] ?? 'Unknown' ),
+			);
+		}
+
+		$inspection   = $data['inspectionResult'] ?? array();
+		$index_status = $inspection['indexStatusResult'] ?? array();
+		$mobile       = $inspection['mobileUsabilityResult'] ?? array();
+		$rich_results = $inspection['richResultsResult'] ?? array();
+
+		return array(
+			'success'          => true,
+			'action'           => 'inspect_url',
+			'url'              => $url,
+			'index_status'     => array(
+				'verdict'          => $index_status['verdict'] ?? 'UNKNOWN',
+				'coverage_state'   => $index_status['coverageState'] ?? '',
+				'indexing_state'   => $index_status['indexingState'] ?? '',
+				'last_crawl_time'  => $index_status['lastCrawlTime'] ?? '',
+				'page_fetch_state' => $index_status['pageFetchState'] ?? '',
+				'google_canonical' => $index_status['googleCanonical'] ?? '',
+				'user_canonical'   => $index_status['userCanonical'] ?? '',
+				'crawled_as'       => $index_status['crawledAs'] ?? '',
+				'robots_txt_state' => $index_status['robotsTxtState'] ?? '',
+				'referring_urls'   => $index_status['referringUrls'] ?? array(),
+				'sitemap'          => $index_status['sitemap'] ?? array(),
+			),
+			'mobile_usability' => array(
+				'verdict' => $mobile['verdict'] ?? 'UNKNOWN',
+				'issues'  => $mobile['issues'] ?? array(),
+			),
+			'rich_results'     => array(
+				'verdict'        => $rich_results['verdict'] ?? 'UNKNOWN',
+				'detected_items' => $rich_results['detectedItems'] ?? array(),
+			),
+		);
+	}
+
+	/**
+	 * List all sitemaps for the configured site.
+	 *
+	 * @param string $access_token OAuth2 access token.
+	 * @param string $site_url     GSC property URL.
+	 * @return array
+	 */
+	private static function listSitemaps( string $access_token, string $site_url ): array {
+		$encoded = rawurlencode( $site_url );
+		$api_url = "https://www.googleapis.com/webmasters/v3/sites/{$encoded}/sitemaps";
+
+		$result = HttpClient::get(
+			$api_url,
+			array(
+				'timeout' => 30,
+				'headers' => array( 'Authorization' => 'Bearer ' . $access_token ),
+				'context' => 'Google Search Console Sitemaps List',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Sitemaps API failed: ' . ( $result['error'] ?? 'Unknown error' ),
+			);
+		}
+
+		$data = json_decode( $result['data'], true );
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to parse Sitemaps response.',
+			);
+		}
+
+		if ( ! empty( $data['error'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'GSC API error: ' . ( $data['error']['message'] ?? 'Unknown' ),
+			);
+		}
+
+		$sitemaps = array();
+		foreach ( ( $data['sitemap'] ?? array() ) as $sm ) {
+			$sitemaps[] = array(
+				'path'            => $sm['path'] ?? '',
+				'last_submitted'  => $sm['lastSubmitted'] ?? '',
+				'last_downloaded' => $sm['lastDownloaded'] ?? '',
+				'is_pending'      => $sm['isPending'] ?? false,
+				'warnings'        => $sm['warnings'] ?? 0,
+				'errors'          => $sm['errors'] ?? 0,
+				'contents'        => $sm['contents'] ?? array(),
+			);
+		}
+
+		return array(
+			'success'        => true,
+			'action'         => 'list_sitemaps',
+			'sitemaps_count' => count( $sitemaps ),
+			'sitemaps'       => $sitemaps,
+		);
+	}
+
+	/**
+	 * Get details for a specific sitemap.
+	 *
+	 * @param array  $input        Ability input containing 'sitemap_url'.
+	 * @param string $access_token OAuth2 access token.
+	 * @param string $site_url     GSC property URL.
+	 * @return array
+	 */
+	private static function getSitemap( array $input, string $access_token, string $site_url ): array {
+		$sitemap_url = sanitize_text_field( $input['sitemap_url'] ?? '' );
+		if ( empty( $sitemap_url ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'sitemap_url is required for get_sitemap action.',
+			);
+		}
+
+		$encoded_site    = rawurlencode( $site_url );
+		$encoded_sitemap = rawurlencode( $sitemap_url );
+		$api_url         = "https://www.googleapis.com/webmasters/v3/sites/{$encoded_site}/sitemaps/{$encoded_sitemap}";
+
+		$result = HttpClient::get(
+			$api_url,
+			array(
+				'timeout' => 30,
+				'headers' => array( 'Authorization' => 'Bearer ' . $access_token ),
+				'context' => 'Google Search Console Sitemap Detail',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Sitemap API failed: ' . ( $result['error'] ?? 'Unknown error' ),
+			);
+		}
+
+		$data = json_decode( $result['data'], true );
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to parse Sitemap response.',
+			);
+		}
+
+		if ( ! empty( $data['error'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'GSC API error: ' . ( $data['error']['message'] ?? 'Unknown' ),
+			);
+		}
+
+		return array(
+			'success'         => true,
+			'action'          => 'get_sitemap',
+			'path'            => $data['path'] ?? '',
+			'last_submitted'  => $data['lastSubmitted'] ?? '',
+			'last_downloaded' => $data['lastDownloaded'] ?? '',
+			'is_pending'      => $data['isPending'] ?? false,
+			'warnings'        => $data['warnings'] ?? 0,
+			'errors'          => $data['errors'] ?? 0,
+			'contents'        => $data['contents'] ?? array(),
+		);
+	}
+
+	/**
+	 * Submit a sitemap to Google Search Console.
+	 *
+	 * @param array  $input        Ability input containing 'sitemap_url'.
+	 * @param string $access_token OAuth2 access token.
+	 * @param string $site_url     GSC property URL.
+	 * @return array
+	 */
+	private static function submitSitemap( array $input, string $access_token, string $site_url ): array {
+		$sitemap_url = sanitize_text_field( $input['sitemap_url'] ?? '' );
+		if ( empty( $sitemap_url ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'sitemap_url is required for submit_sitemap action.',
+			);
+		}
+
+		$encoded_site    = rawurlencode( $site_url );
+		$encoded_sitemap = rawurlencode( $sitemap_url );
+		$api_url         = "https://www.googleapis.com/webmasters/v3/sites/{$encoded_site}/sitemaps/{$encoded_sitemap}";
+
+		// Submit uses PUT with empty body.
+		$response = wp_remote_request(
+			$api_url,
+			array(
+				'method'  => 'PUT',
+				'timeout' => 30,
+				'headers' => array(
+					'Authorization'  => 'Bearer ' . $access_token,
+					'Content-Type'   => 'application/json',
+					'Content-Length' => '0',
+				),
+				'body'    => '',
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Sitemap submit failed: ' . $response->get_error_message(),
+			);
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( $code >= 400 ) {
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+			return array(
+				'success' => false,
+				'error'   => 'Sitemap submit returned HTTP ' . $code . ': ' . ( $body['error']['message'] ?? '' ),
+			);
+		}
+
+		return array(
+			'success'     => true,
+			'action'      => 'submit_sitemap',
+			'sitemap_url' => $sitemap_url,
+			'message'     => 'Sitemap submitted successfully.',
+		);
+	}
+
+	/**
+	 * Get an OAuth2 access token using service account JWT flow.
+	 *
+	 * @param array $service_account Parsed service account JSON.
+	 * @return string|\WP_Error Access token or error.
+	 */
+	private static function get_access_token( array $service_account ) {
+		$cached = get_transient( self::TOKEN_TRANSIENT );
+
+		if ( ! empty( $cached ) ) {
+			return $cached;
+		}
+
+		$header = self::base64url_encode( wp_json_encode( array(
+			'alg' => 'RS256',
+			'typ' => 'JWT',
+		) ) );
+		$now    = time();
+		$claims = self::base64url_encode( wp_json_encode( array(
+			'iss'   => $service_account['client_email'],
+			'scope' => 'https://www.googleapis.com/auth/webmasters',
+			'aud'   => 'https://oauth2.googleapis.com/token',
+			'iat'   => $now,
+			'exp'   => $now + 3600,
+		) ) );
+
+		$unsigned = $header . '.' . $claims;
+
+		$sign_result = openssl_sign( $unsigned, $signature, $service_account['private_key'], 'SHA256' );
+
+		if ( ! $sign_result ) {
+			return new \WP_Error( 'gsc_jwt_sign_failed', 'Failed to sign JWT. Check private key in service account JSON.' );
+		}
+
+		$jwt = $unsigned . '.' . self::base64url_encode( $signature );
+
+		$response = wp_remote_post(
+			'https://oauth2.googleapis.com/token',
+			array(
+				'timeout' => 15,
+				'body'    => array(
+					'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+					'assertion'  => $jwt,
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( empty( $body['access_token'] ) ) {
+			$error_desc = $body['error_description'] ?? ( $body['error'] ?? 'Unknown token error' );
+			return new \WP_Error( 'gsc_token_failed', 'Failed to get access token: ' . $error_desc );
+		}
+
+		set_transient( self::TOKEN_TRANSIENT, $body['access_token'], 3500 );
+
+		return $body['access_token'];
+	}
+
+	/**
+	 * Base64url encode (RFC 7515).
+	 *
+	 * @param string $data Data to encode.
+	 * @return string Base64url encoded string.
+	 */
+	private static function base64url_encode( string $data ): string {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions -- Required for API authentication, not obfuscation.
+		return rtrim( strtr( base64_encode( $data ), '+/', '-_' ), '=' );
+	}
+
+	/**
+	 * Check if Google Search Console is configured.
+	 *
+	 * @return bool
+	 */
+	public static function is_configured(): bool {
+		$config = self::get_config();
+		return ! empty( $config['service_account_json'] );
+	}
+
+	/**
+	 * Get stored configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_config(): array {
+		return get_site_option( self::CONFIG_OPTION, array() );
+	}
+}

--- a/inc/Api/GoogleSearchConsoleAnalytics.php
+++ b/inc/Api/GoogleSearchConsoleAnalytics.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Google Search Console analytics REST endpoint.
+ *
+ * @package DataMachineBusiness\Api
+ */
+
+namespace DataMachineBusiness\Api;
+
+use DataMachine\Abilities\PermissionHelper;
+use WP_REST_Server;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GoogleSearchConsoleAnalytics {
+
+	const ABILITY = 'datamachine/google-search-console';
+
+	public static function register(): void {
+		add_action( 'rest_api_init', array( self::class, 'register_routes' ) );
+	}
+
+	public static function register_routes(): void {
+		register_rest_route(
+			'datamachine/v1',
+			'/analytics/gsc',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( self::class, 'handle_request' ),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'args'                => array(
+					'action' => array(
+						'required'    => true,
+						'type'        => 'string',
+						'description' => __( 'The Google Search Console action to perform.', 'data-machine-business' ),
+					),
+				),
+			)
+		);
+	}
+
+	public static function check_permission( $request ) {
+		$request;
+		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to access analytics data.', 'data-machine-business' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	public static function handle_request( \WP_REST_Request $request ) {
+		$ability = wp_get_ability( self::ABILITY );
+
+		if ( ! $ability ) {
+			return new \WP_Error(
+				'ability_not_found',
+				sprintf(
+					/* translators: %s: Ability slug. */
+					__( 'Analytics ability "%s" not registered. Ensure Data Machine Business is active and WordPress 6.9+ is available.', 'data-machine-business' ),
+					self::ABILITY
+				),
+				array( 'status' => 500 )
+			);
+		}
+
+		$input  = $request->get_json_params();
+		$input  = is_array( $input ) ? $input : $request->get_params();
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( empty( $result['success'] ) ) {
+			$status = self::determine_error_status( $result['error'] ?? '' );
+			return new \WP_Error(
+				'analytics_error',
+				$result['error'] ?? __( 'Analytics request failed.', 'data-machine-business' ),
+				array( 'status' => $status )
+			);
+		}
+
+		return rest_ensure_response( $result );
+	}
+
+	private static function determine_error_status( string $error ): int {
+		if ( false !== stripos( $error, 'not configured' ) || false !== stripos( $error, 'service account' ) ) {
+			return 422;
+		}
+
+		if ( false !== stripos( $error, 'invalid action' ) || false !== stripos( $error, 'required' ) ) {
+			return 400;
+		}
+
+		return 500;
+	}
+}

--- a/inc/Cli/GoogleSearchConsoleCommand.php
+++ b/inc/Cli/GoogleSearchConsoleCommand.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Google Search Console WP-CLI command.
+ *
+ * @package DataMachineBusiness\Cli
+ */
+
+namespace DataMachineBusiness\Cli;
+
+use DataMachine\Cli\BaseCommand;
+use WP_CLI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GoogleSearchConsoleCommand extends BaseCommand {
+
+	/**
+	 * Query Google Search Console analytics.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Action to perform: query_stats, page_stats, query_page_stats, date_stats, inspect_url, list_sitemaps, get_sitemap, submit_sitemap.
+	 *
+	 * [--start-date=<date>]
+	 * : Start date in YYYY-MM-DD format (default: 28 days ago).
+	 *
+	 * [--end-date=<date>]
+	 * : End date in YYYY-MM-DD format (default: 3 days ago).
+	 *
+	 * [--limit=<number>]
+	 * : Row limit (default: 25, max: 25000).
+	 *
+	 * [--url-filter=<string>]
+	 * : Filter results to URLs containing this string.
+	 *
+	 * [--query-filter=<string>]
+	 * : Filter results to queries containing this string.
+	 *
+	 * [--inspect-url=<url>]
+	 * : URL for inspect_url action (named --inspect-url to avoid WP-CLI's global --url).
+	 *
+	 * [--sitemap-url=<url>]
+	 * : Sitemap URL for get_sitemap/submit_sitemap actions.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine analytics gsc query_stats
+	 *     wp datamachine analytics gsc page_stats --url-filter=/blog/ --limit=50
+	 *     wp datamachine analytics gsc inspect_url --inspect-url=https://example.com/about/
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$input = array(
+			'action' => $args[0] ?? '',
+		);
+
+		$this->map_optional( $input, $assoc_args, array(
+			'start-date'   => 'start_date',
+			'end-date'     => 'end_date',
+			'limit'        => 'limit',
+			'url-filter'   => 'url_filter',
+			'query-filter' => 'query_filter',
+			'inspect-url'  => 'url',
+			'sitemap-url'  => 'sitemap_url',
+		) );
+
+		$this->execute_ability( 'datamachine/google-search-console', $input, $assoc_args );
+	}
+
+	private function map_optional( array &$input, array $assoc_args, array $mapping ): void {
+		foreach ( $mapping as $flag => $key ) {
+			if ( isset( $assoc_args[ $flag ] ) ) {
+				$input[ $key ] = $assoc_args[ $flag ];
+			}
+		}
+	}
+
+	private function execute_ability( string $ability_slug, array $input, array $assoc_args ): void {
+		$ability = wp_get_ability( $ability_slug );
+
+		if ( ! $ability ) {
+			WP_CLI::error( "Ability '{$ability_slug}' not registered. Ensure Data Machine Business is active and WordPress 6.9+." );
+			return;
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Unknown error.' );
+			return;
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$results = $result['results'] ?? array();
+		if ( empty( $results ) ) {
+			$display = array_filter(
+				$result,
+				function ( $value, $key ) {
+					return ! in_array( $key, array( 'success', 'tool_name' ), true ) && ! is_array( $value );
+				},
+				ARRAY_FILTER_USE_BOTH
+			);
+
+			if ( ! empty( $display ) ) {
+				$this->format_items( array( $display ), array_keys( $display ), $assoc_args );
+				return;
+			}
+
+			WP_CLI::success( 'Command completed with no tabular results. Use --format=json for full output.' );
+			return;
+		}
+
+		$flat_results = array_map( array( $this, 'flatten_row' ), $results );
+		$fields       = array_keys( $flat_results[0] );
+		$this->format_items( $flat_results, $fields, $assoc_args );
+		WP_CLI::log( sprintf( '%d results', $result['results_count'] ?? count( $results ) ) );
+	}
+
+	private function flatten_row( array $row ): array {
+		$flat = array();
+		foreach ( $row as $key => $value ) {
+			$flat[ $key ] = is_array( $value ) ? implode( ', ', array_map( 'strval', $value ) ) : $value;
+		}
+		return $flat;
+	}
+}

--- a/inc/Tools/GoogleSearchConsole.php
+++ b/inc/Tools/GoogleSearchConsole.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Google Search Console — AI agent wrapper for the google-search-console ability.
+ *
+ * Provides the AI-callable tool interface and settings page configuration.
+ * Delegates actual data fetching to the datamachine/google-search-console ability.
+ *
+ * @package DataMachineBusiness\Tools
+ */
+
+namespace DataMachineBusiness\Tools;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachineBusiness\Abilities\Analytics\GoogleSearchConsoleAbilities;
+
+class GoogleSearchConsole extends BaseTool {
+
+	public function __construct() {
+		$this->registerConfigurationHandlers( 'google_search_console' );
+		$this->registerTool( 'google_search_console', array( $this, 'getToolDefinition' ), array( 'chat', 'pipeline' ), array( 'ability' => 'datamachine/google-search-console' ) );
+	}
+
+	/**
+	 * Execute Google Search Console query by delegating to the ability.
+	 *
+	 * @param array $parameters Contains 'action' and optional parameters.
+	 * @param array $tool_def   Tool definition (unused).
+	 * @return array Result from the ability.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$ability = wp_get_ability( 'datamachine/google-search-console' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'Google Search Console ability not registered. Ensure Data Machine Business is active.',
+				'google_search_console'
+			);
+		}
+
+		$result = $ability->execute( $parameters );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse(
+				$result->get_error_message(),
+				'google_search_console'
+			);
+		}
+
+		if ( ! empty( $result['error'] ) ) {
+			return $this->buildErrorResponse(
+				$result['error'],
+				'google_search_console'
+			);
+		}
+
+		$result['tool_name'] = 'google_search_console';
+		return $result;
+	}
+
+	/**
+	 * Get tool definition for AI agents.
+	 *
+	 * @return array Tool definition array.
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'           => __CLASS__,
+			'method'          => 'handle_tool_call',
+			'description'     => 'Interact with Google Search Console. Fetch search analytics (query stats, page metrics, daily trends), inspect URLs for index status and mobile usability, and manage sitemaps (list, get details, submit).',
+			'requires_config' => true,
+			'parameters'      => array(
+				'type'       => 'object',
+				'properties' => array(
+					'action'       => array(
+					'type'        => 'string',
+					'description' => 'Action to perform: query_stats (top search queries), page_stats (per-page metrics), query_page_stats (query+page combos), date_stats (daily trends), inspect_url (check index/crawl status for a URL), list_sitemaps (list all submitted sitemaps), get_sitemap (details for one sitemap), submit_sitemap (submit a sitemap to Google).',
+				),
+					'url'          => array(
+					'type'        => 'string',
+					'description' => 'Full URL to inspect. Required for inspect_url action.',
+				),
+					'sitemap_url'  => array(
+					'type'        => 'string',
+					'description' => 'Sitemap URL. Required for get_sitemap and submit_sitemap actions.',
+				),
+					'site_url'     => array(
+					'type'        => 'string',
+					'description' => 'Site URL (sc-domain: or https://). Defaults to the configured site URL.',
+				),
+					'start_date'   => array(
+					'type'        => 'string',
+					'description' => 'Start date in YYYY-MM-DD format (defaults to 28 days ago).',
+				),
+					'end_date'     => array(
+					'type'        => 'string',
+					'description' => 'End date in YYYY-MM-DD format (defaults to 3 days ago for final data).',
+				),
+					'limit'        => array(
+					'type'        => 'integer',
+					'description' => 'Row limit (default: 25, max: 25000).',
+				),
+					'url_filter'   => array(
+					'type'        => 'string',
+					'description' => 'Filter results to URLs containing this string.',
+				),
+					'query_filter' => array(
+					'type'        => 'string',
+					'description' => 'Filter results to queries containing this string.',
+				),
+				),
+				'required'   => array( 'action' ),
+			),
+		);
+	}
+
+	/**
+	 * Check if Google Search Console is configured.
+	 *
+	 * @return bool
+	 */
+	public static function is_configured(): bool {
+		return GoogleSearchConsoleAbilities::is_configured();
+	}
+
+	/**
+	 * Get stored configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_config(): array {
+		return GoogleSearchConsoleAbilities::get_config();
+	}
+
+	/**
+	 * Check if this tool is configured.
+	 *
+	 * @param bool   $configured Current status.
+	 * @param string $tool_id    Tool identifier.
+	 * @return bool
+	 */
+	public function check_configuration( $configured, $tool_id ) {
+		if ( 'google_search_console' !== $tool_id ) {
+			return $configured;
+		}
+
+		return self::is_configured();
+	}
+
+	/**
+	 * Get current configuration.
+	 *
+	 * @param array  $config  Current config.
+	 * @param string $tool_id Tool identifier.
+	 * @return array
+	 */
+	public function get_configuration( $config, $tool_id ) {
+		if ( 'google_search_console' !== $tool_id ) {
+			return $config;
+		}
+
+		return self::get_config();
+	}
+
+	/**
+	 * Save configuration from settings page.
+	 *
+	 * @param string $tool_id     Tool identifier.
+	 * @param array  $config_data Configuration data.
+	 */
+	protected function get_config_option_name(): string {
+		return GoogleSearchConsoleAbilities::CONFIG_OPTION;
+	}
+
+	protected function validate_and_build_config( array $config_data ): array {
+		$service_account_json = $config_data['service_account_json'] ?? '';
+		$site_url             = sanitize_text_field( $config_data['site_url'] ?? '' );
+
+		if ( empty( $service_account_json ) ) {
+			return array( 'error' => __( 'Service Account JSON is required', 'data-machine-business' ) );
+		}
+
+		$parsed = json_decode( $service_account_json, true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array( 'error' => __( 'Invalid JSON in Service Account field', 'data-machine-business' ) );
+		}
+
+		if ( empty( $parsed['client_email'] ) || empty( $parsed['private_key'] ) ) {
+			return array( 'error' => __( 'Service Account JSON must contain client_email and private_key', 'data-machine-business' ) );
+		}
+
+		return array(
+			'config'  => array(
+				'service_account_json' => $service_account_json,
+				'site_url'             => $site_url,
+			),
+			'message' => __( 'Google Search Console configuration saved successfully', 'data-machine-business' ),
+		);
+	}
+
+	protected function before_config_save( array $config_data ): void {
+		delete_transient( GoogleSearchConsoleAbilities::TOKEN_TRANSIENT );
+	}
+
+	/**
+	 * Get configuration field definitions for the settings page.
+	 *
+	 * @param array  $fields  Current fields.
+	 * @param string $tool_id Tool identifier.
+	 * @return array
+	 */
+	public function get_config_fields( $fields = array(), $tool_id = '' ) {
+		if ( ! empty( $tool_id ) && 'google_search_console' !== $tool_id ) {
+			return $fields;
+		}
+
+		return array(
+			'service_account_json' => array(
+				'type'        => 'textarea',
+				'label'       => __( 'Service Account JSON', 'data-machine-business' ),
+				'placeholder' => __( 'Paste your Google service account JSON key...', 'data-machine-business' ),
+				'required'    => true,
+				'description' => __( 'The full JSON key file contents for a service account with Search Console access.', 'data-machine-business' ),
+			),
+			'site_url'             => array(
+				'type'        => 'text',
+				'label'       => __( 'Site URL', 'data-machine-business' ),
+				'placeholder' => 'sc-domain:example.com',
+				'required'    => false,
+				'description' => __( 'GSC property URL. Use sc-domain: prefix for domain properties.', 'data-machine-business' ),
+			),
+		);
+	}
+}

--- a/tests/GoogleSearchConsoleBusinessTest.php
+++ b/tests/GoogleSearchConsoleBusinessTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Google Search Console extraction tests.
+ *
+ * @package DataMachineBusiness\Tests
+ */
+
+class GoogleSearchConsoleBusinessTest extends \PHPUnit\Framework\TestCase {
+
+	private string $root;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->root = dirname( __DIR__ );
+	}
+
+	public function test_business_ships_google_search_console_surfaces(): void {
+		$this->assertFileExists( $this->root . '/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php' );
+		$this->assertFileExists( $this->root . '/inc/Tools/GoogleSearchConsole.php' );
+		$this->assertFileExists( $this->root . '/inc/Api/GoogleSearchConsoleAnalytics.php' );
+		$this->assertFileExists( $this->root . '/inc/Cli/GoogleSearchConsoleCommand.php' );
+	}
+
+	public function test_business_preserves_legacy_google_search_console_configuration(): void {
+		$this->assertStringContainsString(
+			"CONFIG_OPTION = 'datamachine_gsc_config'",
+			$this->read_file( 'inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php' )
+		);
+
+		$this->assertStringContainsString(
+			"TOKEN_TRANSIENT = 'datamachine_gsc_access_token'",
+			$this->read_file( 'inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php' )
+		);
+	}
+
+	public function test_business_registers_google_search_console_tool_api_and_cli(): void {
+		$this->assertStringContainsString(
+			"registerTool( 'google_search_console'",
+			$this->read_file( 'inc/Tools/GoogleSearchConsole.php' )
+		);
+
+		$this->assertStringContainsString(
+			"'/analytics/gsc'",
+			$this->read_file( 'inc/Api/GoogleSearchConsoleAnalytics.php' )
+		);
+
+		$this->assertStringContainsString(
+			'datamachine analytics gsc',
+			$this->read_file( 'data-machine-business.php' )
+		);
+	}
+
+	private function read_file( string $relative_path ): string {
+		$contents = file_get_contents( $this->root . '/' . $relative_path );
+		$this->assertIsString( $contents );
+		return $contents;
+	}
+}

--- a/tests/gsc-business-registration-smoke.php
+++ b/tests/gsc-business-registration-smoke.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Pure-PHP smoke test for business-owned Google Search Console surfaces (#2139).
+ *
+ * Run with: php tests/gsc-business-registration-smoke.php
+ *
+ * @package DataMachineBusiness\Tests
+ */
+
+$root     = dirname( __DIR__ );
+$failures = array();
+$passes   = 0;
+
+function assert_business_gsc( bool $condition, string $name, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		$passes++;
+		echo "  ✓ {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  ✗ {$name}\n";
+}
+
+function business_gsc_file_contains( string $relative_path, string $needle ): bool {
+	$contents = file_get_contents( dirname( __DIR__ ) . '/' . $relative_path );
+	return false !== $contents && false !== strpos( $contents, $needle );
+}
+
+echo "Business GSC registration smoke (#2139)\n";
+echo "---------------------------------------\n";
+
+assert_business_gsc(
+	file_exists( $root . '/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php' ),
+	'business ships GoogleSearchConsoleAbilities',
+	$failures,
+	$passes
+);
+
+assert_business_gsc(
+	file_exists( $root . '/inc/Tools/GoogleSearchConsole.php' ),
+	'business ships google_search_console tool wrapper',
+	$failures,
+	$passes
+);
+
+assert_business_gsc(
+	business_gsc_file_contains( 'inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php', "CONFIG_OPTION = 'datamachine_gsc_config'" ),
+	'business preserves legacy GSC config option key',
+	$failures,
+	$passes
+);
+
+assert_business_gsc(
+	business_gsc_file_contains( 'inc/Tools/GoogleSearchConsole.php', "registerTool( 'google_search_console'" ),
+	'business registers google_search_console tool',
+	$failures,
+	$passes
+);
+
+assert_business_gsc(
+	business_gsc_file_contains( 'inc/Api/GoogleSearchConsoleAnalytics.php', "'/analytics/gsc'" ),
+	'business registers the GSC REST route',
+	$failures,
+	$passes
+);
+
+assert_business_gsc(
+	business_gsc_file_contains( 'data-machine-business.php', "datamachine analytics gsc" ),
+	'business registers the GSC WP-CLI command',
+	$failures,
+	$passes
+);
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAILURES:\n";
+	foreach ( $failures as $failure ) {
+		echo " - {$failure}\n";
+	}
+	exit( 1 );
+}
+
+echo "\n{$passes} assertions passed.\n";


### PR DESCRIPTION
## Summary
- Adds the Google Search Console ability, AI tool, REST endpoint, and WP-CLI command to Data Machine Business.
- Preserves the legacy `datamachine_gsc_config` and `datamachine_gsc_access_token` keys so existing core configuration is adopted automatically when this plugin is active.
- Adds business-owned docs and tests for the Search Console integration, plus a source-checkout autoload fallback so the plugin loads before Composer vendor files exist.

## Dependency
- Depends on core removal PR: https://github.com/Extra-Chill/data-machine/pull/2149
- Together these PRs fix https://github.com/Extra-Chill/data-machine/issues/2139.

## Verification
- `php -l data-machine-business.php && php -l inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php && php -l inc/Tools/GoogleSearchConsole.php && php -l inc/Api/GoogleSearchConsoleAnalytics.php && php -l inc/Cli/GoogleSearchConsoleCommand.php && php tests/gsc-business-registration-smoke.php`
- `/Users/chubes/Developer/data-machine@fix-extract-gsc-business/vendor/bin/phpcs data-machine-business.php inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php inc/Tools/GoogleSearchConsole.php inc/Api/GoogleSearchConsoleAnalytics.php inc/Cli/GoogleSearchConsoleCommand.php tests/gsc-business-registration-smoke.php tests/GoogleSearchConsoleBusinessTest.php`
- `homeboy test --path /Users/chubes/Developer/data-machine-business@fix-extract-gsc-business --extension wordpress --force-hot`

## Notes
- `homeboy lint --path /Users/chubes/Developer/data-machine-business@fix-extract-gsc-business --extension wordpress --force-hot` still reports pre-existing lint findings across older Slack/Google Sheets/Google Drive files. The changed Search Console files and plugin bootstrap file pass PHPCS directly.
- Homeboy resolved its Data Machine validation dependency to the local primary checkout, which is behind origin/main. The new business PHPUnit tests are static registration/adoption checks and passed despite that dependency warning.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Moved the Search Console surfaces into Data Machine Business, preserved existing config adoption, added docs/tests, fixed source-checkout autoloading, and ran verification. Chris remains responsible for review and merge.