### PR TITLE
refactor: reflect DMB AGENTS.md CLI surface via shared __invoke-aware introspector

### DIFF
--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -72,10 +72,6 @@ function datamachine_business_load_handlers() {
 	// Global AI tools.
 	new \DataMachineBusiness\Engine\AI\Tools\Global\GoogleAnalytics();
 
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		\WP_CLI::add_command( 'datamachine analytics ga', \DataMachineBusiness\Cli\GoogleAnalyticsCommand::class );
-	}
-
 	// Google Sheets
 	new \DataMachineBusiness\Abilities\GoogleSheets\FetchGoogleSheetsAbility();
 	new \DataMachineBusiness\Abilities\GoogleSheets\PublishGoogleSheetsAbility();
@@ -97,10 +93,6 @@ function datamachine_business_load_handlers() {
 	new \DataMachineBusiness\Tools\PageSpeedTool();
 	\DataMachineBusiness\Api\PageSpeedAnalytics::register();
 
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		\WP_CLI::add_command( 'datamachine analytics pagespeed', \DataMachineBusiness\Cli\PageSpeedCommand::class );
-	}
-
 	// Google Custom Search API tool.
 	new \DataMachineBusiness\Tools\GoogleSearch();
 
@@ -108,10 +100,6 @@ function datamachine_business_load_handlers() {
 	// existing service-account configuration is adopted without migration.
 	new \DataMachineBusiness\Tools\GoogleSearchConsole();
 	\DataMachineBusiness\Api\GoogleSearchConsoleAnalytics::register();
-
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		\WP_CLI::add_command( 'datamachine analytics gsc', \DataMachineBusiness\Cli\GoogleSearchConsoleCommand::class );
-	}
 
 	// Slack
 	new \DataMachineBusiness\Abilities\Slack\PostMessageSlackAbility();
@@ -138,10 +126,6 @@ function datamachine_business_load_handlers() {
 
 	// Media Hygiene — orphan files + unused attachments.
 	new \DataMachineBusiness\Abilities\MediaHygiene\MediaHygieneAbility();
-
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		\WP_CLI::add_command( 'datamachine media', \DataMachineBusiness\Cli\MediaHygieneCommand::class );
-	}
 }
 
 // Hook into plugins_loaded to ensure Data Machine core is loaded first
@@ -168,13 +152,19 @@ add_filter( 'datamachine_analytics_ability_map', function ( array $ability_map )
 
 /**
  * Register business-owned WP-CLI commands.
+ *
+ * The command-string => class map in DataMachineBusiness\Cli\CommandRegistry is
+ * the single source of truth shared with the AGENTS.md section generator, so
+ * the documented command surface can never drift from what is registered.
  */
 add_action( 'plugins_loaded', function (): void {
 	if ( ! defined( 'WP_CLI' ) || ! WP_CLI || ! class_exists( 'DataMachine\\Cli\\BaseCommand' ) ) {
 		return;
 	}
 
-	\WP_CLI::add_command( 'datamachine analytics bing', \DataMachineBusiness\Cli\Commands\BingWebmasterCommand::class );
+	foreach ( \DataMachineBusiness\Cli\CommandRegistry::map() as $command => $command_class ) {
+		\WP_CLI::add_command( $command, $command_class );
+	}
 }, 21 );
 
 /**

--- a/inc/Cli/CommandRegistry.php
+++ b/inc/Cli/CommandRegistry.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * WP-CLI Command Registry for Data Machine Business.
+ *
+ * Single source of truth mapping `wp datamachine ...` command strings to the
+ * command classes that implement them. Both the WP-CLI bootstrap (which calls
+ * WP_CLI::add_command for each entry) and the AGENTS.md section generator
+ * (which reflects over each class to describe the real command surface) read
+ * from this map, so the documented CLI surface can never drift from what is
+ * actually registered.
+ *
+ * @package DataMachineBusiness\Cli
+ */
+
+namespace DataMachineBusiness\Cli;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Canonical map of Data Machine Business WP-CLI commands.
+ */
+final class CommandRegistry {
+
+	/**
+	 * Map of command string => fully-qualified command class.
+	 *
+	 * Keys are the exact strings passed to WP_CLI::add_command (the command
+	 * namespace, e.g. "datamachine analytics ga"). Order here determines both
+	 * registration order and documentation order.
+	 *
+	 * Every command this plugin owns is a flat `__invoke` command — the action
+	 * is a positional argument, not a WP-CLI subcommand — so each reflects to a
+	 * single `__default` entry carrying the command's own short description.
+	 *
+	 * @return array<string, class-string>
+	 */
+	public static function map(): array {
+		return array(
+			'datamachine analytics ga'        => GoogleAnalyticsCommand::class,
+			'datamachine analytics gsc'       => GoogleSearchConsoleCommand::class,
+			'datamachine analytics bing'      => Commands\BingWebmasterCommand::class,
+			'datamachine analytics pagespeed' => PageSpeedCommand::class,
+			'datamachine media'               => MediaHygieneCommand::class,
+		);
+	}
+}

--- a/inc/Runtime/AgentsMdSections.php
+++ b/inc/Runtime/AgentsMdSections.php
@@ -7,26 +7,31 @@
  * describes the real, registered command surface instead of a hand-typed list
  * that silently drifts.
  *
- * The analytics CLI commands this plugin owns (ga, gsc, bing, pagespeed) and its
- * media command are flat `__invoke` commands — the action is a positional arg,
- * not a WP-CLI subcommand — so their truthful reflection unit is the command's
- * own class-docblock summary (what `wp help <cmd>` shows). This mirrors how Data
- * Machine Code registers its AGENTS.md section from reflection over its command
- * classes, and stays self-contained pending the shared command-tree introspector
- * tracked in Extra-Chill/data-machine#2613.
+ * The command surface is read from {@see \DataMachineBusiness\Cli\CommandRegistry},
+ * the single source of truth shared with the WP-CLI bootstrap. Each command is
+ * reflected via the shared `\DataMachine\Engine\AI\CliCommandIntrospector`
+ * (the intelligence / extrachill-cli pattern) when present, with a minimal,
+ * self-contained fallback so this plugin never hard-depends on an unreleased
+ * core class. Every command this plugin owns is a flat `__invoke` command — the
+ * action is a positional argument, not a WP-CLI subcommand — so each reflects
+ * to a single `__default` entry and renders as a headline carrying the
+ * command's own short description.
  *
- * Context safety: callbacks run on `plugins_loaded` in web/cron compose contexts,
- * NOT only under WP-CLI. Reflection over autoloadable command classes never
- * touches the live WP_CLI runner and never instantiates the command classes.
+ * Context safety: callbacks run on `plugins_loaded` in web/cron compose
+ * contexts, NOT only under WP-CLI. Reflection over autoloadable command classes
+ * never touches the live WP_CLI runner and never instantiates the command
+ * classes.
  *
  * @package DataMachineBusiness\Runtime
  */
 
 namespace DataMachineBusiness\Runtime;
 
-defined( 'ABSPATH' ) || exit;
-
+use DataMachineBusiness\Cli\CommandRegistry;
 use ReflectionClass;
+use ReflectionMethod;
+
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Registers the Data Machine Business section in the composable AGENTS.md.
@@ -34,17 +39,11 @@ use ReflectionClass;
 final class AgentsMdSections {
 
 	/**
-	 * Command class => `wp ...` invocation, in display order.
+	 * Fully-qualified shared introspector class.
 	 *
-	 * @var array<class-string, string>
+	 * @var string
 	 */
-	private const COMMANDS = array(
-		'\\DataMachineBusiness\\Cli\\GoogleAnalyticsCommand' => 'datamachine analytics ga <action>',
-		'\\DataMachineBusiness\\Cli\\GoogleSearchConsoleCommand' => 'datamachine analytics gsc <action>',
-		'\\DataMachineBusiness\\Cli\\Commands\\BingWebmasterCommand' => 'datamachine analytics bing <action>',
-		'\\DataMachineBusiness\\Cli\\PageSpeedCommand'    => 'datamachine analytics pagespeed <action>',
-		'\\DataMachineBusiness\\Cli\\MediaHygieneCommand' => 'datamachine media <action>',
-	);
+	private const INTROSPECTOR = '\\DataMachine\\Engine\\AI\\CliCommandIntrospector';
 
 	/**
 	 * Register the Data Machine Business AGENTS.md section.
@@ -76,7 +75,7 @@ final class AgentsMdSections {
 	}
 
 	/**
-	 * Render the section body from reflection over the command classes.
+	 * Render the section body from reflection over the registered commands.
 	 *
 	 * @return string Markdown section, or '' when no commands are available.
 	 */
@@ -84,13 +83,37 @@ final class AgentsMdSections {
 		$wp    = self::resolve_wp_cli_cmd();
 		$lines = array();
 
-		foreach ( self::COMMANDS as $class => $invocation ) {
-			$summary = self::command_summary( $class );
-			if ( '' === $summary ) {
+		foreach ( CommandRegistry::map() as $command => $class ) {
+			$subcommands = self::describe_class( $class );
+			if ( empty( $subcommands ) ) {
 				continue;
 			}
 
-			$lines[] = sprintf( '- `%s %s` — %s', $wp, $invocation, $summary );
+			$default = self::default_subcommand( $subcommands );
+
+			if ( null !== $default ) {
+				// Flat `__invoke` command: render the command itself as the
+				// headline, described by its own short description.
+				$summary = $default['description'];
+				$lines[] = '' !== $summary
+					? sprintf( '- `%s %s <action>` — %s', $wp, $command, $summary )
+					: sprintf( '- `%s %s <action>`', $wp, $command );
+				continue;
+			}
+
+			// Command with real sub-verbs: headline + one bullet per subcommand.
+			$names   = array();
+			$details = array();
+			foreach ( $subcommands as $subcommand ) {
+				$names[]   = $subcommand['name'];
+				$desc      = $subcommand['description'];
+				$details[] = '' !== $desc
+					? sprintf( '  - `%s` — %s', $subcommand['name'], $desc )
+					: sprintf( '  - `%s`', $subcommand['name'] );
+			}
+
+			$lines[] = sprintf( '- `%s %s` — %s', $wp, $command, implode( ', ', $names ) );
+			$lines   = array_merge( $lines, $details );
 		}
 
 		if ( empty( $lines ) ) {
@@ -109,23 +132,126 @@ MD;
 	}
 
 	/**
-	 * Extract a command class's short description from its class docblock.
+	 * Describe a command class's subcommands.
 	 *
-	 * Flat `__invoke` commands carry their summary on the class docblock (the
-	 * first non-tag line), which is what `wp help <command>` displays. Returns ''
-	 * when the class is unavailable or undocumented, so the command is skipped
-	 * rather than rendered with an empty description.
+	 * Prefers the shared `CliCommandIntrospector` (which is `__invoke`-aware:
+	 * a flat command surfaces as a single `__default` entry). Falls back to a
+	 * minimal local reflection path so this plugin never hard-depends on an
+	 * unreleased — or not-yet-deployed — core class. An empty result from the
+	 * shared helper (e.g. a pre-`__invoke`-aware build that skips `__invoke`
+	 * methods) also falls through to the local reflection.
 	 *
 	 * @param class-string $command_class Fully-qualified command class name.
-	 * @return string Short description, or '' when none.
+	 * @return array<int, array{name: string, description: string}>
 	 */
-	private static function command_summary( string $command_class ): string {
-		if ( ! class_exists( $command_class ) ) {
-			return '';
+	private static function describe_class( string $command_class ): array {
+		if ( class_exists( self::INTROSPECTOR )
+			&& method_exists( self::INTROSPECTOR, 'describe_class' )
+		) {
+			$described = call_user_func( array( self::INTROSPECTOR, 'describe_class' ), $command_class );
+			if ( is_array( $described ) && ! empty( $described ) ) {
+				return $described;
+			}
 		}
 
-		$doc = ( new ReflectionClass( $command_class ) )->getDocComment();
-		if ( ! is_string( $doc ) || '' === $doc ) {
+		return self::reflect_class( $command_class );
+	}
+
+	/**
+	 * Return the `__default` (flat `__invoke`) subcommand when the command is
+	 * a single directly-invokable command with no sub-verbs.
+	 *
+	 * @param array<int, array{name: string, description: string}> $subcommands Subcommands.
+	 * @return array{name: string, description: string}|null
+	 */
+	private static function default_subcommand( array $subcommands ): ?array {
+		if ( 1 !== count( $subcommands ) ) {
+			return null;
+		}
+
+		$only = $subcommands[0];
+
+		return ( isset( $only['name'] ) && '__default' === $only['name'] ) ? $only : null;
+	}
+
+	/**
+	 * Self-contained reflection fallback over a command class.
+	 *
+	 * Mirrors the shared introspector's `__invoke`-aware contract: `__invoke`
+	 * (the directly-invokable command handler) maps to a single `__default`
+	 * entry carrying its short description; other public, non-static, non-magic
+	 * methods map to subcommands (underscores converted to hyphens). Returns ''
+	 * descriptions for undocumented methods, and skips them entirely.
+	 *
+	 * @param class-string $command_class Fully-qualified command class name.
+	 * @return array<int, array{name: string, description: string}>
+	 */
+	private static function reflect_class( string $command_class ): array {
+		if ( ! class_exists( $command_class ) ) {
+			return array();
+		}
+
+		try {
+			$reflection = new ReflectionClass( $command_class );
+		} catch ( \ReflectionException $e ) {
+			return array();
+		}
+
+		$subcommands = array();
+
+		foreach ( $reflection->getMethods( ReflectionMethod::IS_PUBLIC ) as $method ) {
+			if ( $method->isStatic() ) {
+				continue;
+			}
+
+			$name = $method->getName();
+			$doc  = $method->getDocComment();
+			$doc  = is_string( $doc ) ? $doc : '';
+
+			if ( '__invoke' === $name ) {
+				$subcommands['__default'] = array(
+					'name'        => '__default',
+					'description' => self::short_description( $doc ),
+				);
+				continue;
+			}
+
+			if ( 0 === strpos( $name, '__' ) ) {
+				continue;
+			}
+
+			if ( '' === $doc ) {
+				continue;
+			}
+
+			$verb                 = str_replace( '_', '-', $name );
+			$subcommands[ $verb ] = array(
+				'name'        => $verb,
+				'description' => self::short_description( $doc ),
+			);
+		}
+
+		// A `__default` entry is the whole command — never mixed with verbs.
+		if ( isset( $subcommands['__default'] ) && count( $subcommands ) > 1 ) {
+			unset( $subcommands['__default'] );
+		}
+
+		ksort( $subcommands, SORT_STRING );
+
+		return array_values( $subcommands );
+	}
+
+	/**
+	 * Extract a docblock's short description (first prose line).
+	 *
+	 * Mirrors WP-CLI's short-description parsing: the first non-empty content
+	 * line of the docblock, before any `## SECTION` heading or `@tag`.
+	 *
+	 * @param string $doc Raw docblock.
+	 * @return string Short description, or '' when none.
+	 */
+	private static function short_description( string $doc ): string {
+		if ( '' === $doc ) {
 			return '';
 		}
 
@@ -135,14 +261,17 @@ MD;
 		}
 
 		foreach ( $lines as $line ) {
-			// Strip docblock decorations: leading `/**` or `*`, trailing `*/`.
 			$line = trim( $line );
 			$line = (string) preg_replace( '#^/?\*+#', '', $line );
 			$line = (string) preg_replace( '#\*+/$#', '', $line );
 			$line = trim( $line );
 
-			if ( '' === $line || '@' === $line[0] || '#' === $line[0] ) {
+			if ( '' === $line ) {
 				continue;
+			}
+
+			if ( '@' === $line[0] || '#' === $line[0] ) {
+				return '';
 			}
 
 			return rtrim( $line, '.' );


### PR DESCRIPTION
## Summary

Lands #39 (now unblocked by the shared `__invoke`-aware `CliCommandIntrospector` in data-machine#2641). Migrates `DataMachineBusiness\Runtime\AgentsMdSections` off its bespoke class-docblock-summary parser and onto the shared introspector, driven by a `command-string => class` map that is the single source of truth shared with the WP-CLI bootstrap.

- **New `inc/Cli/CommandRegistry::map()`** — lists `datamachine analytics ga|gsc|bing|pagespeed` and `datamachine media` => their command classes. This map is now the single source consumed by **both** the bootstrap `add_command` registration **and** the AGENTS.md section generator, so the documented CLI surface can never drift from what is actually registered.
- **Bootstrap refactor** — the four scattered inline `WP_CLI::add_command()` calls plus the standalone Bing registration are replaced by one loop over `CommandRegistry::map()`.
- **`render()` delegates** to `\DataMachine\Engine\AI\CliCommandIntrospector` (class_exists/method_exists guard). Every DMB command is a flat `__invoke` command, so each reflects to a single `__default` entry and renders as the command headline carrying its own short description. The bespoke `command_summary()` docblock parser is removed. Real sub-verb commands (none today) would enumerate their subcommands.
- **Minimal `__invoke`-aware local fallback** retained so the plugin never hard-depends on an unreleased — or not-yet-deployed — core class. An **empty** result from a pre-`__invoke`-aware introspector build also falls through to local reflection, so the section keeps rendering on current production **before** data-machine#2641 deploys (no regression vs PR #38).
- **Context-safe**: reflects class files from disk on `plugins_loaded` (web/cron compose), never the live `WP_CLI` runner.

## Verification

- `php -l` clean on all three changed files.
- `phpcs --standard=WordPress` on the new files: **0 errors / 0 warnings** (excluding the plugin-wide `WordPress.Files.FileName` PSR-4 naming convention that every file in this plugin intentionally uses). Array-arrow alignment warnings auto-fixed with `phpcbf`. The bootstrap's remaining phpcs findings are all pre-existing on `main`; this PR reduces them by one.
- Functional render verified in three scenarios — (a) shared #2641 introspector present, (b) **live pre-#2641 introspector present** (current production), (c) no introspector — all render all five commands (`ga`, `gsc`, `bing`, `pagespeed`, `media`) from registered truth.

Closes #39. Part of the data-machine#2613 AGENTS.md dynamic-CLI fleet.