### PR TITLE
fix: filter network_density GA report to in-network referrers server-side

### DIFF
--- a/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
+++ b/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
@@ -395,6 +395,60 @@ class GoogleAnalyticsAbilities {
 			);
 		}
 
+		// In-network referrer filter for network_density.
+		//
+		// network_density groups by hostName x pageReferrer. pageReferrer is a
+		// near-unbounded, high-cardinality dimension, so the single-page GA4 row
+		// cap fills with the largest external/"(other)" referrer buckets and the
+		// small in-network EC->EC referrer rows fall off the end — silently
+		// under-counting in-network referrals. Constrain pageReferrer to EC hosts
+		// server-side so GA4 only returns in-network rows BEFORE the cap applies,
+		// keeping it one cheap API call (there are far fewer than the row cap of
+		// distinct in-network referrer buckets) and making the result
+		// volume-independent.
+		if ( 'network_density' === $action ) {
+			// Source the EC host set from a filter so it lives in one place
+			// rather than as a brittle inline literal at the call site.
+			$network_hosts = apply_filters(
+				'datamachine_network_density_hosts',
+				array( 'extrachill.com', 'extrachill.link' )
+			);
+
+			$host_expressions = array();
+			foreach ( (array) $network_hosts as $host ) {
+				$host = sanitize_text_field( $host );
+				if ( '' === $host ) {
+					continue;
+				}
+				// CONTAINS covers the apex host and every subdomain
+				// (e.g. "extrachill.com" matches both "extrachill.com" and
+				// "community.extrachill.com"), so wildcard subdomains are
+				// implicit and do not need separate patterns.
+				$host_expressions[] = array(
+					'filter' => array(
+						'fieldName'    => 'pageReferrer',
+						'stringFilter' => array(
+							'matchType' => 'CONTAINS',
+							'value'     => $host,
+						),
+					),
+				);
+			}
+
+			if ( ! empty( $host_expressions ) ) {
+				// A single OR group of pageReferrer CONTAINS expressions is one
+				// filter expression, so it composes with any hostname filter via
+				// the existing 1-vs-andGroup path below.
+				$filters[] = count( $host_expressions ) === 1
+					? $host_expressions[0]
+					: array(
+						'orGroup' => array(
+							'expressions' => $host_expressions,
+						),
+					);
+			}
+		}
+
 		if ( count( $filters ) === 1 ) {
 			$request_body['dimensionFilter'] = $filters[0];
 		} elseif ( count( $filters ) > 1 ) {

--- a/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
@@ -229,6 +229,128 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 156, $users['next_users'] );
 	}
 
+	/**
+	 * network_density must constrain pageReferrer to the in-network EC hosts
+	 * server-side so the GA4 row cap can't truncate the in-network referrer
+	 * long tail. With no other filter, the single dimensionFilter is the OR
+	 * group of pageReferrer CONTAINS expressions for the default host set.
+	 */
+	public function test_network_density_filters_referrer_to_in_network_hosts(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'start_date' => '2026-01-01',
+				'end_date'   => '2026-01-31',
+			),
+			'network_density'
+		);
+
+		$this->assertArrayHasKey(
+			'dimensionFilter',
+			$body,
+			'network_density must emit an in-network pageReferrer dimensionFilter'
+		);
+		$this->assertArrayHasKey(
+			'orGroup',
+			$body['dimensionFilter'],
+			'Default multi-host set must produce an orGroup of pageReferrer expressions'
+		);
+
+		$expressions = $body['dimensionFilter']['orGroup']['expressions'];
+		$this->assertCount( 2, $expressions, 'Default EC host set has two hosts' );
+
+		foreach ( $expressions as $expr ) {
+			$filter = $expr['filter'];
+			$this->assertSame( 'pageReferrer', $filter['fieldName'] );
+			$this->assertSame( 'CONTAINS', $filter['stringFilter']['matchType'] );
+		}
+
+		$values = array_map(
+			static fn( $e ) => $e['filter']['stringFilter']['value'],
+			$expressions
+		);
+		$this->assertContains( 'extrachill.com', $values );
+		$this->assertContains( 'extrachill.link', $values );
+	}
+
+	/**
+	 * The in-network host set is config/filter-driven, not an inline literal.
+	 */
+	public function test_network_density_hosts_are_filterable(): void {
+		$callback = static fn() => array( 'example.test' );
+		add_filter( 'datamachine_network_density_hosts', $callback );
+
+		try {
+			$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+				array(
+					'start_date' => '2026-01-01',
+					'end_date'   => '2026-01-31',
+				),
+				'network_density'
+			);
+		} finally {
+			remove_filter( 'datamachine_network_density_hosts', $callback );
+		}
+
+		// A single host collapses to one (non-grouped) filter expression.
+		$filter = $body['dimensionFilter']['filter'];
+		$this->assertSame( 'pageReferrer', $filter['fieldName'] );
+		$this->assertSame( 'example.test', $filter['stringFilter']['value'] );
+	}
+
+	/**
+	 * The network_density referrer filter ANDs with an explicit hostname filter
+	 * so a per-site density request stays scoped to that host while still only
+	 * counting in-network referrers.
+	 */
+	public function test_network_density_referrer_filter_ands_with_hostname(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'hostname'   => 'extrachill.com',
+				'start_date' => '2026-01-01',
+				'end_date'   => '2026-01-31',
+			),
+			'network_density'
+		);
+
+		$this->assertArrayHasKey( 'andGroup', $body['dimensionFilter'] );
+		$expressions = $body['dimensionFilter']['andGroup']['expressions'];
+		$this->assertCount( 2, $expressions );
+
+		$has_hostname = false;
+		$has_referrer_group = false;
+		foreach ( $expressions as $expr ) {
+			if ( isset( $expr['filter'] ) && 'hostName' === $expr['filter']['fieldName'] ) {
+				$has_hostname = true;
+			}
+			if ( isset( $expr['orGroup'] ) ) {
+				$referrer_fields = array_map(
+					static fn( $e ) => $e['filter']['fieldName'],
+					$expr['orGroup']['expressions']
+				);
+				$has_referrer_group = array( 'pageReferrer', 'pageReferrer' ) === $referrer_fields;
+			}
+		}
+
+		$this->assertTrue( $has_hostname, 'hostName EXACT filter must be present' );
+		$this->assertTrue( $has_referrer_group, 'in-network pageReferrer orGroup must be present' );
+	}
+
+	/**
+	 * network_density is the only report that gets the in-network referrer
+	 * filter — other actions must not emit a pageReferrer dimensionFilter.
+	 */
+	public function test_other_actions_do_not_get_referrer_filter(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'start_date' => '2026-01-01',
+				'end_date'   => '2026-01-31',
+			),
+			'date_stats'
+		);
+
+		$this->assertArrayNotHasKey( 'dimensionFilter', $body );
+	}
+
 	public static function all_filterable_actions(): array {
 		return array(
 			'page_stats'        => array( 'page_stats' ),


### PR DESCRIPTION
## Summary

Fixes #36 — `network_density` GA4 report silently under-counts in-network (EC→EC) referrals when session volume is high.

## Root cause

`network_density` groups by `hostName` × `pageReferrer` and flows through the shared `buildReportRequestBody()`:

- `--limit` is passed verbatim as the GA4 `runReport` page-size `"limit"` (one page).
- No `nextPageToken` pagination.
- No explicit `orderBys` by default → GA4 returns **top rows by sessions, descending**.

Because `pageReferrer` is a **near-unbounded, high-cardinality** dimension, the row budget fills with the largest external / `(other)` referrer buckets and the small in-network EC→EC referrer rows fall off the end. The per-site density math then biases **low and silently**, in a **volume-dependent** way — which is why it looked like a sudden cliff (S30 `0.48%` vs S29 `2.55%`) even though the independent UTM `network_bridge` channel *grew* +25% over the same window.

## The fix (server-side `dimensionFilter`, not pagination)

When `action === 'network_density'`, append a `pageReferrer` filter restricting results to EC hosts **before** the row cap applies, so GA4 only returns in-network referrer rows.

- There are far fewer than the row cap of distinct in-network referrer buckets, so the cap becomes irrelevant — it stays **one cheap API call** and becomes volume-independent.
- EC host set is **config/filter-driven**: `apply_filters( 'datamachine_network_density_hosts', [ 'extrachill.com', 'extrachill.link' ] )` — the set lives in one place, not as a brittle inline literal at the call site.
- Built as an **OR group of `pageReferrer` `CONTAINS` expressions** (apex-host `CONTAINS` also matches every subdomain, so wildcard subdomains like `community.extrachill.com` are implicit). A one-host set collapses to a single (non-grouped) filter.
- **Composes with any `hostname` filter** via the existing 1-vs-`andGroup` path, so per-site density requests stay scoped to that host while still only counting in-network referrers.
- Consumers still bucket in-network vs external as today; the change just guarantees the in-network rows are complete.

## Pagination intentionally skipped

The issue lists `nextPageToken` pagination as an **optional secondary follow-up only**. For `network_density` it is strictly *worse* — it would fetch the entire unbounded external referrer long tail (many API round-trips + quota) just to discard all the external rows. The `dimensionFilter` is the correct, cheaper fix. If a generic "no report ever truncates" pagination is desired for other reports (e.g. `page_stats`), it should be tracked as its own business-plugin-local issue against `fetchReport()` — **not** added to data-machine core (layer purity).

## Layer purity

The change is entirely business-plugin-local (`data-machine-business/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php`). No GA4/`runReport`/pagination logic was added to data-machine core.

## Tests

- Extended `tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php` (WP_UnitTestCase) with four focused cases: default host set → `orGroup` of `pageReferrer` `CONTAINS`; host set is filter-driven (single host collapses to one filter); referrer filter ANDs with `hostname`; other actions get no referrer filter.
- The WP test DB harness (`homeboy test`) and the lint harness (`homeboy lint`) both fail in this environment with the known environmental `runner-steps.sh: No such file or directory` error ("No tests ran — runner failed before producing results"), so I additionally validated the request-body shaping with a standalone smoke test mirroring the four cases (plus an all-empty-host edge case) — **14/14 assertions pass**.
- `phpcs --standard=WordPress` reports **34 errors before and after** my changes (all pre-existing camelCase/file-naming debt the project allows) — **zero new violations** introduced. `homeboy lint` reports **0 findings** for the code (it only exits non-zero due to the broken harness script).

## Acceptance criteria
- [x] `network_density` returns complete in-network referrer rows independent of total session volume / `--limit`.
- [x] EC host set is config/filter-driven, not an inline literal in the GA4 request builder.
- [x] No GA4-specific pagination/runReport logic added to data-machine core.