### PR TITLE
fix(abilities): migrate Slack/Discord/Google* abilities to semantic categories

### DIFF
--- a/inc/Abilities/Discord/FetchMessagesDiscordAbility.php
+++ b/inc/Abilities/Discord/FetchMessagesDiscordAbility.php
@@ -35,7 +35,7 @@ class FetchMessagesDiscordAbility {
 				array(
 					'label'            => __( 'Fetch Discord Messages', 'data-machine-business' ),
 					'description'      => __( 'Fetch recent messages from a Discord channel', 'data-machine-business' ),
-					'category'         => 'datamachine',
+					'category'         => 'datamachine-fetch',
 					'input_schema'     => array(
 						'type'       => 'object',
 						'required'   => array( 'channel_id' ),

--- a/inc/Abilities/Discord/PostMessageDiscordAbility.php
+++ b/inc/Abilities/Discord/PostMessageDiscordAbility.php
@@ -35,7 +35,7 @@ class PostMessageDiscordAbility {
 				array(
 					'label'            => __( 'Post Message to Discord', 'data-machine-business' ),
 					'description'      => __( 'Post a message to a Discord channel', 'data-machine-business' ),
-					'category'         => 'datamachine',
+					'category'         => 'datamachine-publishing',
 					'input_schema'     => array(
 						'type'       => 'object',
 						'required'   => array( 'channel_id', 'content' ),

--- a/inc/Abilities/GoogleDrive/FetchGoogleDriveAbility.php
+++ b/inc/Abilities/GoogleDrive/FetchGoogleDriveAbility.php
@@ -61,7 +61,7 @@ class FetchGoogleDriveAbility {
 				array(
 					'label'               => __( 'Fetch Google Drive Folder', 'data-machine-business' ),
 					'description'         => __( 'List files in a Google Drive folder and download or export their contents.', 'data-machine-business' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-fetch',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'folder_id' ),

--- a/inc/Abilities/GoogleSheets/FetchGoogleSheetsAbility.php
+++ b/inc/Abilities/GoogleSheets/FetchGoogleSheetsAbility.php
@@ -39,7 +39,7 @@ class FetchGoogleSheetsAbility {
 				array(
 					'label'               => __( 'Fetch Google Sheets', 'data-machine-business' ),
 					'description'         => __( 'Fetch data from Google Sheets spreadsheets', 'data-machine-business' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-fetch',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'spreadsheet_id' ),

--- a/inc/Abilities/GoogleSheets/PublishGoogleSheetsAbility.php
+++ b/inc/Abilities/GoogleSheets/PublishGoogleSheetsAbility.php
@@ -39,7 +39,7 @@ class PublishGoogleSheetsAbility {
 				array(
 					'label'               => __( 'Publish to Google Sheets', 'data-machine-business' ),
 					'description'         => __( 'Append data rows to Google Sheets spreadsheets', 'data-machine-business' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-publishing',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'spreadsheet_id', 'data' ),

--- a/inc/Abilities/Slack/FetchMessagesSlackAbility.php
+++ b/inc/Abilities/Slack/FetchMessagesSlackAbility.php
@@ -35,7 +35,7 @@ class FetchMessagesSlackAbility {
 				array(
 					'label'            => __( 'Fetch Slack Messages', 'data-machine-business' ),
 					'description'      => __( 'Fetch recent messages from a Slack channel', 'data-machine-business' ),
-					'category'         => 'datamachine',
+					'category'         => 'datamachine-fetch',
 					'input_schema'     => array(
 						'type'       => 'object',
 						'required'   => array( 'channel' ),

--- a/inc/Abilities/Slack/PostMessageSlackAbility.php
+++ b/inc/Abilities/Slack/PostMessageSlackAbility.php
@@ -35,7 +35,7 @@ class PostMessageSlackAbility {
 				array(
 					'label'            => __( 'Post Message to Slack', 'data-machine-business' ),
 					'description'      => __( 'Post a message to a Slack channel or DM', 'data-machine-business' ),
-					'category'         => 'datamachine',
+					'category'         => 'datamachine-publishing',
 					'input_schema'     => array(
 						'type'       => 'object',
 						'required'   => array( 'channel', 'text' ),


### PR DESCRIPTION
Closes #18.

## What

Updates the 7 abilities that still referenced the bare \`datamachine\` category to use the appropriate semantic subcategory registered by Data Machine core's \`DataMachine\\Abilities\\AbilityCategories\`.

| Ability | Slug | New category |
|---|---|---|
| FetchGoogleDriveAbility | datamachine/fetch-googledrive | datamachine-fetch |
| FetchGoogleSheetsAbility | datamachine/fetch-googlesheets | datamachine-fetch |
| PublishGoogleSheetsAbility | datamachine/publish-googlesheets | datamachine-publishing |
| FetchMessagesSlackAbility | datamachine/fetch-messages-slack | datamachine-fetch |
| PostMessageSlackAbility | datamachine/post-message-slack | datamachine-publishing |
| FetchMessagesDiscordAbility | datamachine/fetch-messages-discord | datamachine-fetch |
| PostMessageDiscordAbility | datamachine/post-message-discord | datamachine-publishing |

## Why

Every PHP request on a DM-active site was logging 7 \`_doingItWrong\` notices like:

\`\`\`
Ability category "datamachine" is not registered.
\`\`\`

The Analytics abilities (BingWebmaster, GoogleAnalytics, GoogleSearchConsole) already used semantic slugs — this PR brings the remaining 7 in line with that pattern.

## How to verify

\`\`\`bash
# Before: each request logged 7 notices to the WP error log
# After: zero category-related notices

wp --allow-root --path=/var/www/extrachill.com eval 'do_action( "wp_abilities_api_init" ); echo "ok\n";'
\`\`\`

No behavior changes — only metadata. Schemas, callbacks, and permission gates are untouched.