### PR TITLE
refactor(analytics): make content-flags outcome-first per empirical validation (#42)

### DIFF
--- a/inc/Abilities/Analytics/ContentFlagsAbility.php
+++ b/inc/Abilities/Analytics/ContentFlagsAbility.php
@@ -4,39 +4,54 @@
  *
  * Deterministic TRIAGE SCREEN — not a quality score. Sits on top of the
  * datamachine/content-performance join (category -> post-IDs -> url_to_postid()
- * -> GA4 engagement) and runs a small set of deterministic structural red-flag
- * signatures over each comparable post, telling a human WHICH posts to look at.
- * The human judges; the screen does not.
+ * -> GA4 engagement) and flags posts by OUTCOME, then annotates each flagged
+ * post with structural notes as a POSSIBLE explanation. It tells a human WHICH
+ * posts to look at; the human judges. The screen never claims a post is bad
+ * because of its structure.
  *
- * Why a screen and not a model: validation over 277 comparable posts
- * (music-history + song-meanings) found NO strong single structural predictor
- * of GOOD performance — every structural feature (heading count, image count,
- * lists, internal links, word count beyond a floor) correlates near-zero
- * (|Pearson r| < 0.15) with dwell/engagement. Content is the quality lever, not
- * structure. But the BAD signatures ARE clean and deterministic, so we encode
- * only those. Per-page dwell is noisy and unbounded (one validation outlier
- * showed 3,642s — almost certainly a tab left open, not 60 minutes of reading),
- * so a regression/score on these rows would be self-deception. We deliberately
- * avoid one.
+ * Why outcome-only, with structure demoted to advisory notes: a 277-post
+ * empirical validation (music-history + song-meanings, "bad" = bottom-third
+ * dwell within category, base rate 34%) found the structural rules predict
+ * quality at barely-above-chance precision and do NOT generalize:
+ *   - word_count < 500          -> 59% precision (1.77x lift)
+ *   - word_count < 600          -> 48% precision
+ *   - padded (h/1k>15 & wc<1000) -> 47% precision
+ *   - heading density h/1k > 12  -> 38% precision
+ * Correlations are ~zero (avg_para vs dwell r=0.005, h_per_1k vs dwell
+ * r=-0.011). The memorable "padded stub" (jerry-garcias-run-for-the-roses) is
+ * real for that ONE post but is memorable, not predictive. Flagging a post on
+ * structure alone is wrong ~half the time — it would call good posts bad. So
+ * structure is EXPLANATION, not PREDICTION: a structural note may only ride
+ * along on a post already flagged by the outcome rule.
  *
- * Flag rules (all deterministic, validated on 277 posts):
- *   1. thin                   — word_count < 600. Word count is the ONE clean
- *                               structural signal: median dwell rises
- *                               monotonically 79s (0-500w) -> 98s (500-800w) ->
- *                               123s (800-1200w) then plateaus.
- *   2. padded_stub            — headings_per_1k_words > 15 AND word_count < 1000.
- *                               A thin post chopped up with sub-headings/embeds
- *                               to look substantial. Bottom-quartile posts carry
- *                               MORE headings/1k (10.9 vs 5.7) and embeds (14 vs
- *                               8) than top-quartile.
- *   3. demand_failing_content — engaged_sessions >= 10 AND
- *                               avg_duration < 0.4 * category_median_duration.
- *                               Real search demand landing on a page that can't
- *                               hold it — the highest-priority editorial fix and
- *                               the load-bearing flag. Sorted first.
- *   4. format_mismatch        — listicle-titled (^(\d+|top|best)) post in an
- *                               explainer category. Advisory only / opt-in,
- *                               because it is category-relative.
+ * The ONE confident flag:
+ *   demand_failing_content — engaged_sessions >= 10 AND
+ *                            avg_duration < 0.4 * category_median_duration.
+ *                            Real search demand landing on a page that can't
+ *                            hold it. This is the OUTCOME (high sessions + dwell
+ *                            far below the category median), not a structural
+ *                            proxy for it — the only confident, load-bearing
+ *                            signal. Sorted first (it is the only flag).
+ *
+ * Advisory structural notes (only attached to an already-flagged post, never a
+ * standalone verdict):
+ *   - thin         — word_count < 500 (the 59%-precision threshold). A note
+ *                    that the flagged post is also short.
+ *   - padded_stub  — headings_per_1k_words > 15 AND word_count < 1000. A note
+ *                    that the flagged post is also chopped up to look fuller.
+ *
+ * Category context (advisory, NOT a per-post flag):
+ *   - coverage     — with_traffic / published_total. A low ratio is a
+ *                    deterministic DISCOVERY-gap signal (the category's problem
+ *                    is distribution, fixable by crosslinking traffic IN), as
+ *                    distinct from a content-quality gap. e.g. interviews 36%
+ *                    vs song-meanings 99%.
+ *
+ * Cross-category caveat: dwell is comparable ONLY WITHIN a category. It is
+ * contaminated by traffic-source and demand differences between categories, so
+ * a post's dwell must never be compared against a post in another category. All
+ * flags here are category-relative (demand_failing_content uses the category
+ * median); there is no global threshold.
  *
  * Honesty note (mirrors content-performance): per-page dwell is GA4-only. The
  * first-party analytics events table records a load-time pageview with no
@@ -57,21 +72,24 @@ defined( 'ABSPATH' ) || exit;
 class ContentFlagsAbility {
 
 	/**
-	 * Word-count floor below which a post is flagged `thin`.
+	 * Word-count floor below which a flagged post also gets the `thin` note.
+	 *
+	 * Tightened to the empirically-validated 59%-precision threshold (< 500),
+	 * not < 600 — and only ever as an advisory note on an already-flagged post.
 	 *
 	 * @var int
 	 */
-	const THIN_WORDS = 600;
+	const THIN_WORDS = 500;
 
 	/**
-	 * `padded_stub` thresholds: too many headings per 1k words AND short.
+	 * `padded_stub` note threshold: too many headings per 1k words.
 	 *
 	 * @var float
 	 */
 	const PADDED_HEADINGS_PER_1K = 15.0;
 
 	/**
-	 * Word ceiling for the `padded_stub` flag.
+	 * Word ceiling for the `padded_stub` note.
 	 *
 	 * @var int
 	 */
@@ -110,27 +128,23 @@ class ContentFlagsAbility {
 				'datamachine/content-flags',
 				array(
 					'label'               => 'Content Red-Flag Detector',
-					'description'         => 'Deterministic TRIAGE SCREEN (not a quality score) over a category\'s published posts. Reuses the datamachine/content-performance category->GA4-engagement join, then runs structural red-flag signatures over each comparable post: thin (word_count < 600), padded_stub (>15 headings/1k words AND <1000 words), demand_failing_content (>=10 engaged sessions AND avg dwell < 0.4x category median — the load-bearing flag, sorted first), and an advisory format_mismatch (listicle title in an explainer category). Validation on 277 posts found NO clean predictor of GOOD performance, so this screens for the clean BAD signatures only and tells a human which posts to look at; it does not score quality. Per-page dwell is GA4-only (the first-party pageview table has no duration event), so results carry GA sampling caveats and are NOT bot-filtered.',
+					'description'         => 'Deterministic TRIAGE SCREEN (not a quality score) over a category\'s published posts. Reuses the datamachine/content-performance category->GA4-engagement join, then flags posts by OUTCOME and annotates them with structure as a POSSIBLE explanation. The ONE confident flag is demand_failing_content (engaged_sessions >= 10 AND avg dwell < 0.4x the category median) — it measures the outcome, not a structural proxy. Structural signals (thin: word_count < 500; padded_stub: >15 headings/1k words AND <1000 words) are ADVISORY NOTES attached only to an already-flagged post — never standalone verdicts — because a 277-post validation showed structural rules predict quality at 40-59% precision (barely above the 34% base rate) and do not generalize. Also reports a category-level coverage ratio (with_traffic/published): a low ratio signals a DISCOVERY gap, not a content gap. CAVEAT: flags and dwell are valid only WITHIN this category — dwell is contaminated by traffic-source and demand differences between categories, so never compare a post against a post in another category. Per-page dwell is GA4-only (the first-party pageview table has no duration event), so results carry GA sampling caveats and are NOT bot-filtered.',
 					'category'            => 'datamachine-analytics',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'category' ),
 						'properties' => array(
-							'category'         => array(
+							'category' => array(
 								'type'        => 'string',
 								'description' => 'Category slug to screen (e.g. "music-history", "song-meanings").',
 							),
-							'days'             => array(
+							'days'     => array(
 								'type'        => 'integer',
 								'description' => 'Lookback window in days (default: 28). Passed straight through to content-performance.',
 							),
-							'hostname'         => array(
+							'hostname' => array(
 								'type'        => 'string',
 								'description' => 'Hostname whose pages map to this blog\'s posts (default: extrachill.com).',
-							),
-							'include_advisory' => array(
-								'type'        => 'boolean',
-								'description' => 'Include the category-relative advisory format_mismatch flag (default: false). It is opt-in because it is only meaningful in explainer-style categories.',
 							),
 						),
 					),
@@ -140,10 +154,12 @@ class ContentFlagsAbility {
 							'success'         => array( 'type' => 'boolean' ),
 							'category'        => array( 'type' => 'string' ),
 							'window'          => array( 'type' => 'object' ),
+							'published_total' => array( 'type' => 'integer' ),
+							'with_traffic'    => array( 'type' => 'integer' ),
+							'coverage'        => array( 'type' => 'number' ),
 							'comparable'      => array( 'type' => 'integer' ),
 							'flagged'         => array( 'type' => 'integer' ),
 							'median_duration' => array( 'type' => 'number' ),
-							'flag_counts'     => array( 'type' => 'object' ),
 							'posts'           => array( 'type' => 'array' ),
 							'caveat'          => array( 'type' => 'string' ),
 							'error'           => array( 'type' => 'string' ),
@@ -164,21 +180,24 @@ class ContentFlagsAbility {
 	}
 
 	/**
-	 * Run the deterministic red-flag screen over a category.
+	 * Run the deterministic, outcome-first red-flag screen over a category.
 	 *
 	 * Reuses ContentPerformanceAbility::audit() for the category -> post-IDs ->
-	 * url_to_postid() -> GA4-engagement join and the comparable-post set
-	 * (engaged_sessions, avg_duration, word_count) plus the category median
-	 * duration. We do NOT rebuild that join. On top of the joined rows we
-	 * extract the few extra structural features the flag rules need (headings)
-	 * and apply the deterministic signatures.
+	 * url_to_postid() -> GA4-engagement join, the comparable-post set
+	 * (engaged_sessions, avg_duration, word_count), the category median
+	 * duration, and the published/with-traffic totals. We do NOT rebuild that
+	 * join.
+	 *
+	 * A post is FLAGGED only when it trips the single confident, outcome-based
+	 * rule (demand_failing_content). On each flagged post we then attach
+	 * advisory structural NOTES (thin, padded_stub) as possible explanations.
+	 * Structure never flags a post on its own.
 	 *
 	 * @param array $input Ability input.
 	 * @return array Ability response.
 	 */
 	public static function screen( array $input ): array {
-		$category         = sanitize_title( $input['category'] ?? '' );
-		$include_advisory = ! empty( $input['include_advisory'] );
+		$category = sanitize_title( $input['category'] ?? '' );
 
 		if ( '' === $category ) {
 			return array(
@@ -187,11 +206,11 @@ class ContentFlagsAbility {
 			);
 		}
 
-		// Reuse the content-performance join + GA engagement + median, rather
-		// than rebuilding it. Force a min_sessions of 1 so we screen every post
-		// that had ANY traffic — the flag rules carry their own session gates
-		// (demand_failing_content requires >=10), so the ranking-honesty gate
-		// that content-performance uses (>=5) is not what we want here.
+		// Reuse the content-performance join + GA engagement + median + totals,
+		// rather than rebuilding it. Force min_sessions of 1 so we screen every
+		// post that had ANY traffic — the demand flag carries its own session
+		// gate (>=10), so the ranking-honesty gate content-performance uses (>=5)
+		// is not what we want here.
 		$performance = ContentPerformanceAbility::audit(
 			array(
 				'category'     => $category,
@@ -211,16 +230,11 @@ class ContentFlagsAbility {
 
 		$comparable      = (array) ( $performance['posts'] ?? array() );
 		$median_duration = (float) ( $performance['median_duration'] ?? 0.0 );
+		$published_total = (int) ( $performance['published_total'] ?? 0 );
+		$with_traffic    = (int) ( $performance['with_traffic'] ?? 0 );
+		$coverage        = $published_total > 0 ? round( $with_traffic / $published_total, 3 ) : 0.0;
 
-		$flagged     = array();
-		$flag_counts = array(
-			'thin'                   => 0,
-			'padded_stub'            => 0,
-			'demand_failing_content' => 0,
-		);
-		if ( $include_advisory ) {
-			$flag_counts['format_mismatch'] = 0;
-		}
+		$flagged = array();
 
 		foreach ( $comparable as $row ) {
 			$post = get_post( (int) ( $row['post_id'] ?? 0 ) );
@@ -231,66 +245,49 @@ class ContentFlagsAbility {
 			$word_count       = (int) ( $row['word_count'] ?? 0 );
 			$engaged_sessions = (int) ( $row['engaged_sessions'] ?? 0 );
 			$avg_duration     = (float) ( $row['avg_duration'] ?? 0.0 );
-			$headings         = self::count_headings( $post );
-			$headings_per_1k  = $word_count > 0 ? round( $headings / ( $word_count / 1000 ), 1 ) : 0.0;
 
-			$flags = array();
-
-			// 1. thin — the one clean structural floor.
-			if ( $word_count < self::THIN_WORDS ) {
-				$flags[] = 'thin';
-			}
-
-			// 2. padded_stub — chopped up to look substantial while staying thin.
-			if ( $headings_per_1k > self::PADDED_HEADINGS_PER_1K && $word_count < self::PADDED_MAX_WORDS ) {
-				$flags[] = 'padded_stub';
-			}
-
-			// 3. demand_failing_content — the load-bearing flag. Real demand on a
-			// page that can't hold it. Guarded by a positive category median.
+			// The ONLY flag: outcome-based demand_failing_content. Guarded by a
+			// positive category median (category-relative, never global).
 			$demand_threshold = $median_duration > 0 ? self::DEMAND_DURATION_FACTOR * $median_duration : 0.0;
-			if ( $engaged_sessions >= self::DEMAND_MIN_SESSIONS && $demand_threshold > 0 && $avg_duration < $demand_threshold ) {
-				$flags[] = 'demand_failing_content';
-			}
+			$is_demand_fail   = ( $engaged_sessions >= self::DEMAND_MIN_SESSIONS && $demand_threshold > 0 && $avg_duration < $demand_threshold );
 
-			// 4. format_mismatch — advisory / opt-in, category-relative.
-			if ( $include_advisory && self::is_listicle_title( $post->post_title ) ) {
-				$flags[] = 'format_mismatch';
-			}
-
-			if ( empty( $flags ) ) {
+			if ( ! $is_demand_fail ) {
 				continue;
 			}
 
-			foreach ( $flags as $flag ) {
-				if ( isset( $flag_counts[ $flag ] ) ) {
-					++$flag_counts[ $flag ];
-				}
+			// Advisory structural notes — POSSIBLE explanations only, attached to
+			// this already-flagged post. They never flag a post on their own.
+			$headings        = self::count_headings( $post );
+			$headings_per_1k = $word_count > 0 ? round( $headings / ( $word_count / 1000 ), 1 ) : 0.0;
+
+			$structural_notes = array();
+			if ( $word_count < self::THIN_WORDS ) {
+				$structural_notes[] = 'thin';
+			}
+			if ( $headings_per_1k > self::PADDED_HEADINGS_PER_1K && $word_count < self::PADDED_MAX_WORDS ) {
+				$structural_notes[] = 'padded_stub';
 			}
 
 			$flagged[] = array(
 				'post_id'          => (int) $post->ID,
 				'slug'             => $post->post_name,
 				'title'            => $post->post_title,
-				'flags'            => $flags,
-				'severity'         => self::severity( $flags ),
-				'word_count'       => $word_count,
-				'headings'         => $headings,
-				'headings_per_1k'  => $headings_per_1k,
+				'flag'             => 'demand_failing_content',
 				'engaged_sessions' => $engaged_sessions,
 				'avg_duration'     => $avg_duration,
 				'category_median'  => $median_duration,
+				'word_count'       => $word_count,
+				'headings'         => $headings,
+				'headings_per_1k'  => $headings_per_1k,
+				'structural_notes' => $structural_notes,
 			);
 		}
 
-		// Sort by severity descending — demand_failing_content posts first, then
-		// stable on lowest dwell so the worst-holding pages bubble up.
+		// Worst-holding pages first (lowest dwell relative to the same category
+		// median). Single flag, so severity is just ascending dwell.
 		usort(
 			$flagged,
 			static function ( $a, $b ) {
-				if ( $a['severity'] !== $b['severity'] ) {
-					return $b['severity'] <=> $a['severity'];
-				}
 				return $a['avg_duration'] <=> $b['avg_duration'];
 			}
 		);
@@ -299,33 +296,15 @@ class ContentFlagsAbility {
 			'success'         => true,
 			'category'        => $category,
 			'window'          => $performance['window'] ?? array(),
+			'published_total' => $published_total,
+			'with_traffic'    => $with_traffic,
+			'coverage'        => $coverage,
 			'comparable'      => count( $comparable ),
 			'flagged'         => count( $flagged ),
 			'median_duration' => $median_duration,
-			'flag_counts'     => $flag_counts,
 			'posts'           => $flagged,
-			'caveat'          => 'Triage screen, not a quality score. Per-page dwell is GA4-only and not bot-filtered; the flags tell a human which posts to inspect — the human judges.',
+			'caveat'          => 'Triage screen, not a quality score. The ONLY flag is demand_failing_content (an OUTCOME measure); structural notes are possible explanations, never verdicts — structure predicts quality at barely-above-chance precision. Flags/dwell are valid only WITHIN this category; never compare across categories. Per-page dwell is GA4-only and not bot-filtered.',
 		);
-	}
-
-	/**
-	 * Severity rank for sorting. demand_failing_content is the load-bearing
-	 * flag and outranks everything; padded_stub outranks plain thin.
-	 *
-	 * @param array $flags Flags tripped on a post.
-	 * @return int Higher = sort first.
-	 */
-	private static function severity( array $flags ): int {
-		if ( in_array( 'demand_failing_content', $flags, true ) ) {
-			return 3;
-		}
-		if ( in_array( 'padded_stub', $flags, true ) ) {
-			return 2;
-		}
-		if ( in_array( 'thin', $flags, true ) ) {
-			return 1;
-		}
-		return 0;
 	}
 
 	/**
@@ -347,15 +326,5 @@ class ContentFlagsAbility {
 		// rendered tag would double-count. Prefer the block count when present
 		// (block editor), else fall back to raw tag count (classic content).
 		return $block_headings > 0 ? $block_headings : (int) $tag_headings;
-	}
-
-	/**
-	 * Whether a title reads as a listicle (leading number, "top", or "best").
-	 *
-	 * @param string $title Post title.
-	 * @return bool
-	 */
-	private static function is_listicle_title( string $title ): bool {
-		return 1 === preg_match( '/^\s*(\d+|top|best)\b/i', $title );
 	}
 }


### PR DESCRIPTION
## Why

The initial `datamachine/content-flags` (merged in #43) treated `thin`, `padded_stub`, and `format_mismatch` as standalone confident flags. The two **follow-up validation comments on #42** supersede that framing, and the merged code didn't yet reflect them. This PR brings the ability in line with the final spec.

The load-bearing finding (277-post validation, "bad" = bottom-third dwell within category, base rate 34%):

| Rule | precision | lift |
|---|---|---|
| word_count < 500 | 59% | 1.77x |
| word_count < 600 | 48% | 1.43x |
| padded (h/1k>15 & wc<1000) | 47% | 1.40x |
| heading density h/1k > 12 | 38% | 1.13x |

Correlations are ~zero (`avg_para` vs dwell r=0.005, `h_per_1k` vs dwell r=-0.011). **Flagging a post on structure alone is wrong ~half the time — it would call good posts bad.** The memorable "padded stub" (`run-for-the-roses`) is real for that one post but memorable, not predictive.

## What changed

- **`demand_failing_content` is now the ONLY flag** — it measures the OUTCOME (`engaged_sessions >= 10 AND avg_duration < 0.4 * category_median_duration`), not a structural proxy. A post is flagged only when it trips this rule. It is category-relative (uses the category median); no global threshold.
- **`thin` and `padded_stub` demoted to advisory `structural_notes`** — attached only to an already-flagged post as *possible explanations*, never standalone verdicts. `thin` tightened to `word_count < 500` (the 59%-precision threshold).
- **Dropped the standalone `format_mismatch` flag** (too weak to generalize) plus the `severity()` / `is_listicle_title()` helpers and the `include_advisory` input.
- **Added a category-level `coverage` ratio** (`with_traffic / published_total`). A low ratio is a deterministic DISCOVERY-gap signal — the category's problem is distribution (fix: crosslink traffic IN), distinct from a content-quality gap. Advisory category context, not a per-post flag.
- **Added the cross-category caveat** to the description and the output `caveat`: flags and dwell are valid only WITHIN a category — dwell is contaminated by traffic-source/demand differences between categories, so never compare a post against one in another category.

**Structure is now explanation, not prediction.** "Triage screen, not a quality score" now has teeth: even the structural inputs are explanatory hints. Still reuses `ContentPerformanceAbility::audit()` for the join — no rebuild.

## Verified live (prod GA + content-performance abilities are deployed)

`music-history`, 28d:
- `published_total: 463 · with_traffic: 406 · coverage: 87.7%`
- `comparable: 384 · flagged: 8` (was 94 under the old standalone-structural-flag logic)
- **Every flagged post is `demand_failing_content`** (0 non-outcome flags). `run-for-the-roses` flagged first (11 sess, 25.7s vs 101.9s median).
- Structural notes ride along correctly: `acdc-thunderstruck-meaning` and `queen-live-aid-1985-full-concert` carry a `thin` note (both < 500w) because they're *already* flagged; the rest have no notes.
- `php -l` clean. `phpcs --standard=WordPress`: 7 findings, the same house-style baseline as the sibling `ContentPerformanceAbility`.

Paired CLI rework lands in extrachill-cli (content-flags-rework). Merge this ability PR first.

Refs #42