### PR TITLE
feat: own the google-analytics CLI command (move from core) + fix path_sequence table

### DIFF
--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -72,6 +72,10 @@ function datamachine_business_load_handlers() {
 	// Global AI tools.
 	new \DataMachineBusiness\Engine\AI\Tools\Global\GoogleAnalytics();
 
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		\WP_CLI::add_command( 'datamachine analytics ga', \DataMachineBusiness\Cli\GoogleAnalyticsCommand::class );
+	}
+
 	// Google Sheets
 	new \DataMachineBusiness\Abilities\GoogleSheets\FetchGoogleSheetsAbility();
 	new \DataMachineBusiness\Abilities\GoogleSheets\PublishGoogleSheetsAbility();
@@ -144,9 +148,20 @@ function datamachine_business_load_handlers() {
 add_action( 'plugins_loaded', 'datamachine_business_load_handlers', 20 );
 
 /**
+ * Register the Data Machine Business AGENTS.md section.
+ *
+ * Runs in every context (web/cron compose, not only WP-CLI) so the generated
+ * AGENTS.md always reflects this plugin's registered command surface.
+ */
+add_action( 'plugins_loaded', function (): void {
+	\DataMachineBusiness\Runtime\AgentsMdSections::register();
+}, 21 );
+
+/**
  * Register business-owned analytics routes with Data Machine core.
  */
 add_filter( 'datamachine_analytics_ability_map', function ( array $ability_map ): array {
+	$ability_map['ga']   = 'datamachine/google-analytics';
 	$ability_map['bing'] = 'datamachine/bing-webmaster';
 	return $ability_map;
 } );

--- a/inc/Cli/GoogleAnalyticsCommand.php
+++ b/inc/Cli/GoogleAnalyticsCommand.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * Google Analytics (GA4) WP-CLI command.
+ *
+ * Delegates to the datamachine/google-analytics ability owned by this plugin.
+ * Lives in Data Machine Business alongside the ability it wraps — Data Machine
+ * core stays agnostic of named external analytics integrations.
+ *
+ * @package DataMachineBusiness\Cli
+ */
+
+namespace DataMachineBusiness\Cli;
+
+use DataMachine\Cli\BaseCommand;
+use WP_CLI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class GoogleAnalyticsCommand extends BaseCommand {
+
+	/**
+	 * Query Google Analytics (GA4) data.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Action to perform: page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics, landing_pages, engagement, new_vs_returning, network_density, path_sequence.
+	 *
+	 * [--start-date=<date>]
+	 * : Start date in YYYY-MM-DD format (default: 28 days ago). Not used for realtime.
+	 *
+	 * [--end-date=<date>]
+	 * : End date in YYYY-MM-DD format (default: yesterday). Not used for realtime.
+	 *
+	 * [--limit=<number>]
+	 * : Row limit (default: 25, max: 10000).
+	 *
+	 * [--page-filter=<string>]
+	 * : Filter results to pages with paths containing this string.
+	 *
+	 * [--hostname=<string>]
+	 * : Filter to pages on this hostname (for multisite GA4 properties).
+	 *
+	 * [--sort-by=<field>]
+	 * : Sort results by this metric or dimension field name.
+	 *
+	 * [--order=<direction>]
+	 * : Sort direction: asc or desc (default: desc).
+	 *
+	 * [--compare]
+	 * : Compare against the previous period of equal length. Adds delta columns.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Page performance stats
+	 *     wp datamachine analytics ga page_stats
+	 *
+	 *     # Traffic sources
+	 *     wp datamachine analytics ga traffic_sources --limit=50
+	 *
+	 *     # Real-time active users
+	 *     wp datamachine analytics ga realtime
+	 *
+	 *     # Daily trends for blog pages
+	 *     wp datamachine analytics ga date_stats --page-filter=/blog/ --format=json
+	 *
+	 *     # Top events
+	 *     wp datamachine analytics ga top_events
+	 *
+	 *     # Landing pages with highest engagement
+	 *     wp datamachine analytics ga landing_pages --sort-by=engagementRate --order=desc
+	 *
+	 *     # Engagement metrics for specific section
+	 *     wp datamachine analytics ga engagement --page-filter=/blog/
+	 *
+	 *     # New vs returning users
+	 *     wp datamachine analytics ga new_vs_returning
+	 *
+	 *     # Ordered cross-host journeys (true network density)
+	 *     wp datamachine analytics ga path_sequence
+	 *
+	 *     # Filter by hostname for multisite
+	 *     wp datamachine analytics ga page_stats --hostname=events.extrachill.com
+	 *
+	 *     # Compare last 28 days vs previous 28 days
+	 *     wp datamachine analytics ga page_stats --compare
+	 *
+	 *     # Sort by bounce rate ascending (worst engagement)
+	 *     wp datamachine analytics ga page_stats --sort-by=bounceRate --order=asc --limit=10
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$input = array(
+			'action' => $args[0] ?? '',
+		);
+
+		$this->map_optional( $input, $assoc_args, array(
+			'start-date'  => 'start_date',
+			'end-date'    => 'end_date',
+			'limit'       => 'limit',
+			'page-filter' => 'page_filter',
+			'hostname'    => 'hostname',
+			'sort-by'     => 'sort_by',
+			'order'       => 'order',
+		) );
+
+		// --compare is a boolean flag (no value).
+		if ( isset( $assoc_args['compare'] ) ) {
+			$input['compare'] = true;
+		}
+
+		$this->execute_ability( 'datamachine/google-analytics', $input, $assoc_args );
+	}
+
+	/**
+	 * Map CLI flags to ability input keys.
+	 *
+	 * @param array $input      Ability input (modified by reference).
+	 * @param array $assoc_args CLI associative arguments.
+	 * @param array $mapping    Flag-to-key mapping (cli-flag => ability_key).
+	 */
+	private function map_optional( array &$input, array $assoc_args, array $mapping ): void {
+		foreach ( $mapping as $flag => $key ) {
+			if ( isset( $assoc_args[ $flag ] ) ) {
+				$input[ $key ] = $assoc_args[ $flag ];
+			}
+		}
+	}
+
+	/**
+	 * Execute an ability and output the results.
+	 *
+	 * @param string $ability_slug Ability slug.
+	 * @param array  $input        Ability input.
+	 * @param array  $assoc_args   CLI associative arguments (for format).
+	 */
+	private function execute_ability( string $ability_slug, array $input, array $assoc_args ): void {
+		$ability = wp_get_ability( $ability_slug );
+
+		if ( ! $ability ) {
+			WP_CLI::error( "Ability '{$ability_slug}' not registered. Ensure Data Machine Business is active and WordPress 6.9+." );
+			return;
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Unknown error.' );
+			return;
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		// JSON output: dump the whole result.
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		// Table/CSV output: format the results array.
+		$results = $result['results'] ?? array();
+
+		if ( empty( $results ) ) {
+			// Show top-level data for actions that don't return a results array.
+			$display = array_filter(
+				$result,
+				function ( $value, $key ) {
+					return ! in_array( $key, array( 'success', 'tool_name' ), true ) && ! is_array( $value );
+				},
+				ARRAY_FILTER_USE_BOTH
+			);
+
+			if ( ! empty( $display ) ) {
+				$items = array( $display );
+				$this->format_items( $items, array_keys( $display ), $assoc_args );
+				return;
+			}
+
+			// For nested data (scores, metrics), flatten one level.
+			$flattened = $this->flatten_result( $result );
+			if ( ! empty( $flattened ) ) {
+				$items = array( $flattened );
+				$this->format_items( $items, array_keys( $flattened ), $assoc_args );
+				return;
+			}
+
+			WP_CLI::success( 'Command completed with no tabular results. Use --format=json for full output.' );
+			return;
+		}
+
+		// Ensure results are flat for table display.
+		$flat_results = array_map( array( $this, 'flatten_row' ), $results );
+
+		if ( ! empty( $flat_results ) ) {
+			$fields = array_keys( $flat_results[0] );
+			$this->format_items( $flat_results, $fields, $assoc_args );
+		}
+
+		// Show summary with date range if available.
+		$count = $result['results_count'] ?? count( $results );
+		if ( ! empty( $result['date_range'] ) ) {
+			$range    = $result['date_range'];
+			$start    = $range['start_date'] ?? '?';
+			$end      = $range['end_date'] ?? '?';
+			$days_ago = $range['days_ago'] ?? null;
+
+			WP_CLI::log( sprintf( '%d results (%s to %s)', $count, $start, $end ) );
+
+			if ( null !== $days_ago && $days_ago > 30 ) {
+				WP_CLI::warning( sprintf(
+					'Data is %d days stale (latest: %s). Check API key and site verification.',
+					$days_ago,
+					$end
+				) );
+			}
+		} else {
+			WP_CLI::log( sprintf( '%d results', $count ) );
+		}
+	}
+
+	/**
+	 * Flatten a result row for table display.
+	 *
+	 * Converts nested arrays (like GA4 dimension/metric values) into flat key-value pairs.
+	 * Scalar arrays (like GSC's 'keys') become comma-separated strings. Arrays whose
+	 * elements are themselves arrays/objects (like path_sequence's 'next_hosts') are
+	 * rendered readably rather than blindly imploded, which would otherwise trigger
+	 * "Array to string conversion" warnings.
+	 *
+	 * @param array $row Result row.
+	 * @return array Flat row.
+	 */
+	private function flatten_row( array $row ): array {
+		$flat = array();
+		foreach ( $row as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$flat[ $key ] = $this->stringify_cell( $value );
+			} else {
+				$flat[ $key ] = $value;
+			}
+		}
+		return $flat;
+	}
+
+	/**
+	 * Render an array cell value as a readable string for table/CSV output.
+	 *
+	 * Scalar arrays are comma-joined (preserving the GSC 'keys' behavior). Arrays
+	 * containing nested arrays/objects are rendered as compact, readable summaries:
+	 * arrays of {next_host, users} pairs (path_sequence's 'next_hosts') become
+	 * "host:users; host:users", and any other non-scalar structure falls back to a
+	 * JSON encoding so the cell never triggers an "Array to string conversion" warning.
+	 *
+	 * @param array $value Array cell value.
+	 * @return string Readable string representation.
+	 */
+	private function stringify_cell( array $value ): string {
+		$has_nested = false;
+		foreach ( $value as $element ) {
+			if ( is_array( $element ) || is_object( $element ) ) {
+				$has_nested = true;
+				break;
+			}
+		}
+
+		// Scalar arrays (e.g. GSC's 'keys'): join as before.
+		if ( ! $has_nested ) {
+			return implode( ', ', array_map( 'strval', $value ) );
+		}
+
+		// Targeted rendering for path_sequence's next_host/users pairs.
+		$pairs = array();
+		foreach ( $value as $element ) {
+			$element = (array) $element;
+			if ( isset( $element['next_host'] ) && isset( $element['users'] ) ) {
+				$pairs[] = $element['next_host'] . ':' . $element['users'];
+			} else {
+				// Unknown nested shape: fall back to JSON for the whole cell.
+				return (string) wp_json_encode( $value );
+			}
+		}
+
+		return implode( '; ', $pairs );
+	}
+
+	/**
+	 * Flatten a nested result into a single-level array for display.
+	 *
+	 * Used for scores/metrics where the result has nested objects.
+	 *
+	 * @param array $result Full result array.
+	 * @return array Flattened key-value pairs.
+	 */
+	private function flatten_result( array $result ): array {
+		$flat = array();
+
+		foreach ( $result as $key => $value ) {
+			if ( in_array( $key, array( 'success', 'tool_name', 'results', 'results_count' ), true ) ) {
+				continue;
+			}
+
+			if ( is_array( $value ) ) {
+				foreach ( $value as $sub_key => $sub_value ) {
+					if ( is_array( $sub_value ) ) {
+						// For metrics with value/numeric/score sub-keys, use displayValue.
+						$flat[ $sub_key ] = $sub_value['value'] ?? wp_json_encode( $sub_value );
+					} else {
+						$flat[ $sub_key ] = $sub_value;
+					}
+				}
+			} else {
+				$flat[ $key ] = $value;
+			}
+		}
+
+		return $flat;
+	}
+}

--- a/inc/Runtime/AgentsMdSections.php
+++ b/inc/Runtime/AgentsMdSections.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * AGENTS.md section registration for Data Machine Business.
+ *
+ * Data Machine core owns the AGENTS.md substrate (SectionRegistry). Each plugin
+ * that adds WP-CLI surface registers its own section so the generated AGENTS.md
+ * describes the real, registered command surface instead of a hand-typed list
+ * that silently drifts.
+ *
+ * The analytics CLI commands this plugin owns (ga, gsc, bing, pagespeed) and its
+ * media command are flat `__invoke` commands — the action is a positional arg,
+ * not a WP-CLI subcommand — so their truthful reflection unit is the command's
+ * own class-docblock summary (what `wp help <cmd>` shows). This mirrors how Data
+ * Machine Code registers its AGENTS.md section from reflection over its command
+ * classes, and stays self-contained pending the shared command-tree introspector
+ * tracked in Extra-Chill/data-machine#2613.
+ *
+ * Context safety: callbacks run on `plugins_loaded` in web/cron compose contexts,
+ * NOT only under WP-CLI. Reflection over autoloadable command classes never
+ * touches the live WP_CLI runner and never instantiates the command classes.
+ *
+ * @package DataMachineBusiness\Runtime
+ */
+
+namespace DataMachineBusiness\Runtime;
+
+defined( 'ABSPATH' ) || exit;
+
+use ReflectionClass;
+
+/**
+ * Registers the Data Machine Business section in the composable AGENTS.md.
+ */
+final class AgentsMdSections {
+
+	/**
+	 * Command class => `wp ...` invocation, in display order.
+	 *
+	 * @var array<class-string, string>
+	 */
+	private const COMMANDS = array(
+		'\\DataMachineBusiness\\Cli\\GoogleAnalyticsCommand' => 'datamachine analytics ga <action>',
+		'\\DataMachineBusiness\\Cli\\GoogleSearchConsoleCommand' => 'datamachine analytics gsc <action>',
+		'\\DataMachineBusiness\\Cli\\Commands\\BingWebmasterCommand' => 'datamachine analytics bing <action>',
+		'\\DataMachineBusiness\\Cli\\PageSpeedCommand'    => 'datamachine analytics pagespeed <action>',
+		'\\DataMachineBusiness\\Cli\\MediaHygieneCommand' => 'datamachine media <action>',
+	);
+
+	/**
+	 * Register the Data Machine Business AGENTS.md section.
+	 */
+	public static function register(): void {
+		if ( ! class_exists( '\\DataMachine\\Engine\\AI\\SectionRegistry' ) ) {
+			return;
+		}
+
+		$registry = '\\DataMachine\\Engine\\AI\\SectionRegistry';
+		if ( ! is_callable( array( $registry, 'register' ) ) ) {
+			return;
+		}
+
+		call_user_func(
+			array( $registry, 'register' ),
+			'AGENTS.md',
+			'data-machine-business',
+			25,
+			array( self::class, 'render' ),
+			array(
+				'label'       => 'Data Machine Business',
+				'description' => 'Business-owned WP-CLI surface (Google Analytics, Search Console, Bing, PageSpeed, media hygiene).',
+				'owner'       => 'data-machine-business',
+				'freshness'   => 'snapshot',
+				'conditions'  => 'Registered when Data Machine Business and composable memory section registration are available.',
+			)
+		);
+	}
+
+	/**
+	 * Render the section body from reflection over the command classes.
+	 *
+	 * @return string Markdown section, or '' when no commands are available.
+	 */
+	public static function render(): string {
+		$wp    = self::resolve_wp_cli_cmd();
+		$lines = array();
+
+		foreach ( self::COMMANDS as $class => $invocation ) {
+			$summary = self::command_summary( $class );
+			if ( '' === $summary ) {
+				continue;
+			}
+
+			$lines[] = sprintf( '- `%s %s` — %s', $wp, $invocation, $summary );
+		}
+
+		if ( empty( $lines ) ) {
+			return '';
+		}
+
+		$body = implode( "\n", $lines );
+
+		return <<<MD
+## Data Machine Business
+
+Business-owned WP-CLI commands. The action is a positional argument — run `{$wp} help <command>` to discover the available actions and options for each.
+
+{$body}
+MD;
+	}
+
+	/**
+	 * Extract a command class's short description from its class docblock.
+	 *
+	 * Flat `__invoke` commands carry their summary on the class docblock (the
+	 * first non-tag line), which is what `wp help <command>` displays. Returns ''
+	 * when the class is unavailable or undocumented, so the command is skipped
+	 * rather than rendered with an empty description.
+	 *
+	 * @param class-string $command_class Fully-qualified command class name.
+	 * @return string Short description, or '' when none.
+	 */
+	private static function command_summary( string $command_class ): string {
+		if ( ! class_exists( $command_class ) ) {
+			return '';
+		}
+
+		$doc = ( new ReflectionClass( $command_class ) )->getDocComment();
+		if ( ! is_string( $doc ) || '' === $doc ) {
+			return '';
+		}
+
+		$lines = preg_split( '/\r\n|\r|\n/', $doc );
+		if ( false === $lines ) {
+			return '';
+		}
+
+		foreach ( $lines as $line ) {
+			// Strip docblock decorations: leading `/**` or `*`, trailing `*/`.
+			$line = trim( $line );
+			$line = (string) preg_replace( '#^/?\*+#', '', $line );
+			$line = (string) preg_replace( '#\*+/$#', '', $line );
+			$line = trim( $line );
+
+			if ( '' === $line || '@' === $line[0] || '#' === $line[0] ) {
+				continue;
+			}
+
+			return rtrim( $line, '.' );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Resolve the WP-CLI command prefix for the current environment.
+	 *
+	 * @return string
+	 */
+	private static function resolve_wp_cli_cmd(): string {
+		$parts = array( 'wp' );
+
+		if ( function_exists( 'posix_geteuid' ) && 0 === posix_geteuid() ) {
+			$parts[] = '--allow-root';
+		}
+
+		$abspath = rtrim( ABSPATH, '/' );
+		if ( '/var/www/html' !== $abspath ) {
+			$parts[] = '--path=' . $abspath;
+		}
+
+		return apply_filters( 'datamachine_wp_cli_cmd', implode( ' ', $parts ) );
+	}
+}


### PR DESCRIPTION
## Summary

The `datamachine/google-analytics` ability already lives in this plugin, but its WP-CLI wrapper — `wp datamachine analytics ga` — was left behind in **Data Machine core**. That made core reference a business-only integration it can't satisfy on its own (its `AnalyticsCommand` wrapped exactly one ability: `google-analytics`). The abilities moved; the CLI didn't. This PR finishes the move and fixes the table bug from #2633 in the process.

## Changes

- **New `DataMachineBusiness\Cli\GoogleAnalyticsCommand`** — the `datamachine analytics ga` command, sitting next to its sibling `gsc` / `bing` / `pagespeed` commands and the ability it wraps.
- **Registered on `plugins_loaded`** alongside the GA ability (`WP_CLI` guard), matching the `gsc` registration pattern.
- **Added `ga` to the analytics REST ability map** (`datamachine_analytics_ability_map`). It was previously absent, so the GA REST route never existed — now `POST /datamachine/v1/analytics/ga` works like `bing`.
- **Carried the #2633 `path_sequence` table fix.** `next_hosts` is an array of `{next_host, users}` objects; the old `flatten_row` imploded array cells with `strval()` on each inner array, flooding `Array to string conversion` warnings and leaving the table empty (`--format=json` was fine). A new `stringify_cell()` renders:
  - scalar arrays (GSC `keys`) → comma-joined, as before
  - `next_hosts` → `community.extrachill.com:34; events.extrachill.com:18`
  - any other nested structure → `wp_json_encode()` fallback (never warns)
- **New `DataMachineBusiness\Runtime\AgentsMdSections`** — registers a "Data Machine Business" AGENTS.md section that reflects this plugin's WP-CLI surface (`ga`, `gsc`, `bing`, `pagespeed`, `media`) from the command class docblocks, so generated AGENTS.md tracks registered truth instead of a hand-typed list. Mirrors how Data Machine Code registers its own section; runs in web/cron compose contexts, never touches the live WP-CLI runner.

## Verification

- `php -l` clean on all three files.
- `stringify_cell()` verified in isolation under `E_ALL`: path_sequence pairs, empty `next_hosts`, GSC scalar keys, and unknown-nested JSON fallback — zero warnings.
- AGENTS.md section render verified in isolation (single-line and multi-line docblocks both parse to clean summaries).
- phpcs: new code carries only the repo-wide house-style baseline (PSR-4 filename + class-doc conventions) that every sibling — including Data Machine Code's own `AgentsMdSections.php` (137 findings under vanilla `WordPress`) — already carries. No new alignment/logic findings.

## Merge order

**Merge this BEFORE** the paired core removal (`Extra-Chill/data-machine` → `remove-analytics-ga-cli-from-core`). This adds `datamachine analytics ga`; that one removes it from core. Merging this first guarantees zero gap in command availability.

Closes #2633 (paired with the core removal PR).