### PR TITLE
Add Bing Webmaster business integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This plugin extends Data Machine with business-focused integrations including:
 - **Slack**: Post messages and fetch conversations from channels
 - **Discord**: Post messages and fetch messages from server channels
 - **Amazon Affiliate Link**: Search Amazon products and return affiliate links using the Amazon Creators API
+- **Bing Webmaster Tools**: Fetch Bing search, traffic, page, and crawl analytics
 
 ## Requirements
 
@@ -182,6 +183,19 @@ Existing credentials saved by older Data Machine core versions are adopted autom
 2. Create Amazon Creators API credentials.
 3. In Data Machine tool settings, configure Credential ID, Credential Secret, Partner Tag, and Marketplace.
 4. Use `amazon_affiliate_link` only for genuinely relevant product references.
+
+## Bing Webmaster Tools
+
+Bing Webmaster Tools is owned by Data Machine Business. When this plugin is active, it registers the same user-facing capability that previously lived in Data Machine core:
+
+- Ability: `datamachine/bing-webmaster`
+- AI tool: `bing_webmaster`
+- REST route: `POST /wp-json/datamachine/v1/analytics/bing`
+- WP-CLI: `wp datamachine analytics bing <action>`
+
+Existing sites keep their saved configuration because the business plugin adopts the original `datamachine_bing_webmaster_config` site option.
+
+See [Bing Webmaster Tools](docs/bing-webmaster.md) for setup and usage details.
 
 ## License
 

--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -94,6 +94,10 @@ function datamachine_business_load_handlers() {
 	new \DataMachineBusiness\Abilities\Discord\PostMessageDiscordAbility();
 	new \DataMachineBusiness\Abilities\Discord\FetchMessagesDiscordAbility();
 
+	// Bing Webmaster Tools.
+	new \DataMachineBusiness\Abilities\Analytics\BingWebmasterAbilities();
+	new \DataMachineBusiness\Tools\BingWebmaster();
+
 	// Discord Handlers
 	new \DataMachineBusiness\Handlers\Discord\DiscordPublish();
 	new \DataMachineBusiness\Handlers\Discord\DiscordFetch();
@@ -104,6 +108,25 @@ function datamachine_business_load_handlers() {
 
 // Hook into plugins_loaded to ensure Data Machine core is loaded first
 add_action( 'plugins_loaded', 'datamachine_business_load_handlers', 20 );
+
+/**
+ * Register business-owned analytics routes with Data Machine core.
+ */
+add_filter( 'datamachine_analytics_ability_map', function ( array $ability_map ): array {
+	$ability_map['bing'] = 'datamachine/bing-webmaster';
+	return $ability_map;
+} );
+
+/**
+ * Register business-owned WP-CLI commands.
+ */
+add_action( 'plugins_loaded', function (): void {
+	if ( ! defined( 'WP_CLI' ) || ! WP_CLI || ! class_exists( 'DataMachine\\Cli\\BaseCommand' ) ) {
+		return;
+	}
+
+	\WP_CLI::add_command( 'datamachine analytics bing', \DataMachineBusiness\Cli\Commands\BingWebmasterCommand::class );
+}, 21 );
 
 /**
  * Contribute Google Drive scopes to the unified Google OAuth credential.

--- a/docs/bing-webmaster.md
+++ b/docs/bing-webmaster.md
@@ -1,0 +1,97 @@
+# Bing Webmaster Tools
+
+**Owner**: Data Machine Business
+
+**Tool ID**: `bing_webmaster`
+
+**Ability**: `datamachine/bing-webmaster`
+
+**Runtime files**:
+
+- Tool: `inc/Tools/BingWebmaster.php`
+- Ability: `inc/Abilities/Analytics/BingWebmasterAbilities.php`
+- CLI: `inc/Cli/Commands/BingWebmasterCommand.php`
+
+## Overview
+
+Bing Webmaster Tools fetches search analytics data from the Bing Webmaster API. It provides search query stats, traffic and ranking data, page performance, and crawl statistics.
+
+When Data Machine Business is active, it also contributes the `bing` analytics REST route through Data Machine core's `datamachine_analytics_ability_map` extension point.
+
+## Configuration
+
+### API Key
+
+- Purpose: authenticates requests to the Bing Webmaster API
+- Source: Bing Webmaster Tools -> Settings -> API Access -> API Key
+- Storage: site option `datamachine_bing_webmaster_config`
+
+Data Machine Business intentionally reuses the original Data Machine core option key so existing saved configurations are adopted without migration.
+
+### Site URL
+
+The configured site URL must match the site registered in Bing Webmaster Tools. If omitted, the ability uses the WordPress site URL.
+
+Example stored config:
+
+```php
+array(
+    'api_key'  => 'your-bing-api-key',
+    'site_url' => 'https://example.com',
+)
+```
+
+## Actions
+
+- `query_stats` - search query performance
+- `traffic_stats` - rank and traffic data
+- `page_stats` - per-page metrics
+- `crawl_stats` - Bing crawler activity and statistics
+
+## REST Usage
+
+```http
+POST /wp-json/datamachine/v1/analytics/bing
+Content-Type: application/json
+
+{
+  "action": "query_stats",
+  "limit": 20,
+  "days": 30
+}
+```
+
+## WP-CLI Usage
+
+```bash
+wp datamachine analytics bing query_stats
+wp datamachine analytics bing traffic_stats --format=json
+wp datamachine analytics bing crawl_stats --limit=50
+wp datamachine analytics bing page_stats --days=30
+```
+
+## Response Shape
+
+```php
+array(
+    'success'       => true,
+    'action'        => 'query_stats',
+    'results_count' => 20,
+    'date_range'    => array(
+        'start_date' => '2026-01-01',
+        'end_date'   => '2026-01-31',
+        'days_ago'   => 3,
+        'span_days'  => 30,
+    ),
+    'results'       => array(...),
+)
+```
+
+The ability parses Bing's `/Date(timestamp)/` response format into `Y-m-d` dates and applies the optional `days` filter client-side because the Bing API endpoints do not accept date parameters.
+
+## Error Messages
+
+- Missing API key: `Bing Webmaster Tools not configured. Add an API key in Settings.`
+- Invalid action: `Invalid action. Must be one of: query_stats, traffic_stats, page_stats, crawl_stats`
+- Network failure: `Failed to connect to Bing Webmaster API: {error}`
+- Parse failure: `Failed to parse Bing Webmaster API response.`

--- a/inc/Abilities/Analytics/BingWebmasterAbilities.php
+++ b/inc/Abilities/Analytics/BingWebmasterAbilities.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Bing Webmaster Tools ability.
+ *
+ * @package DataMachineBusiness\Abilities\Analytics
+ */
+
+namespace DataMachineBusiness\Abilities\Analytics;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+
+defined( 'ABSPATH' ) || exit;
+
+class BingWebmasterAbilities {
+
+	/**
+	 * Existing Data Machine core option key. Reusing it adopts stored config.
+	 *
+	 * @var string
+	 */
+	const CONFIG_OPTION = 'datamachine_bing_webmaster_config';
+
+	/**
+	 * API endpoint mapping for supported actions.
+	 *
+	 * @var array<string,string>
+	 */
+	const ACTION_ENDPOINTS = array(
+		'query_stats'   => 'GetQueryStats',
+		'traffic_stats' => 'GetRankAndTrafficStats',
+		'page_stats'    => 'GetPageStats',
+		'crawl_stats'   => 'GetCrawlStats',
+	);
+
+	/**
+	 * Default result limit.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_LIMIT = 20;
+
+	/**
+	 * Regex to parse Bing's /Date(timestamp)/ format.
+	 *
+	 * @var string
+	 */
+	const DATE_REGEX = '/^\/Date\((\d+)([+-]\d{4})?\)\/$/';
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->register_abilities();
+		self::$registered = true;
+	}
+
+	private function register_abilities(): void {
+		$register_callback = function (): void {
+			wp_register_ability(
+				'datamachine/bing-webmaster',
+				array(
+					'label'               => 'Bing Webmaster Tools',
+					'description'         => 'Fetch search analytics data from Bing Webmaster Tools API',
+					'category'            => 'datamachine-analytics',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'action' ),
+						'properties' => array(
+							'action'   => array(
+								'type'        => 'string',
+								'description' => 'Analytics action: query_stats, traffic_stats, page_stats, crawl_stats.',
+							),
+							'site_url' => array(
+								'type'        => 'string',
+								'description' => 'Site URL to query (defaults to configured site URL).',
+							),
+							'limit'    => array(
+								'type'        => 'integer',
+								'description' => 'Maximum number of results to return (default: 20).',
+							),
+							'days'     => array(
+								'type'        => 'integer',
+								'description' => 'Only return data from the last N days (client-side filter).',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'       => array( 'type' => 'boolean' ),
+							'action'        => array( 'type' => 'string' ),
+							'results_count' => array( 'type' => 'integer' ),
+							'date_range'    => array(
+								'type'       => 'object',
+								'properties' => array(
+									'start_date' => array( 'type' => 'string' ),
+									'end_date'   => array( 'type' => 'string' ),
+									'days_ago'   => array( 'type' => 'integer' ),
+									'span_days'  => array( 'type' => 'integer' ),
+								),
+							),
+							'results'       => array( 'type' => 'array' ),
+							'error'         => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'fetch_stats' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Fetch stats from Bing Webmaster Tools API.
+	 *
+	 * @param array $input Ability input.
+	 * @return array<string,mixed> Ability response.
+	 */
+	public static function fetch_stats( array $input ): array {
+		$action = sanitize_text_field( $input['action'] ?? '' );
+
+		if ( empty( $action ) || ! isset( self::ACTION_ENDPOINTS[ $action ] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Invalid action. Must be one of: ' . implode( ', ', array_keys( self::ACTION_ENDPOINTS ) ),
+			);
+		}
+
+		$config = self::get_config();
+
+		if ( empty( $config['api_key'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Bing Webmaster Tools not configured. Add an API key in Settings.',
+			);
+		}
+
+		$site_url = ! empty( $input['site_url'] ) ? sanitize_text_field( $input['site_url'] ) : ( $config['site_url'] ?? get_site_url() );
+		$limit    = ! empty( $input['limit'] ) ? (int) $input['limit'] : self::DEFAULT_LIMIT;
+		$days     = ! empty( $input['days'] ) ? (int) $input['days'] : 0;
+		$endpoint = self::ACTION_ENDPOINTS[ $action ];
+
+		$request_url = add_query_arg(
+			array(
+				'apikey'  => $config['api_key'],
+				'siteUrl' => $site_url,
+			),
+			'https://ssl.bing.com/webmaster/api.svc/json/' . $endpoint
+		);
+
+		$result = HttpClient::get(
+			$request_url,
+			array(
+				'timeout' => 15,
+				'headers' => array(
+					'Accept' => 'application/json',
+				),
+				'context' => 'Bing Webmaster Tools Ability',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to connect to Bing Webmaster API: ' . ( $result['error'] ?? 'Unknown error' ),
+			);
+		}
+
+		$data = json_decode( $result['data'], true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to parse Bing Webmaster API response.',
+			);
+		}
+
+		$results = $data['d'] ?? array();
+
+		if ( ! is_array( $results ) ) {
+			$results = array();
+		}
+
+		$parsed_dates = array();
+		foreach ( $results as &$row ) {
+			if ( isset( $row['Date'] ) ) {
+				$parsed = self::parse_bing_date( $row['Date'] );
+				if ( $parsed ) {
+					$row['Date']    = $parsed['iso'];
+					$parsed_dates[] = $parsed['timestamp'];
+				}
+			}
+		}
+		unset( $row );
+
+		if ( $days > 0 && ! empty( $parsed_dates ) ) {
+			$cutoff  = time() - ( $days * DAY_IN_SECONDS );
+			$results = array_values( array_filter( $results, function ( $row ) use ( $cutoff ) {
+				if ( empty( $row['Date'] ) ) {
+					return true;
+				}
+				$timestamp = strtotime( $row['Date'] );
+				return false !== $timestamp && $timestamp >= $cutoff;
+			} ) );
+		}
+
+		if ( count( $results ) > $limit ) {
+			$results = array_slice( $results, 0, $limit );
+		}
+
+		$date_range = array();
+		if ( ! empty( $parsed_dates ) ) {
+			$min_ts     = min( $parsed_dates );
+			$max_ts     = max( $parsed_dates );
+			$date_range = array(
+				'start_date' => gmdate( 'Y-m-d', $min_ts ),
+				'end_date'   => gmdate( 'Y-m-d', $max_ts ),
+				'days_ago'   => (int) floor( ( time() - $max_ts ) / DAY_IN_SECONDS ),
+				'span_days'  => (int) floor( ( $max_ts - $min_ts ) / DAY_IN_SECONDS ),
+			);
+		}
+
+		return array(
+			'success'       => true,
+			'action'        => $action,
+			'results_count' => count( $results ),
+			'date_range'    => $date_range,
+			'results'       => $results,
+		);
+	}
+
+	/**
+	 * Parse Bing's WCF /Date(timestamp)/ format.
+	 *
+	 * @param string $date_string Bing date string like "/Date(1316156400000-0700)/".
+	 * @return array{timestamp:int,iso:string}|null Parsed date, or null.
+	 */
+	public static function parse_bing_date( string $date_string ): ?array {
+		if ( ! preg_match( self::DATE_REGEX, $date_string, $matches ) ) {
+			return null;
+		}
+
+		$ms        = (int) $matches[1];
+		$timestamp = (int) floor( $ms / 1000 );
+
+		return array(
+			'timestamp' => $timestamp,
+			'iso'       => gmdate( 'Y-m-d', $timestamp ),
+		);
+	}
+
+	public static function is_configured(): bool {
+		$config = self::get_config();
+		return ! empty( $config['api_key'] );
+	}
+
+	/**
+	 * Get stored configuration.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function get_config(): array {
+		return get_site_option( self::CONFIG_OPTION, array() );
+	}
+}

--- a/inc/Cli/Commands/BingWebmasterCommand.php
+++ b/inc/Cli/Commands/BingWebmasterCommand.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Bing Webmaster WP-CLI command.
+ *
+ * @package DataMachineBusiness\Cli\Commands
+ */
+
+namespace DataMachineBusiness\Cli\Commands;
+
+use DataMachine\Cli\BaseCommand;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+class BingWebmasterCommand extends BaseCommand {
+
+	/**
+	 * Query Bing Webmaster Tools analytics.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Action to perform: query_stats, traffic_stats, page_stats, crawl_stats.
+	 *
+	 * [--limit=<number>]
+	 * : Maximum number of results (default: 20).
+	 *
+	 * [--days=<number>]
+	 * : Only show data from the last N days (client-side filter).
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine analytics bing query_stats
+	 *     wp datamachine analytics bing traffic_stats --format=json
+	 *     wp datamachine analytics bing crawl_stats --limit=50
+	 *     wp datamachine analytics bing traffic_stats --days=30
+	 *
+	 * @when after_wp_load
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$input = array(
+			'action' => $args[0] ?? '',
+		);
+
+		foreach ( array( 'limit', 'days' ) as $key ) {
+			if ( isset( $assoc_args[ $key ] ) ) {
+				$input[ $key ] = $assoc_args[ $key ];
+			}
+		}
+
+		$this->execute_ability( 'datamachine/bing-webmaster', $input, $assoc_args );
+	}
+
+	/**
+	 * Execute an ability and output the results.
+	 *
+	 * @param string $ability_slug Ability slug.
+	 * @param array  $input        Ability input.
+	 * @param array  $assoc_args   CLI associative arguments.
+	 */
+	private function execute_ability( string $ability_slug, array $input, array $assoc_args ): void {
+		$ability = wp_get_ability( $ability_slug );
+
+		if ( ! $ability ) {
+			WP_CLI::error( "Ability '{$ability_slug}' not registered. Ensure Data Machine Business is active and WordPress 6.9+." );
+			return;
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Unknown error.' );
+			return;
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$results = $result['results'] ?? array();
+		if ( empty( $results ) ) {
+			WP_CLI::success( 'Command completed with no tabular results. Use --format=json for full output.' );
+			return;
+		}
+
+		$flat_results = array_map( array( $this, 'flatten_row' ), $results );
+		$fields       = array_keys( $flat_results[0] );
+		$this->format_items( $flat_results, $fields, $assoc_args );
+
+		$count = $result['results_count'] ?? count( $results );
+		if ( ! empty( $result['date_range'] ) ) {
+			$range    = $result['date_range'];
+			$start    = $range['start_date'] ?? '?';
+			$end      = $range['end_date'] ?? '?';
+			$days_ago = $range['days_ago'] ?? null;
+
+			WP_CLI::log( sprintf( '%d results (%s to %s)', $count, $start, $end ) );
+
+			if ( null !== $days_ago && $days_ago > 30 ) {
+				WP_CLI::warning( sprintf( 'Data is %d days stale (latest: %s). Check API key and site verification.', $days_ago, $end ) );
+			}
+			return;
+		}
+
+		WP_CLI::log( sprintf( '%d results', $count ) );
+	}
+
+	/**
+	 * Flatten a result row for table display.
+	 *
+	 * @param array $row Result row.
+	 * @return array<string,mixed> Flat row.
+	 */
+	private function flatten_row( array $row ): array {
+		$flat = array();
+		foreach ( $row as $key => $value ) {
+			$flat[ $key ] = is_array( $value ) ? implode( ', ', array_map( 'strval', $value ) ) : $value;
+		}
+		return $flat;
+	}
+}

--- a/inc/Tools/BingWebmaster.php
+++ b/inc/Tools/BingWebmaster.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Bing Webmaster Tools AI tool.
+ *
+ * @package DataMachineBusiness\Tools
+ */
+
+namespace DataMachineBusiness\Tools;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachineBusiness\Abilities\Analytics\BingWebmasterAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class BingWebmaster extends BaseTool {
+
+	public function __construct() {
+		$this->registerConfigurationHandlers( 'bing_webmaster' );
+		$this->registerTool( 'bing_webmaster', array( $this, 'get_tool_definition' ), array( 'chat', 'pipeline' ), array( 'ability' => 'datamachine/bing-webmaster' ) );
+	}
+
+	/**
+	 * Execute Bing Webmaster query by delegating to the ability.
+	 *
+	 * @param array $parameters Contains action and optional query args.
+	 * @param array $tool_def   Tool definition.
+	 * @return array<string,mixed> Tool result.
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$tool_def;
+		$ability = wp_get_ability( 'datamachine/bing-webmaster' );
+
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'Bing Webmaster ability not registered. Ensure Data Machine Business is active.',
+				'bing_webmaster'
+			);
+		}
+
+		$result = $ability->execute( $parameters );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'bing_webmaster' );
+		}
+
+		if ( ! empty( $result['error'] ) ) {
+			return $this->buildErrorResponse( $result['error'], 'bing_webmaster' );
+		}
+
+		$result['tool_name'] = 'bing_webmaster';
+		return $result;
+	}
+
+	/**
+	 * Get tool definition for AI agents.
+	 *
+	 * @return array<string,mixed> Tool definition array.
+	 */
+	public function get_tool_definition(): array {
+		return array(
+			'class'           => __CLASS__,
+			'method'          => 'handle_tool_call',
+			'description'     => 'Fetch search analytics data from Bing Webmaster Tools. Returns query performance stats, traffic rankings, page-level stats, or crawl information for the configured site. Use to analyze search visibility, top queries, and crawl health on Bing.',
+			'requires_config' => true,
+			'parameters'      => array(
+				'type'       => 'object',
+				'properties' => array(
+					'action'   => array(
+						'type'        => 'string',
+						'description' => 'Analytics action to perform: query_stats (search query performance), traffic_stats (rank and traffic data), page_stats (per-page metrics), crawl_stats (crawl information).',
+					),
+					'site_url' => array(
+						'type'        => 'string',
+						'description' => 'Site URL to query. Defaults to the configured site URL.',
+					),
+					'limit'    => array(
+						'type'        => 'integer',
+						'description' => 'Maximum number of results to return (default: 20).',
+					),
+				),
+				'required'   => array( 'action' ),
+			),
+		);
+	}
+
+	public static function is_configured(): bool {
+		return BingWebmasterAbilities::is_configured();
+	}
+
+	/**
+	 * Get stored configuration.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function get_config(): array {
+		return BingWebmasterAbilities::get_config();
+	}
+
+	public function check_configuration( $configured, $tool_id ) {
+		if ( 'bing_webmaster' !== $tool_id ) {
+			return $configured;
+		}
+
+		return self::is_configured();
+	}
+
+	public function get_configuration( $config, $tool_id ) {
+		if ( 'bing_webmaster' !== $tool_id ) {
+			return $config;
+		}
+
+		return self::get_config();
+	}
+
+	protected function get_config_option_name(): string {
+		return BingWebmasterAbilities::CONFIG_OPTION;
+	}
+
+	protected function validate_and_build_config( array $config_data ): array {
+		$api_key = sanitize_text_field( $config_data['api_key'] ?? '' );
+
+		if ( empty( $api_key ) ) {
+			return array( 'error' => __( 'Bing Webmaster API key is required', 'data-machine-business' ) );
+		}
+
+		return array(
+			'config'  => array(
+				'api_key'  => $api_key,
+				'site_url' => esc_url_raw( $config_data['site_url'] ?? '' ),
+			),
+			'message' => __( 'Bing Webmaster Tools configuration saved successfully', 'data-machine-business' ),
+		);
+	}
+
+	public function get_config_fields( $fields = array(), $tool_id = '' ) {
+		if ( ! empty( $tool_id ) && 'bing_webmaster' !== $tool_id ) {
+			return $fields;
+		}
+
+		return array(
+			'api_key'  => array(
+				'type'        => 'password',
+				'label'       => __( 'Bing Webmaster API Key', 'data-machine-business' ),
+				'placeholder' => __( 'Enter your Bing Webmaster API key', 'data-machine-business' ),
+				'required'    => true,
+				'description' => __( 'Get your API key from Bing Webmaster Tools -> Settings -> API Access', 'data-machine-business' ),
+			),
+			'site_url' => array(
+				'type'        => 'text',
+				'label'       => __( 'Site URL', 'data-machine-business' ),
+				'placeholder' => 'https://yoursite.com',
+				'required'    => false,
+				'description' => __( 'The site URL registered in Bing Webmaster Tools. Defaults to your WordPress site URL.', 'data-machine-business' ),
+			),
+		);
+	}
+}

--- a/tests/bing-webmaster-ability-smoke.php
+++ b/tests/bing-webmaster-ability-smoke.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Smoke tests for the business-owned Bing Webmaster ability.
+ *
+ * Run with: php tests/bing-webmaster-ability-smoke.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+define( 'DAY_IN_SECONDS', 86400 );
+
+require_once __DIR__ . '/../inc/Abilities/Analytics/BingWebmasterAbilities.php';
+
+use DataMachineBusiness\Abilities\Analytics\BingWebmasterAbilities;
+
+$failures = array();
+
+$parsed = BingWebmasterAbilities::parse_bing_date( '/Date(1316156400000-0700)/' );
+if ( ! is_array( $parsed ) || 1316156400 !== $parsed['timestamp'] || '2011-09-16' !== $parsed['iso'] ) {
+	$failures[] = 'parse_bing_date parses Bing WCF dates into UTC day metadata.';
+}
+
+if ( null !== BingWebmasterAbilities::parse_bing_date( '2011-09-16' ) ) {
+	$failures[] = 'parse_bing_date rejects non-Bing date strings.';
+}
+
+if ( 'datamachine_bing_webmaster_config' !== BingWebmasterAbilities::CONFIG_OPTION ) {
+	$failures[] = 'CONFIG_OPTION preserves the former Data Machine core option key for adoption.';
+}
+
+if ( ! isset( BingWebmasterAbilities::ACTION_ENDPOINTS['query_stats'], BingWebmasterAbilities::ACTION_ENDPOINTS['traffic_stats'], BingWebmasterAbilities::ACTION_ENDPOINTS['page_stats'], BingWebmasterAbilities::ACTION_ENDPOINTS['crawl_stats'] ) ) {
+	$failures[] = 'ACTION_ENDPOINTS preserves the supported Bing actions.';
+}
+
+if ( $failures ) {
+	fwrite( STDERR, "FAILED: " . count( $failures ) . " Bing Webmaster smoke assertion(s) failed.\n" );
+	foreach ( $failures as $failure ) {
+		fwrite( STDERR, "- {$failure}\n" );
+	}
+	exit( 1 );
+}
+
+echo "All Bing Webmaster business smoke assertions passed.\n";


### PR DESCRIPTION
## Summary
- Adds the Bing Webmaster ability and `bing_webmaster` AI tool to Data Machine Business.
- Registers the business-owned REST route contribution and WP-CLI command for `datamachine analytics bing`.
- Reuses `datamachine_bing_webmaster_config` so existing Data Machine core configuration is adopted without migration.
- Adds a Composer-autoload fallback because this plugin has no runtime package dependencies and source/test checkouts may not contain `vendor/`.

Depends on https://github.com/Extra-Chill/data-machine/pull/2150 for the core REST extension point and core removal.

Part of https://github.com/Extra-Chill/data-machine/issues/2141.

## Verification
- `/Users/chubes/Developer/data-machine@fix-extract-bing-webmaster/vendor/bin/phpcs --standard=/Users/chubes/Developer/data-machine@fix-extract-bing-webmaster/phpcs.xml.dist data-machine-business.php inc/Abilities/Analytics/BingWebmasterAbilities.php inc/Tools/BingWebmaster.php inc/Cli/Commands/BingWebmasterCommand.php tests/bing-webmaster-ability-smoke.php`
- `php tests/bing-webmaster-ability-smoke.php`
- `homeboy test --path /Users/chubes/Developer/data-machine-business@feat-bing-webmaster-tools --extension wordpress --force-hot` passed activation/install; PHPUnit discovery found no matching PHPUnit test files.

## Notes
- `composer validate --strict` reports the existing `version` field warning; non-strict validation passes.
- Full `homeboy lint` reports pre-existing findings in existing business files; the new/changed PHP files pass PHPCS.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Porting the Bing Webmaster implementation from Data Machine core, adding the adoption path/docs/smoke checks, fixing the source-checkout autoload issue, and running verification. Chris remains responsible for review and merge.