### PR TITLE
fix(abilities): register GoogleDrive abilities under datamachine-fetch category

### DIFF
--- a/inc/Abilities/GoogleDrive/DownloadGoogleDriveAbility.php
+++ b/inc/Abilities/GoogleDrive/DownloadGoogleDriveAbility.php
@@ -45,7 +45,7 @@ class DownloadGoogleDriveAbility {
 				array(
 					'label'               => __( 'Download Google Drive File', 'data-machine-business' ),
 					'description'         => __( 'Download a binary Google Drive file to local disk. Defaults to the WordPress uploads area under drive-imports/<YYYY>/<MM>/. Refuses native Google Docs/Sheets/Slides — use read-googledrive-doc for those.', 'data-machine-business' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-fetch',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'file' ),

--- a/inc/Abilities/GoogleDrive/ListGoogleDriveFilesAbility.php
+++ b/inc/Abilities/GoogleDrive/ListGoogleDriveFilesAbility.php
@@ -44,7 +44,7 @@ class ListGoogleDriveFilesAbility {
 				array(
 					'label'               => __( 'List Google Drive Files', 'data-machine-business' ),
 					'description'         => __( 'List every file in a Google Drive folder. Drains all pagination pages and returns metadata only — does not export Docs or download binaries.', 'data-machine-business' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-fetch',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'folder' ),

--- a/inc/Abilities/GoogleDrive/ReadGoogleDriveDocAbility.php
+++ b/inc/Abilities/GoogleDrive/ReadGoogleDriveDocAbility.php
@@ -51,7 +51,7 @@ class ReadGoogleDriveDocAbility {
 				array(
 					'label'               => __( 'Read Google Drive Document', 'data-machine-business' ),
 					'description'         => __( 'Export the text content of a Google Doc, Sheet, or Slides file as markdown, plain text, or CSV. Refuses native binary files (use download-googledrive for those).', 'data-machine-business' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-fetch',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'file' ),


### PR DESCRIPTION
Closes #27

## Summary

Three GoogleDrive abilities were registering under a bare `datamachine` category that doesn't exist in the canonical category registry (see `data-machine/inc/Abilities/AbilityCategories.php`), triggering `_doing_it_wrong` notices on every boot. Fixed by registering all three under `datamachine-fetch`, matching the existing `FetchGoogleDriveAbility` precedent.

## Changes

| File | Line | New category | Reasoning |
|------|------|--------------|-----------|
| `inc/Abilities/GoogleDrive/ListGoogleDriveFilesAbility.php` | 47 | `datamachine-fetch` | Directory listing — fetch-shaped |
| `inc/Abilities/GoogleDrive/ReadGoogleDriveDocAbility.php` | 54 | `datamachine-fetch` | Returns doc contents — matches `FetchGoogleDriveAbility` precedent |
| `inc/Abilities/GoogleDrive/DownloadGoogleDriveAbility.php` | 48 | `datamachine-fetch` | Downloads file bytes — fetch-shaped |

All four GoogleDrive abilities (`FetchGoogleDriveAbility`, `ListGoogleDriveFilesAbility`, `ReadGoogleDriveDocAbility`, `DownloadGoogleDriveAbility`) now consistently register under `datamachine-fetch`.

## Verification

- `php -l` clean on all three modified files
- Grep for bare `category => 'datamachine'` in `inc/` returns **zero matches** after the fix:
  ```
  grep -rnE "category\s*=>\s*['\"]datamachine['\"]" inc/
  # (no output)
  ```