### PR TITLE
feat(media): Media Hygiene ability + `wp datamachine media` CLI

### DIFF
--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -131,6 +131,13 @@ function datamachine_business_load_handlers() {
 
 	// Business AI tools
 	new \DataMachineBusiness\Tools\AmazonAffiliateLink();
+
+	// Media Hygiene — orphan files + unused attachments.
+	new \DataMachineBusiness\Abilities\MediaHygiene\MediaHygieneAbility();
+
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		\WP_CLI::add_command( 'datamachine media', \DataMachineBusiness\Cli\MediaHygieneCommand::class );
+	}
 }
 
 // Hook into plugins_loaded to ensure Data Machine core is loaded first

--- a/inc/Abilities/MediaHygiene/MediaHygieneAbility.php
+++ b/inc/Abilities/MediaHygiene/MediaHygieneAbility.php
@@ -1,0 +1,359 @@
+<?php
+/**
+ * Media Hygiene ability — orphan files + unused attachments.
+ *
+ * Registers a single `datamachine/media-hygiene` ability that dispatches on
+ * an `action` input:
+ *
+ *   - `orphan-files`    — list files on disk with no attachment row
+ *   - `unused`          — list attachments referenced nowhere
+ *   - `diagnose`        — summary roll-up of all detectors (no deletion)
+ *   - `delete-orphans`  — gated deletion of orphan files (requires `apply`)
+ *   - `delete-unused`   — gated deletion of unused attachments (requires `apply`)
+ *
+ * All read actions are pure / non-destructive. All write actions require
+ * `apply = true` and respect a `limit` for batched safety. Default `limit`
+ * for delete is 100, max 1000 per invocation.
+ *
+ * @package DataMachineBusiness\Abilities\MediaHygiene
+ */
+
+namespace DataMachineBusiness\Abilities\MediaHygiene;
+
+use DataMachine\Abilities\PermissionHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+class MediaHygieneAbility {
+
+	private const VALID_ACTIONS = array(
+		'diagnose',
+		'orphan-files',
+		'unused',
+		'delete-orphans',
+		'delete-unused',
+	);
+
+	private const DEFAULT_LIMIT       = 500;
+	private const MAX_DELETE_PER_CALL = 1000;
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/media-hygiene',
+				array(
+					'label'               => __( 'Media Hygiene', 'data-machine-business' ),
+					'description'         => __( 'Detect orphan files on disk and unused attachments in the WordPress media library. Supports gated deletion of confirmed dead weight.', 'data-machine-business' ),
+					'category'            => 'datamachine-media',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'action' ),
+						'properties' => array(
+							'action' => array(
+								'type'        => 'string',
+								'enum'        => self::VALID_ACTIONS,
+								'description' => __( 'Action to perform: diagnose, orphan-files, unused, delete-orphans, delete-unused.', 'data-machine-business' ),
+							),
+							'limit'  => array(
+								'type'        => 'integer',
+								'description' => __( 'Maximum items to scan or delete per invocation. Default 500 for scans, 100 for deletes (max 1000).', 'data-machine-business' ),
+							),
+							'apply'  => array(
+								'type'        => 'boolean',
+								'description' => __( 'Required for delete actions. Without apply=true, delete actions return a dry-run preview.', 'data-machine-business' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success' => array( 'type' => 'boolean' ),
+							'action'  => array( 'type' => 'string' ),
+							'dry_run' => array( 'type' => 'boolean' ),
+							'summary' => array( 'type' => 'object' ),
+							'results' => array( 'type' => 'array' ),
+							'error'   => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'run' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+
+		self::$registered = true;
+	}
+
+	/**
+	 * Ability execute callback. Dispatches on action.
+	 *
+	 * @param array $input
+	 * @return array
+	 */
+	public static function run( array $input ): array {
+		$action = sanitize_text_field( $input['action'] ?? '' );
+		if ( ! in_array( $action, self::VALID_ACTIONS, true ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Invalid action. Must be one of: ' . implode( ', ', self::VALID_ACTIONS ),
+			);
+		}
+
+		$limit = isset( $input['limit'] ) ? max( 0, (int) $input['limit'] ) : self::DEFAULT_LIMIT;
+		$apply = ! empty( $input['apply'] );
+
+		switch ( $action ) {
+			case 'diagnose':
+				return self::diagnose( $limit );
+			case 'orphan-files':
+				return self::list_orphan_files( $limit );
+			case 'unused':
+				return self::list_unused_attachments( $limit );
+			case 'delete-orphans':
+				return self::delete_orphans( $limit, $apply );
+			case 'delete-unused':
+				return self::delete_unused( $limit, $apply );
+		}
+
+		// Unreachable — guarded by VALID_ACTIONS check above.
+		return array( 'success' => false, 'error' => 'Unhandled action.' );
+	}
+
+	/**
+	 * Summary roll-up — counts + bytes for each detector, no per-item list.
+	 *
+	 * @param int $limit Per-detector cap for the scan.
+	 * @return array
+	 */
+	private static function diagnose( int $limit ): array {
+		$orphans = self::scan_orphan_files( $limit );
+		$unused  = MediaHygieneScanner::find_unreferenced_attachments( $limit );
+
+		$orphan_bytes = array_sum( array_column( $orphans, 'size' ) );
+		$unused_bytes = array_sum( array_column( $unused, 'size' ) );
+
+		return array(
+			'success' => true,
+			'action'  => 'diagnose',
+			'dry_run' => true,
+			'summary' => array(
+				'orphan_files_count'    => count( $orphans ),
+				'orphan_files_bytes'    => $orphan_bytes,
+				'orphan_files_human'    => size_format( $orphan_bytes, 2 ),
+				'unused_attachments'    => count( $unused ),
+				'unused_bytes'          => $unused_bytes,
+				'unused_human'          => size_format( $unused_bytes, 2 ),
+				'total_reclaimable'     => $orphan_bytes + $unused_bytes,
+				'total_human'           => size_format( $orphan_bytes + $unused_bytes, 2 ),
+				'scan_limit_per_detector' => $limit,
+			),
+		);
+	}
+
+	/**
+	 * Lists orphan files (no associated attachment row).
+	 *
+	 * @param int $limit
+	 * @return array
+	 */
+	private static function list_orphan_files( int $limit ): array {
+		$orphans = self::scan_orphan_files( $limit );
+
+		return array(
+			'success' => true,
+			'action'  => 'orphan-files',
+			'dry_run' => true,
+			'summary' => array(
+				'count'       => count( $orphans ),
+				'total_bytes' => array_sum( array_column( $orphans, 'size' ) ),
+				'scan_limit'  => $limit,
+			),
+			'results' => $orphans,
+		);
+	}
+
+	/**
+	 * Lists attachments with no detected references.
+	 *
+	 * @param int $limit
+	 * @return array
+	 */
+	private static function list_unused_attachments( int $limit ): array {
+		$unused = MediaHygieneScanner::find_unreferenced_attachments( $limit );
+
+		return array(
+			'success' => true,
+			'action'  => 'unused',
+			'dry_run' => true,
+			'summary' => array(
+				'count'       => count( $unused ),
+				'total_bytes' => array_sum( array_column( $unused, 'size' ) ),
+				'scan_limit'  => $limit,
+			),
+			'results' => $unused,
+		);
+	}
+
+	/**
+	 * Deletes orphan files. Requires `apply = true`; otherwise dry-run.
+	 *
+	 * @param int  $limit
+	 * @param bool $apply
+	 * @return array
+	 */
+	private static function delete_orphans( int $limit, bool $apply ): array {
+		$limit   = $limit > 0 ? min( $limit, self::MAX_DELETE_PER_CALL ) : 100;
+		$orphans = self::scan_orphan_files( $limit );
+
+		if ( ! $apply ) {
+			return array(
+				'success' => true,
+				'action'  => 'delete-orphans',
+				'dry_run' => true,
+				'summary' => array(
+					'would_delete'    => count( $orphans ),
+					'bytes_to_free'   => array_sum( array_column( $orphans, 'size' ) ),
+					'note'            => 'Pass apply=true to actually delete.',
+				),
+				'results' => $orphans,
+			);
+		}
+
+		$deleted      = 0;
+		$bytes_freed  = 0;
+		$failed       = array();
+
+		foreach ( $orphans as $orphan ) {
+			$path = $orphan['path'];
+			if ( ! is_writable( $path ) ) {
+				$failed[] = array( 'path' => $orphan['relative'], 'reason' => 'not_writable' );
+				continue;
+			}
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+			if ( @unlink( $path ) ) {
+				$deleted++;
+				$bytes_freed += (int) $orphan['size'];
+			} else {
+				$failed[] = array( 'path' => $orphan['relative'], 'reason' => 'unlink_failed' );
+			}
+		}
+
+		return array(
+			'success' => true,
+			'action'  => 'delete-orphans',
+			'dry_run' => false,
+			'summary' => array(
+				'deleted'       => $deleted,
+				'bytes_freed'   => $bytes_freed,
+				'failed_count'  => count( $failed ),
+			),
+			'results' => $failed,
+		);
+	}
+
+	/**
+	 * Deletes unused attachments. Requires `apply = true`; otherwise dry-run.
+	 *
+	 * Uses `wp_delete_attachment( $id, true )` for full WP-aware deletion
+	 * (removes file + all size variants + DB rows).
+	 *
+	 * @param int  $limit
+	 * @param bool $apply
+	 * @return array
+	 */
+	private static function delete_unused( int $limit, bool $apply ): array {
+		$limit  = $limit > 0 ? min( $limit, self::MAX_DELETE_PER_CALL ) : 100;
+		$unused = MediaHygieneScanner::find_unreferenced_attachments( $limit );
+
+		if ( ! $apply ) {
+			return array(
+				'success' => true,
+				'action'  => 'delete-unused',
+				'dry_run' => true,
+				'summary' => array(
+					'would_delete'  => count( $unused ),
+					'bytes_to_free' => array_sum( array_column( $unused, 'size' ) ),
+					'note'          => 'Pass apply=true to actually delete. Uses wp_delete_attachment( id, true ).',
+				),
+				'results' => $unused,
+			);
+		}
+
+		$deleted     = 0;
+		$bytes_freed = 0;
+		$failed      = array();
+
+		foreach ( $unused as $u ) {
+			$id   = (int) $u['id'];
+			$size = (int) $u['size'];
+			$res  = wp_delete_attachment( $id, true );
+			if ( false === $res || null === $res ) {
+				$failed[] = array( 'id' => $id, 'reason' => 'wp_delete_attachment_failed' );
+				continue;
+			}
+			$deleted++;
+			$bytes_freed += $size;
+		}
+
+		return array(
+			'success' => true,
+			'action'  => 'delete-unused',
+			'dry_run' => false,
+			'summary' => array(
+				'deleted'      => $deleted,
+				'bytes_freed'  => $bytes_freed,
+				'failed_count' => count( $failed ),
+			),
+			'results' => $failed,
+		);
+	}
+
+	/**
+	 * Returns the orphan-file list for the current site. Combines the on-disk
+	 * walk with the DB attached-file + variant index and returns files that
+	 * appear in neither.
+	 *
+	 * @param int $limit
+	 * @return array
+	 */
+	private static function scan_orphan_files( int $limit ): array {
+		// Walk uploads with no limit at this level — we want to count
+		// accurately, then cap the returned result list at $limit.
+		$files = MediaHygieneScanner::walk_uploads( 0 );
+		if ( empty( $files ) ) {
+			return array();
+		}
+
+		$attached = array_flip( array_map( 'strval', MediaHygieneScanner::attached_file_index() ) );
+		$variants = MediaHygieneScanner::variant_index();
+
+		$orphans = array();
+		foreach ( $files as $file ) {
+			$rel = $file['relative'];
+			if ( isset( $attached[ $rel ] ) ) {
+				continue;
+			}
+			if ( isset( $variants[ $rel ] ) ) {
+				continue;
+			}
+			$orphans[] = $file;
+			if ( $limit > 0 && count( $orphans ) >= $limit ) {
+				break;
+			}
+		}
+
+		return $orphans;
+	}
+}

--- a/inc/Abilities/MediaHygiene/MediaHygieneScanner.php
+++ b/inc/Abilities/MediaHygiene/MediaHygieneScanner.php
@@ -1,0 +1,375 @@
+<?php
+/**
+ * Shared filesystem + DB scanning utilities for media hygiene abilities.
+ *
+ * Pure read helpers — no mutations. The orphan-file and unused-attachment
+ * abilities both compose these helpers; keeping the SQL/glob logic here
+ * avoids duplication and keeps the abilities thin.
+ *
+ * @package DataMachineBusiness\Abilities\MediaHygiene
+ */
+
+namespace DataMachineBusiness\Abilities\MediaHygiene;
+
+defined( 'ABSPATH' ) || exit;
+
+class MediaHygieneScanner {
+
+	/**
+	 * File extensions considered "media" for orphan scanning.
+	 *
+	 * Conservative list — everything WordPress core treats as an attachable
+	 * media type. Configurable via the `datamachine_media_hygiene_extensions`
+	 * filter.
+	 */
+	private const DEFAULT_EXTENSIONS = array(
+		'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'svg', 'bmp', 'ico', 'tiff',
+		'mp4', 'mov', 'webm', 'ogv', 'mp3', 'wav', 'm4a', 'ogg',
+		'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'zip',
+	);
+
+	/**
+	 * Subdirectories under `wp-content/uploads/` to skip entirely when
+	 * scanning for orphan files. These are managed by other systems (caches,
+	 * exports, plugin internals) and should not be reported as orphans.
+	 *
+	 * Configurable via the `datamachine_media_hygiene_ignored_dirs` filter.
+	 */
+	private const DEFAULT_IGNORED_DIRS = array(
+		'cache',
+		'breeze',
+		'wpo-cache',
+		'wc-logs',
+		'woocommerce_uploads',
+		'data-machine-logs',
+		'datamachine-files',
+		'fonts',
+		'backup', // Imagify originals — managed separately by `find-dead-imagify-backups`.
+	);
+
+	/**
+	 * Returns the list of media file extensions to scan (lowercased, no dots).
+	 *
+	 * @return string[]
+	 */
+	public static function extensions(): array {
+		$exts = apply_filters( 'datamachine_media_hygiene_extensions', self::DEFAULT_EXTENSIONS );
+		return array_values( array_unique( array_map( 'strtolower', (array) $exts ) ) );
+	}
+
+	/**
+	 * Returns the list of subdirectory names to skip during orphan scans.
+	 *
+	 * @return string[]
+	 */
+	public static function ignored_dirs(): array {
+		$dirs = apply_filters( 'datamachine_media_hygiene_ignored_dirs', self::DEFAULT_IGNORED_DIRS );
+		return array_values( array_unique( array_map( 'strtolower', (array) $dirs ) ) );
+	}
+
+	/**
+	 * Returns the absolute uploads basedir for the current site context.
+	 *
+	 * Caller is responsible for `switch_to_blog()` if scanning a specific site.
+	 *
+	 * @return string
+	 */
+	public static function uploads_basedir(): string {
+		$uploads = wp_get_upload_dir();
+		return rtrim( (string) ( $uploads['basedir'] ?? '' ), '/' );
+	}
+
+	/**
+	 * Walks the current site's uploads directory and returns every media file
+	 * relative to `uploads_basedir`, skipping ignored subdirs.
+	 *
+	 * Caller scopes the site via `switch_to_blog()` before calling. For
+	 * multisite subsites, this naturally walks only `uploads/sites/N/` because
+	 * `wp_get_upload_dir()` returns the site-scoped basedir under that context.
+	 *
+	 * @param int $limit Maximum files to return. 0 means no limit.
+	 * @return array<int, array{path:string, relative:string, size:int}>
+	 */
+	public static function walk_uploads( int $limit = 0 ): array {
+		$basedir = self::uploads_basedir();
+		if ( '' === $basedir || ! is_dir( $basedir ) ) {
+			return array();
+		}
+
+		$ignored = self::ignored_dirs();
+		$exts    = self::extensions();
+		$results = array();
+
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveCallbackFilterIterator(
+				new \RecursiveDirectoryIterator( $basedir, \FilesystemIterator::SKIP_DOTS ),
+				static function ( $file, $key, $iterator ) use ( $basedir, $ignored ) {
+					if ( $file->isDir() ) {
+						$name = strtolower( $file->getFilename() );
+						if ( in_array( $name, $ignored, true ) ) {
+							return false;
+						}
+						// On the network site, skip per-site subdirs — those are scanned
+						// in their own switch_to_blog() context, not via the main site.
+						if ( is_multisite() && get_current_blog_id() === get_main_site_id() ) {
+							$rel = substr( $file->getPathname(), strlen( $basedir ) + 1 );
+							if ( 'sites' === strtolower( $rel ) ) {
+								return false;
+							}
+						}
+						return true;
+					}
+					return true;
+				}
+			)
+		);
+
+		foreach ( $iterator as $file ) {
+			if ( ! $file->isFile() ) {
+				continue;
+			}
+			$ext = strtolower( $file->getExtension() );
+			if ( ! in_array( $ext, $exts, true ) ) {
+				continue;
+			}
+			$path     = $file->getPathname();
+			$relative = substr( $path, strlen( $basedir ) + 1 );
+
+			$results[] = array(
+				'path'     => $path,
+				'relative' => $relative,
+				'size'     => (int) $file->getSize(),
+			);
+
+			if ( $limit > 0 && count( $results ) >= $limit ) {
+				break;
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Returns the set of `_wp_attached_file` postmeta values for the current
+	 * site, keyed by attachment ID. These are paths relative to the uploads
+	 * basedir — same shape as `walk_uploads()` `relative` values.
+	 *
+	 * @return array<int, string> attachment_id => relative_path
+	 */
+	public static function attached_file_index(): array {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			"SELECT post_id, meta_value
+			 FROM {$wpdb->postmeta}
+			 WHERE meta_key = '_wp_attached_file'",
+			ARRAY_A
+		);
+
+		$index = array();
+		if ( is_array( $rows ) ) {
+			foreach ( $rows as $row ) {
+				$index[ (int) $row['post_id'] ] = (string) $row['meta_value'];
+			}
+		}
+		return $index;
+	}
+
+	/**
+	 * Returns the set of every image-size variant filename derived from
+	 * `_wp_attachment_metadata` for the current site.
+	 *
+	 * WordPress stores resized variants (thumbnail, medium, large, etc.) as
+	 * separate files alongside the original. The original's relative path
+	 * comes from `_wp_attached_file`, but the variants are only enumerated
+	 * in the serialized `_wp_attachment_metadata` blob. An orphan scan that
+	 * only checks `_wp_attached_file` would falsely flag every thumbnail.
+	 *
+	 * Returns a set of basenames keyed for O(1) lookup.
+	 *
+	 * @return array<string, true> map of variant relative path => true
+	 */
+	public static function variant_index(): array {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_col(
+			"SELECT meta_value
+			 FROM {$wpdb->postmeta}
+			 WHERE meta_key = '_wp_attachment_metadata'"
+		);
+
+		$variants = array();
+		if ( ! is_array( $rows ) ) {
+			return $variants;
+		}
+
+		foreach ( $rows as $blob ) {
+			$meta = @maybe_unserialize( $blob );
+			if ( ! is_array( $meta ) ) {
+				continue;
+			}
+			$file = isset( $meta['file'] ) ? (string) $meta['file'] : '';
+			$dir  = '' !== $file ? trim( dirname( $file ), '/.' ) : '';
+			$dir  = '' !== $dir ? $dir . '/' : '';
+
+			if ( ! empty( $meta['sizes'] ) && is_array( $meta['sizes'] ) ) {
+				foreach ( $meta['sizes'] as $size ) {
+					if ( ! is_array( $size ) || empty( $size['file'] ) ) {
+						continue;
+					}
+					$variants[ $dir . $size['file'] ] = true;
+				}
+			}
+
+			// Imagify / WebP / scaled originals sometimes register additional
+			// derivative files via the `original_image` key.
+			if ( ! empty( $meta['original_image'] ) ) {
+				$variants[ $dir . (string) $meta['original_image'] ] = true;
+			}
+		}
+
+		return $variants;
+	}
+
+	/**
+	 * Scans the current site for attachment IDs that appear unreferenced.
+	 *
+	 * "Unreferenced" = the attachment's filename does not appear in any of:
+	 * - `wp_posts.post_content` (all post types except `attachment`)
+	 * - `wp_postmeta.meta_value` (any postmeta row)
+	 * - `wp_term_taxonomy.description`
+	 * - `wp_options.option_value`
+	 *
+	 * Featured-image references are detected via `_thumbnail_id` postmeta
+	 * (which is included in the postmeta scan automatically).
+	 *
+	 * Caller is responsible for `switch_to_blog()`.
+	 *
+	 * @param int $limit Maximum attachments to check (0 = no limit).
+	 * @return array<int, array{id:int, file:string, size:int, url:string}>
+	 */
+	public static function find_unreferenced_attachments( int $limit = 0 ): array {
+		global $wpdb;
+
+		$basedir = self::uploads_basedir();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$sql = "SELECT p.ID, m.meta_value AS file
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->postmeta} m
+					ON m.post_id = p.ID AND m.meta_key = '_wp_attached_file'
+				WHERE p.post_type = 'attachment'
+				ORDER BY p.ID ASC";
+		if ( $limit > 0 ) {
+			$sql .= $wpdb->prepare( ' LIMIT %d', $limit );
+		}
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		if ( ! is_array( $rows ) || empty( $rows ) ) {
+			return array();
+		}
+
+		$unreferenced = array();
+		foreach ( $rows as $row ) {
+			$id   = (int) $row['ID'];
+			$file = (string) $row['file'];
+			if ( '' === $file ) {
+				continue;
+			}
+			if ( self::is_referenced( $id, $file ) ) {
+				continue;
+			}
+			$abs  = $basedir . '/' . $file;
+			$size = is_readable( $abs ) ? (int) @filesize( $abs ) : 0;
+
+			$unreferenced[] = array(
+				'id'   => $id,
+				'file' => $file,
+				'size' => $size,
+				'url'  => wp_get_attachment_url( $id ) ?: '',
+			);
+		}
+
+		return $unreferenced;
+	}
+
+	/**
+	 * Checks whether an attachment is referenced anywhere meaningful.
+	 *
+	 * Heuristic, not exhaustive — third-party plugins can store references
+	 * in ways we don't probe (e.g. block-bound media in custom block JSON
+	 * patterns). False positives (claiming attachment is unreferenced when
+	 * it isn't) are possible. For safety, the `delete-unused-attachments`
+	 * ability is gated by `--apply` and a confirmation prompt.
+	 *
+	 * @param int    $attachment_id Attachment post ID.
+	 * @param string $file          `_wp_attached_file` value.
+	 * @return bool
+	 */
+	public static function is_referenced( int $attachment_id, string $file ): bool {
+		global $wpdb;
+
+		$basename = basename( $file );
+
+		// 1. post_content LIKE '%basename%' across all non-attachment post types.
+		$content_sql = $wpdb->prepare(
+			"SELECT 1 FROM {$wpdb->posts}
+			 WHERE post_type != 'attachment'
+			   AND post_status NOT IN ('trash','auto-draft')
+			   AND post_content LIKE %s
+			 LIMIT 1",
+			'%' . $wpdb->esc_like( $basename ) . '%'
+		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery
+		if ( $wpdb->get_var( $content_sql ) ) {
+			return true;
+		}
+
+		// 2. postmeta LIKE '%basename%' (catches _thumbnail_id JSON refs,
+		//    ACF image fields storing IDs/URLs, gallery shortcode IDs, etc.)
+		//    Note: _thumbnail_id stores the integer attachment ID, so we also
+		//    probe for the literal ID.
+		$id_str   = (string) $attachment_id;
+		$meta_sql = $wpdb->prepare(
+			"SELECT 1 FROM {$wpdb->postmeta}
+			 WHERE meta_value LIKE %s OR meta_value = %s
+			 LIMIT 1",
+			'%' . $wpdb->esc_like( $basename ) . '%',
+			$id_str
+		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery
+		if ( $wpdb->get_var( $meta_sql ) ) {
+			return true;
+		}
+
+		// 3. term_taxonomy.description LIKE '%basename%'
+		$term_sql = $wpdb->prepare(
+			"SELECT 1 FROM {$wpdb->term_taxonomy}
+			 WHERE description LIKE %s
+			 LIMIT 1",
+			'%' . $wpdb->esc_like( $basename ) . '%'
+		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery
+		if ( $wpdb->get_var( $term_sql ) ) {
+			return true;
+		}
+
+		// 4. options.option_value LIKE '%basename%' (site icon, logo, custom
+		//    header, theme mods, widget configs all live here).
+		$opt_sql = $wpdb->prepare(
+			"SELECT 1 FROM {$wpdb->options}
+			 WHERE option_value LIKE %s OR option_value = %s
+			 LIMIT 1",
+			'%' . $wpdb->esc_like( $basename ) . '%',
+			$id_str
+		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery
+		if ( $wpdb->get_var( $opt_sql ) ) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/inc/Cli/MediaHygieneCommand.php
+++ b/inc/Cli/MediaHygieneCommand.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Media Hygiene WP-CLI command.
+ *
+ * Thin wrapper around the `datamachine/media-hygiene` ability. All business
+ * logic lives in the ability; this command only handles CLI args, output
+ * formatting, and multisite iteration.
+ *
+ * @package DataMachineBusiness\Cli
+ */
+
+namespace DataMachineBusiness\Cli;
+
+use DataMachine\Cli\BaseCommand;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+class MediaHygieneCommand extends BaseCommand {
+
+	/**
+	 * Inspect and clean dead-weight media (orphan files + unreferenced attachments).
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Action to perform: diagnose | orphan-files | unused | delete-orphans | delete-unused
+	 *
+	 * [--limit=<n>]
+	 * : Maximum items per detector (default: 500 for scans, 100 for deletes; max 1000 for deletes).
+	 *
+	 * [--apply]
+	 * : Required for delete actions. Without --apply, delete actions return a dry-run preview.
+	 *
+	 * [--all-sites]
+	 * : Run across every site in the multisite network. Without this flag, runs only against
+	 *   the current site (or the --url=<site> target if provided).
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - count
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # See how much dead weight is on the current site
+	 *     wp datamachine media diagnose
+	 *
+	 *     # Scan every site in the network
+	 *     wp datamachine media diagnose --all-sites
+	 *
+	 *     # List the first 100 orphan files on disk
+	 *     wp datamachine media orphan-files --limit=100
+	 *
+	 *     # Preview which attachments would be deleted as unused
+	 *     wp datamachine media delete-unused --limit=50
+	 *
+	 *     # Actually delete them
+	 *     wp datamachine media delete-unused --limit=50 --apply
+	 *
+	 * @when after_wp_load
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$action = $args[0] ?? '';
+		if ( '' === $action ) {
+			WP_CLI::error( 'Action is required. See `wp help datamachine media` for usage.' );
+			return;
+		}
+
+		$input = array( 'action' => $action );
+
+		if ( isset( $assoc_args['limit'] ) ) {
+			$input['limit'] = (int) $assoc_args['limit'];
+		}
+
+		if ( ! empty( $assoc_args['apply'] ) ) {
+			$input['apply'] = true;
+		}
+
+		$format     = $assoc_args['format'] ?? 'table';
+		$all_sites  = ! empty( $assoc_args['all-sites'] );
+
+		if ( $all_sites && is_multisite() ) {
+			$this->run_across_network( $input, $format );
+			return;
+		}
+
+		$result = $this->execute_one( $input );
+		$this->emit( $result, $format );
+	}
+
+	/**
+	 * Iterates the network, invoking the ability per site and aggregating.
+	 */
+	private function run_across_network( array $input, string $format ): void {
+		$sites = get_sites( array( 'number' => 0 ) );
+		if ( empty( $sites ) ) {
+			WP_CLI::warning( 'No sites found.' );
+			return;
+		}
+
+		$rows = array();
+		foreach ( $sites as $site ) {
+			$blog_id = (int) $site->blog_id;
+			switch_to_blog( $blog_id );
+
+			$result = $this->execute_one( $input );
+
+			$summary = is_array( $result ) && isset( $result['summary'] ) && is_array( $result['summary'] )
+				? $result['summary']
+				: array();
+
+			$rows[] = array_merge(
+				array(
+					'blog_id' => $blog_id,
+					'url'     => get_site_url( $blog_id ),
+				),
+				$summary
+			);
+
+			restore_current_blog();
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $rows, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		// Pick a stable column set across rows for table output.
+		$fields = ! empty( $rows ) ? array_keys( $rows[0] ) : array( 'blog_id', 'url' );
+		\WP_CLI\Utils\format_items( 'table', $rows, $fields );
+	}
+
+	/**
+	 * Invokes the ability for the current site context.
+	 *
+	 * @return array
+	 */
+	private function execute_one( array $input ): array {
+		$ability = wp_get_ability( 'datamachine/media-hygiene' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Media Hygiene ability not registered. Ensure Data Machine Business is active and WordPress 6.9+ is available.' );
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Unknown error.' );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Emits a single-site result in the requested format.
+	 */
+	private function emit( array $result, string $format ): void {
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$summary = is_array( $result['summary'] ?? null ) ? $result['summary'] : array();
+		$results = is_array( $result['results'] ?? null ) ? $result['results'] : array();
+
+		if ( ! empty( $summary ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Summary:' );
+			$summary_rows = array();
+			foreach ( $summary as $k => $v ) {
+				$summary_rows[] = array(
+					'metric' => $k,
+					'value'  => is_scalar( $v ) ? (string) $v : wp_json_encode( $v ),
+				);
+			}
+			\WP_CLI\Utils\format_items( 'table', $summary_rows, array( 'metric', 'value' ) );
+		}
+
+		if ( 'count' === $format ) {
+			WP_CLI::line( (string) count( $results ) );
+			return;
+		}
+
+		if ( empty( $results ) ) {
+			return;
+		}
+
+		// Per-item results table.
+		$fields = array_keys( reset( $results ) );
+		\WP_CLI\Utils\format_items( $format, $results, $fields );
+	}
+}


### PR DESCRIPTION
Closes #29

## What this does

Adds detection + gated deletion for two classes of dead-weight media:

1. **Orphan files on disk** — files in `wp-content/uploads/` with no matching attachment row
2. **Unused attachments** — `post_type=attachment` rows referenced nowhere in `post_content`, `postmeta`, term descriptions, or options

Plus a `diagnose` action that rolls both up into a single summary report.

## Surface

### Ability

`datamachine/media-hygiene` (category `datamachine-media`)

| Action | Purpose | Destructive? |
|---|---|---|
| `diagnose` | Roll-up summary: orphan-file count + bytes, unused-attachment count + bytes, total reclaimable | No |
| `orphan-files` | List orphan files on disk | No |
| `unused` | List zero-reference attachments | No |
| `delete-orphans` | Delete orphan files (requires `apply=true`) | Gated |
| `delete-unused` | Delete unused attachments via `wp_delete_attachment( id, true )` (requires `apply=true`) | Gated |

### CLI

```
wp datamachine media diagnose                           # current site
wp datamachine media diagnose --all-sites               # iterate the network
wp datamachine media orphan-files --limit=100
wp datamachine media unused --limit=200 --format=json
wp datamachine media delete-unused --limit=50           # dry-run preview
wp datamachine media delete-unused --limit=50 --apply   # actually delete
```

## Safety

- **Dry-run by default** — all delete actions return a preview unless `apply=true` is explicitly passed
- **Hard cap of 1000 deletes per invocation**, default 100
- **Variant-aware** — filenames from `_wp_attachment_metadata` (thumbnail, medium, large, scaled, original_image) are pulled into a lookup table so resized variants are never falsely flagged as orphans
- **Reference probe checks both basename AND literal attachment ID** — catches `_thumbnail_id` integer storage, ACF image fields storing IDs, gallery shortcodes referencing IDs, theme mods storing logo IDs, etc.
- **Multisite-correct** — `--all-sites` iterates via `get_sites()` + `switch_to_blog()`; per-site upload directories resolved via `wp_get_upload_dir()` under each site's context, so `wp-content/uploads/sites/N/` is scoped correctly to site N
- **Skips known-managed subdirs** — `cache/`, `breeze/`, `datamachine-files/`, `wc-logs/`, `backup/` (Imagify originals, owned by a future `find-dead-imagify-backups` action), `fonts/`, etc.
- **Skips the network site's `sites/` tree** when running on the main site, because each subsite is scanned in its own `switch_to_blog()` context

## Architecture

- `inc/Abilities/MediaHygiene/MediaHygieneScanner.php` — shared filesystem + DB helpers (walk uploads, build attached-file index, build variant index, probe for references)
- `inc/Abilities/MediaHygiene/MediaHygieneAbility.php` — single ability that dispatches on `action`, owns all business logic per the project rule that business logic lives in abilities
- `inc/Cli/MediaHygieneCommand.php` — thin CLI wrapper that calls `wp_get_ability( 'datamachine/media-hygiene' )->execute( $input )` and handles output formatting + network iteration

Plugin loader hook in `data-machine-business.php` follows the existing pattern (sits next to `AmazonAffiliateLink` near the bottom of `datamachine_business_load_handlers()`).

## Filters

| Filter | Purpose |
|---|---|
| `datamachine_media_hygiene_extensions` | Override the scanned media file extension list |
| `datamachine_media_hygiene_ignored_dirs` | Override the list of `uploads/` subdirs to skip |

These let platform plugins (e.g. `extrachill-admin-tools`) add site-specific exclusions like `uploads/blogger/` (a 346 MB archived migration on extrachill.com we want to keep) without modifying core.

## Not in this PR (deferred to follow-ups)

Per the original issue, three more detectors were proposed:
- `find-duplicate-attachments` (sha1-grouped dupes)
- `find-dead-imagify-backups` (orphan files specifically under `*/backup/`)
- `media_hygiene_report` nightly system task

These are intentionally out of scope for this PR — the orphan + unused detectors are the 80/20 high-value primitives. Duplicate detection requires hashing every file (expensive on 12K+ libraries) and benefits from being its own focused ability with its own batched / async strategy. The dead-Imagify-backups detector and the nightly system task should land after this PR's surface has been validated in production.

## Validation

- [x] `php -l` clean on all four touched files
- [x] PSR-4 autoloader covers the new namespace (`DataMachineBusiness\\` → `inc/`) — no `composer dump-autoload` needed
- [x] Matches the existing `PageSpeedAbility` + `PageSpeedCommand` patterns (single ability dispatching on action, thin CLI wrapper, `PermissionHelper::can_manage()` gate, output-format options)
- [ ] **Manual smoke test happens post-deploy** — the deployed DMB doesn't have these files yet, so the CLI command can only be exercised after `homeboy release data-machine-business` + `homeboy deploy`

## Context

Filed after a disk-cleanup session on extrachill.com (2026-05-27) that recovered 51 GB of non-content waste but left 44 GB of `wp-content/uploads/` untouched because nothing on the system could tell us which images were dead weight. This PR is the precondition for taking another swing at that 44 GB.