### PR TITLE
chore: tighten homeboy config

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -2,18 +2,28 @@
   "auto_cleanup": false,
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {
-    "wordpress": {}
+    "wordpress": {
+      "php": "8.2",
+      "release_latest_branch": "release-latest",
+      "settings": {
+        "validation_dependencies": "data-machine"
+      }
+    }
   },
   "id": "data-machine-business",
   "remote_path": "wp-content/plugins/data-machine-business",
   "version_targets": [
     {
       "file": "data-machine-business.php",
-      "pattern": "Version:\\s*([0-9.]+)"
+      "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"
     },
     {
       "file": "data-machine-business.php",
       "pattern": "DATAMACHINE_BUSINESS_VERSION',\\s*'([0-9.]+)'"
+    },
+    {
+      "file": "composer.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Make the Homeboy component config explicit about PHP version, release branch, and the Data Machine validation dependency.
- Harden version target matching for the plugin header and include `composer.json` so releases keep package metadata in sync.

## Testing
- `homeboy test --path /Users/chubes/Developer/data-machine-business@chore-add-homeboy-config` passed: 22 tests, 65 assertions.
- `homeboy status --path /Users/chubes/Developer/data-machine-business@chore-add-homeboy-config` resolved the component cleanly.

## Known existing checks
- `homeboy audit --path /Users/chubes/Developer/data-machine-business@chore-add-homeboy-config` reports existing convention drift in extracted integration code.
- `homeboy lint --path /Users/chubes/Developer/data-machine-business@chore-add-homeboy-config` reports existing PHPCS findings in extracted integration code.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the config change, ran validation, and prepared the PR description.