### PR TITLE
fix(oauth): preserve scope on Google token refresh

### DIFF
--- a/inc/OAuth/Providers/GoogleAuth.php
+++ b/inc/OAuth/Providers/GoogleAuth.php
@@ -262,16 +262,34 @@ class GoogleAuth extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
 	/**
 	 * Update credentials with new tokens.
 	 *
+	 * Merges the refreshed token fields into the existing stored account so
+	 * non-refresh fields (notably `scope` and `last_verified_at`, set at initial
+	 * consent) survive a refresh_token grant. Google's refresh-token grant
+	 * response does NOT echo `scope` back — only the initial authorization-code
+	 * exchange does — so rebuilding the account dict from scratch silently
+	 * dropped scope and any other previously-stored fields, making downstream
+	 * `has_scope()` checks return false and surfacing a misleading
+	 * "re-authenticate" error until the next refresh wiped scope again.
+	 *
+	 * See data-machine#2167. This is the per-provider (Option A) fix; the
+	 * storage-layer merge-semantics fix that would protect every OAuth
+	 * provider from the same footgun is tracked separately.
+	 *
 	 * @param string $access_token New access token
 	 * @param string $refresh_token Refresh token
 	 * @param int $expires_in Token expiry time in seconds
 	 */
 	private function update_credentials( string $access_token, string $refresh_token, int $expires_in ) {
-		$account_data = array(
-			'access_token' => $access_token,
-			'refresh_token' => $refresh_token,
-			'expires_at' => time() + $expires_in,
-			'last_refreshed_at' => time(),
+		$existing = $this->get_account();
+
+		$account_data = array_merge(
+			is_array( $existing ) ? $existing : array(),
+			array(
+				'access_token'      => $access_token,
+				'refresh_token'     => $refresh_token,
+				'expires_at'        => time() + $expires_in,
+				'last_refreshed_at' => time(),
+			)
 		);
 
 		$this->save_account( $account_data );


### PR DESCRIPTION
Closes Extra-Chill/data-machine#2167 (Option A; Option B storage-layer follow-up at Extra-Chill/data-machine#2168).

## The bug

Google's OAuth refresh-token grant response does **not** echo `scope` back — only the initial authorization-code exchange does. `GoogleAuth::update_credentials()` rebuilt the account dict from scratch with only 4 fields:

```php
$account_data = array(
    'access_token'      => $access_token,
    'refresh_token'     => $refresh_token,
    'expires_at'        => time() + $expires_in,
    'last_refreshed_at' => time(),
);
$this->save_account( $account_data );
```

`BaseAuthProvider::save_account()` does a **full replacement** of the stored account (encrypt → overwrite the slot). So every refresh silently dropped `scope`, `last_verified_at`, and any other previously-stored fields.

Downstream `has_scope()` checks then returned `false` even though the OAuth grant on Google's side still had the scope. Users got the misleading `please re-authenticate` error that only `fixed` itself until the next refresh wiped scope again — classic intermittent bug.

## The fix

Merge the refreshed token fields into the existing decrypted account before saving, so non-refresh fields survive:

```php
$existing = $this->get_account();

$account_data = array_merge(
    is_array( $existing ) ? $existing : array(),
    array(
        'access_token'      => $access_token,
        'refresh_token'     => $refresh_token,
        'expires_at'        => time() + $expires_in,
        'last_refreshed_at' => time(),
    )
);

$this->save_account( $account_data );
```

`get_account()` returns decrypted plaintext (`BaseAuthProvider::get_account()` → `decrypt_fields()`), so merging plaintext-with-plaintext and letting `save_account()` re-encrypt the sensitive fields is contract-correct. No double-encryption: `encrypt_fields()` skips values that already carry the `dm:enc:v1:` envelope.

## What this preserves on every refresh

- `scope` (the load-bearing field for `has_scope()` — fixes the actual bug)
- `last_verified_at` (set at initial consent in `handle_oauth_callback`)
- Any future fields stored on a Google account (e.g. `username`, profile email, account id, etc.) without needing to update this method again

## Scope of this PR

- **Only fixes Google.** `GoogleAuth::update_credentials()` is the only call site of itself; only the refresh path was wrong.
- **No version bump, no changelog edit.** Conventional commit (`fix:`) — homeboy will pick the bump at release time.
- **Storage-layer footgun for other providers** (Slack, Discord, Twitter, Facebook, Threads, Bluesky, Pinterest, Instagram, LinkedIn, Reddit, …) is tracked separately at Extra-Chill/data-machine#2168 — that's the defensive Option B fix in `BaseAuthProvider::save_account()` that would protect every provider from the same class of bug.

## Verification

- `php -l inc/OAuth/Providers/GoogleAuth.php` — clean.
- `grep -rn update_credentials inc/` — single caller (`refresh_access_token()`), no other code paths affected.
- Read `BaseAuthProvider::get_account()` / `save_account()` to confirm decrypt-on-read / encrypt-on-write contract holds with merge semantics.