### PR TITLE
feat(analytics): mediavine-reports ability (direct GraphQL+CSV fetch)

### DIFF
--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -68,6 +68,7 @@ function datamachine_business_load_handlers() {
 
 	// Load Abilities (they self-register)
 	new \DataMachineBusiness\Abilities\Analytics\GoogleAnalyticsAbilities();
+	new \DataMachineBusiness\Abilities\Analytics\MediavineReportsAbilities();
 	new \DataMachineBusiness\Abilities\Analytics\ContentPerformanceAbility();
 	new \DataMachineBusiness\Abilities\Analytics\ContentFlagsAbility();
 

--- a/inc/Abilities/Analytics/MediavineReportsAbilities.php
+++ b/inc/Abilities/Analytics/MediavineReportsAbilities.php
@@ -1,0 +1,728 @@
+<?php
+/**
+ * Mediavine Reports Abilities
+ *
+ * Primitive ability for fetching per-period, per-URL Mediavine ad revenue
+ * directly from Mediavine's publisher API. All Mediavine revenue data — CLI,
+ * REST, chat, the revenue arc — flows through this ability.
+ *
+ * Mediavine ships no documented public API, but its dashboard is backed by a
+ * clean HTTP API that PHP reaches DIRECTLY from the server (tested 2026-06-21:
+ * a plain wp_remote_get of the pages CSV returned HTTP 200) — no browser, no
+ * Playwright, no cross-host glue. Two surfaces are used:
+ *
+ *   1. GraphQL login mutation (unidashSignIn) -> a Bearer access token, cached
+ *      in a transient until it expires.
+ *   2. The per-page revenue CSV report (slug,views,revenue,rpm,cpm,viewability,
+ *      fillRate,impressionsPerPageview) for a date range — the rows that feed
+ *      `extrachill analytics revenue import`.
+ *
+ * A bonus `summary` action calls the metricsSummary GraphQL query for
+ * site-level totals (note: that query uses ISO timestamps, NOT MM/DD/YYYY).
+ *
+ * Structurally this mirrors GoogleAnalyticsAbilities: a CONFIG_OPTION read via
+ * get_config(), a token cached in a transient, authenticate -> fetch -> return
+ * structured rows, registered on wp_abilities_api_init with
+ * PermissionHelper::can_manage under the datamachine-analytics category,
+ * show_in_rest => false, instantiated in data-machine-business.php.
+ *
+ * Credentials ({email, password}) live in the datamachine_mediavine_config
+ * option (server-side), never in code. This automates OUR OWN dashboard login
+ * to export OUR OWN revenue — keep it low-frequency (backfill once, monthly).
+ *
+ * @package DataMachineBusiness\Abilities\Analytics
+ * @since 0.32.0
+ */
+
+namespace DataMachineBusiness\Abilities\Analytics;
+
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+
+defined( 'ABSPATH' ) || exit;
+
+class MediavineReportsAbilities {
+
+	/**
+	 * Option key for storing Mediavine configuration ({email, password}).
+	 *
+	 * @var string
+	 */
+	const CONFIG_OPTION = 'datamachine_mediavine_config';
+
+	/**
+	 * Transient key for the cached access token.
+	 *
+	 * @var string
+	 */
+	const TOKEN_TRANSIENT = 'datamachine_mediavine_access_token';
+
+	/**
+	 * Mediavine publisher API base URL.
+	 *
+	 * @var string
+	 */
+	const API_BASE = 'https://api-publishers.mediavine.com';
+
+	/**
+	 * Default Extra Chill site id (base64 "InternalSite:11476").
+	 *
+	 * @var string
+	 */
+	const DEFAULT_SITE_ID = 'SW50ZXJuYWxTaXRlOjExNDc2';
+
+	/**
+	 * Per-page CSV row cap requested from Mediavine.
+	 *
+	 * @var int
+	 */
+	const PAGES_PER_PAGE = 100000;
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/mediavine-reports',
+				array(
+					'label'               => 'Mediavine Reports',
+					'description'         => 'Fetch per-period, per-URL Mediavine ad revenue directly from the Mediavine publisher API (GraphQL login + CSV report). Actions: pages (per-period per-URL revenue rows: slug,views,revenue,rpm,cpm,viewability,fillRate,impressionsPerPageview,period), summary (site-level aggregate totals: earnings, pageviews, sessions, rpm), backfill (iterate a list of periods, returning pages rows per period for a full revenue-arc backfill). Credentials live server-side in the datamachine_mediavine_config option.',
+					'category'            => 'datamachine-analytics',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'action' ),
+						'properties' => array(
+							'action'     => array(
+								'type'        => 'string',
+								'description' => 'Action: pages (per-period per-URL CSV rows), summary (aggregate totals), backfill (iterate periods).',
+							),
+							'start_date' => array(
+								'type'        => 'string',
+								'description' => 'Window start in YYYY-MM-DD (used by pages/summary when periods is not supplied).',
+							),
+							'end_date'   => array(
+								'type'        => 'string',
+								'description' => 'Window end in YYYY-MM-DD (used by pages/summary when periods is not supplied).',
+							),
+							'period'     => array(
+								'type'        => 'string',
+								'description' => 'Optional period label (e.g. 2026-05) stamped on the returned rows so the revenue arc can group by it.',
+							),
+							'periods'    => array(
+								'type'        => 'array',
+								'description' => 'For backfill: list of {period, start_date, end_date} objects (YYYY-MM-DD dates). Each yields its own set of pages rows stamped with that period.',
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'period'     => array( 'type' => 'string' ),
+										'start_date' => array( 'type' => 'string' ),
+										'end_date'   => array( 'type' => 'string' ),
+									),
+								),
+							),
+							'site_id'    => array(
+								'type'        => 'string',
+								'description' => 'Mediavine site id. Defaults to the configured site_id, else the Extra Chill default.',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'       => array( 'type' => 'boolean' ),
+							'action'        => array( 'type' => 'string' ),
+							'results_count' => array( 'type' => 'integer' ),
+							'results'       => array( 'type' => 'array' ),
+							'periods'       => array( 'type' => 'array' ),
+							'error'         => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'fetch' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => false ),
+				)
+			);
+		};
+
+		if ( doing_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Ability entry point — route to the requested action.
+	 *
+	 * @param array $input Ability input.
+	 * @return array Ability response.
+	 */
+	public static function fetch( array $input ): array {
+		$action = sanitize_text_field( $input['action'] ?? '' );
+
+		$valid_actions = array( 'pages', 'summary', 'backfill' );
+		if ( empty( $action ) || ! in_array( $action, $valid_actions, true ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Invalid action. Must be one of: ' . implode( ', ', $valid_actions ),
+			);
+		}
+
+		$config = self::get_config();
+
+		if ( empty( $config['email'] ) || empty( $config['password'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Mediavine not configured. Set {email, password} in the datamachine_mediavine_config option.',
+			);
+		}
+
+		$access_token = self::get_access_token( $config );
+
+		if ( is_wp_error( $access_token ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to authenticate with Mediavine: ' . $access_token->get_error_message(),
+			);
+		}
+
+		$site_id = ! empty( $input['site_id'] )
+			? sanitize_text_field( $input['site_id'] )
+			: ( ! empty( $config['site_id'] ) ? (string) $config['site_id'] : self::DEFAULT_SITE_ID );
+
+		if ( 'summary' === $action ) {
+			return self::fetchSummary( $input, $access_token, $site_id );
+		}
+
+		if ( 'backfill' === $action ) {
+			return self::fetchBackfill( $input, $access_token, $site_id );
+		}
+
+		return self::fetchPages( $input, $access_token, $site_id );
+	}
+
+	/**
+	 * Fetch per-page revenue rows for a single date range.
+	 *
+	 * @param array  $input        Ability input.
+	 * @param string $access_token Bearer token.
+	 * @param string $site_id      Mediavine site id.
+	 * @return array
+	 */
+	private static function fetchPages( array $input, string $access_token, string $site_id ): array {
+		$start_date = self::resolveDate( $input['start_date'] ?? '', '-28 days' );
+		$end_date   = self::resolveDate( $input['end_date'] ?? '', '-1 day' );
+		$period     = sanitize_text_field( $input['period'] ?? '' );
+
+		$rows = self::fetchPagesRows( $access_token, $site_id, $start_date, $end_date, $period );
+
+		if ( is_wp_error( $rows ) ) {
+			return array(
+				'success' => false,
+				'error'   => $rows->get_error_message(),
+			);
+		}
+
+		return array(
+			'success'       => true,
+			'action'        => 'pages',
+			'site_id'       => $site_id,
+			'period'        => $period,
+			'date_range'    => array(
+				'start_date' => $start_date,
+				'end_date'   => $end_date,
+			),
+			'results_count' => count( $rows ),
+			'results'       => $rows,
+		);
+	}
+
+	/**
+	 * Iterate a list of periods, fetching per-page rows for each.
+	 *
+	 * The list shape is [{period, start_date, end_date}, ...]. Each period that
+	 * fetches successfully contributes its rows; per-period failures are
+	 * reported in the period summary rather than aborting the whole backfill, so
+	 * a single bad month never loses the rest of a multi-year backfill.
+	 *
+	 * @param array  $input        Ability input.
+	 * @param string $access_token Bearer token.
+	 * @param string $site_id      Mediavine site id.
+	 * @return array
+	 */
+	private static function fetchBackfill( array $input, string $access_token, string $site_id ): array {
+		$periods = $input['periods'] ?? array();
+
+		if ( ! is_array( $periods ) || empty( $periods ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'backfill requires a non-empty "periods" list of {period, start_date, end_date} objects.',
+			);
+		}
+
+		$all_rows         = array();
+		$period_summaries = array();
+
+		foreach ( $periods as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$period     = sanitize_text_field( $entry['period'] ?? '' );
+			$start_date = self::resolveDate( $entry['start_date'] ?? '', '-28 days' );
+			$end_date   = self::resolveDate( $entry['end_date'] ?? '', '-1 day' );
+
+			$rows = self::fetchPagesRows( $access_token, $site_id, $start_date, $end_date, $period );
+
+			if ( is_wp_error( $rows ) ) {
+				$period_summaries[] = array(
+					'period'     => $period,
+					'start_date' => $start_date,
+					'end_date'   => $end_date,
+					'rows'       => 0,
+					'error'      => $rows->get_error_message(),
+				);
+				continue;
+			}
+
+			$all_rows           = array_merge( $all_rows, $rows );
+			$period_summaries[] = array(
+				'period'     => $period,
+				'start_date' => $start_date,
+				'end_date'   => $end_date,
+				'rows'       => count( $rows ),
+			);
+		}
+
+		return array(
+			'success'       => true,
+			'action'        => 'backfill',
+			'site_id'       => $site_id,
+			'periods'       => $period_summaries,
+			'results_count' => count( $all_rows ),
+			'results'       => $all_rows,
+		);
+	}
+
+	/**
+	 * GET the per-page revenue CSV and parse it into structured rows.
+	 *
+	 * The CSV header is slug,views,revenue,rpm,cpm,viewability,fillRate,
+	 * impressionsPerPageview — exactly the tokens the revenue importer matches
+	 * loosely. Each parsed row carries those fields plus the supplied period so
+	 * the consumer can stamp the revenue arc.
+	 *
+	 * @param string $access_token Bearer token.
+	 * @param string $site_id      Mediavine site id.
+	 * @param string $start_date   Window start (Y-m-d).
+	 * @param string $end_date     Window end (Y-m-d).
+	 * @param string $period       Period label to stamp on each row.
+	 * @return array|\WP_Error Parsed rows or error.
+	 */
+	private static function fetchPagesRows( string $access_token, string $site_id, string $start_date, string $end_date, string $period ) {
+		$url = self::API_BASE . '/reports/' . rawurlencode( $site_id ) . '/pages.csv?' . http_build_query(
+			array(
+				'startDate'      => self::toMdy( $start_date ),
+				'endDate'        => self::toMdy( $end_date ),
+				'perPage'        => self::PAGES_PER_PAGE,
+				'useMonetizable' => 'false',
+			)
+		);
+
+		$result = HttpClient::get(
+			$url,
+			array(
+				'timeout' => 60,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Accept'        => 'text/csv',
+				),
+				'context' => 'Mediavine Pages CSV',
+			)
+		);
+
+		if ( empty( $result['success'] ) ) {
+			return new \WP_Error( 'mediavine_pages_failed', 'Failed to fetch Mediavine pages CSV: ' . ( $result['error'] ?? 'Unknown error' ) );
+		}
+
+		return self::parsePagesCsv( (string) ( $result['data'] ?? '' ), $period );
+	}
+
+	/**
+	 * Parse the per-page revenue CSV body into structured rows.
+	 *
+	 * Public-by-extraction so CSV parsing is unit-testable without an HTTP
+	 * round-trip. Header names are matched loosely (lowercased, non-alphanumeric
+	 * stripped) so minor dashboard renames still map. Numbers are returned typed
+	 * (views int, money/ratios float) and each row carries the period.
+	 *
+	 * @param string $csv    Raw CSV body.
+	 * @param string $period Period label to stamp on each row.
+	 * @return array Parsed rows.
+	 */
+	public static function parsePagesCsv( string $csv, string $period ): array {
+		$csv = trim( $csv );
+		if ( '' === $csv ) {
+			return array();
+		}
+
+		$lines = preg_split( '/\r\n|\r|\n/', $csv );
+		if ( empty( $lines ) ) {
+			return array();
+		}
+
+		$header_cells = str_getcsv( array_shift( $lines ) );
+		$column_index = array();
+		foreach ( $header_cells as $i => $raw ) {
+			$key = preg_replace( '/[^a-z0-9]/', '', strtolower( trim( (string) $raw ) ) );
+			if ( '' !== $key ) {
+				$column_index[ $key ] = $i;
+			}
+		}
+
+		// Canonical token => output field. Mirrors the importer's loose matching
+		// so the rows this ability emits drop straight into the revenue store.
+		$field_map = array(
+			'slug'                   => array( 'slug', 'string' ),
+			'url'                    => array( 'slug', 'string' ),
+			'page'                   => array( 'slug', 'string' ),
+			'views'                  => array( 'views', 'int' ),
+			'pageviews'              => array( 'views', 'int' ),
+			'revenue'                => array( 'revenue', 'float' ),
+			'earnings'               => array( 'revenue', 'float' ),
+			'rpm'                    => array( 'rpm', 'float' ),
+			'cpm'                    => array( 'cpm', 'float' ),
+			'viewability'            => array( 'viewability', 'float' ),
+			'fillrate'               => array( 'fillRate', 'float' ),
+			'impressionsperpageview' => array( 'impressionsPerPageview', 'float' ),
+		);
+
+		$rows = array();
+		foreach ( $lines as $line ) {
+			if ( '' === trim( $line ) ) {
+				continue;
+			}
+
+			$cells = str_getcsv( $line );
+			$row   = array();
+
+			foreach ( $field_map as $token => $spec ) {
+				if ( ! isset( $column_index[ $token ] ) ) {
+					continue;
+				}
+				$idx = $column_index[ $token ];
+				$raw = isset( $cells[ $idx ] ) ? (string) $cells[ $idx ] : '';
+
+				list( $field, $type ) = $spec;
+
+				if ( 'string' === $type ) {
+					// Only the first matching slug-token wins (slug before url/page).
+					if ( ! isset( $row[ $field ] ) ) {
+						$row[ $field ] = trim( $raw );
+					}
+				} else {
+					$number = self::parseNumber( $raw );
+					$value  = 'int' === $type ? (int) $number : $number;
+					if ( ! isset( $row[ $field ] ) ) {
+						$row[ $field ] = $value;
+					}
+				}
+			}
+
+			if ( empty( $row['slug'] ) ) {
+				continue;
+			}
+
+			$row['period'] = $period;
+			$rows[]        = $row;
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Fetch the site-level metricsSummary aggregate.
+	 *
+	 * NOTE: metricsSummary uses ISO 8601 timestamps (e.g. 2023-01-01T05:00:00.000Z),
+	 * NOT the MM/DD/YYYY format the CSV report uses. The Y-m-d window is converted
+	 * to the start/end-of-day ISO instants here.
+	 *
+	 * @param array  $input        Ability input.
+	 * @param string $access_token Bearer token.
+	 * @param string $site_id      Mediavine site id.
+	 * @return array
+	 */
+	private static function fetchSummary( array $input, string $access_token, string $site_id ): array {
+		$start_date = self::resolveDate( $input['start_date'] ?? '', '-28 days' );
+		$end_date   = self::resolveDate( $input['end_date'] ?? '', '-1 day' );
+
+		$query = 'query MetricsSummaryQuery($data: MetricsSummaryInput!){ metricsSummary(data:$data){ summary{ earnings pageviews sessions cpm sessionRpm pageRpm paidImpressions } } }';
+
+		$body = array(
+			'query'         => $query,
+			'operationName' => 'MetricsSummaryQuery',
+			'variables'     => array(
+				'data' => array(
+					'siteId'    => $site_id,
+					'startDate' => self::toIso( $start_date, false ),
+					'endDate'   => self::toIso( $end_date, true ),
+				),
+			),
+		);
+
+		$result = HttpClient::post(
+			self::API_BASE . '/graphql',
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Content-Type'  => 'application/json',
+				),
+				'body'    => wp_json_encode( $body ),
+				'context' => 'Mediavine metricsSummary',
+			)
+		);
+
+		if ( empty( $result['success'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to fetch Mediavine summary: ' . ( $result['error'] ?? 'Unknown error' ),
+			);
+		}
+
+		$data = json_decode( $result['data'], true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array(
+				'success' => false,
+				'error'   => 'Failed to parse Mediavine summary response.',
+			);
+		}
+
+		$error = self::graphqlError( $data );
+		if ( null !== $error ) {
+			return array(
+				'success' => false,
+				'error'   => 'Mediavine summary API error: ' . $error,
+			);
+		}
+
+		$summary = $data['data']['metricsSummary']['summary'] ?? array();
+
+		$row = array(
+			'period'          => sanitize_text_field( $input['period'] ?? '' ),
+			'earnings'        => (float) ( $summary['earnings'] ?? 0 ),
+			'pageviews'       => (int) ( $summary['pageviews'] ?? 0 ),
+			'sessions'        => (int) ( $summary['sessions'] ?? 0 ),
+			'cpm'             => (float) ( $summary['cpm'] ?? 0 ),
+			'sessionRpm'      => (float) ( $summary['sessionRpm'] ?? 0 ),
+			'pageRpm'         => (float) ( $summary['pageRpm'] ?? 0 ),
+			'paidImpressions' => (int) ( $summary['paidImpressions'] ?? 0 ),
+		);
+
+		return array(
+			'success'       => true,
+			'action'        => 'summary',
+			'site_id'       => $site_id,
+			'date_range'    => array(
+				'start_date' => $start_date,
+				'end_date'   => $end_date,
+			),
+			'results_count' => 1,
+			'results'       => array( $row ),
+		);
+	}
+
+	/**
+	 * Get a Bearer access token, logging in via GraphQL if not cached.
+	 *
+	 * The unidashSignIn mutation returns accessToken + expiresIn. The token is
+	 * cached in a transient until shortly before expiresIn so repeat calls in a
+	 * backfill reuse one login. If twoFactorRequired is true the account has 2FA
+	 * enabled, which this flow cannot satisfy — a clear error is returned.
+	 *
+	 * @param array $config Stored config ({email, password}).
+	 * @return string|\WP_Error Access token or error.
+	 */
+	private static function get_access_token( array $config ) {
+		$cached = get_transient( self::TOKEN_TRANSIENT );
+
+		if ( ! empty( $cached ) ) {
+			return $cached;
+		}
+
+		$query = 'mutation LoginFormMutation($data: UnidashSignInInput!){ unidashSignIn(data:$data){ accessToken expiresIn refreshToken tokenType twoFactorRequired userId } }';
+
+		$body = array(
+			'query'         => $query,
+			'operationName' => 'LoginFormMutation',
+			'variables'     => array(
+				'data' => array(
+					'email'    => (string) $config['email'],
+					'password' => (string) $config['password'],
+				),
+			),
+		);
+
+		$result = HttpClient::post(
+			self::API_BASE . '/graphql',
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+				'body'    => wp_json_encode( $body ),
+				'context' => 'Mediavine login',
+			)
+		);
+
+		if ( empty( $result['success'] ) ) {
+			return new \WP_Error( 'mediavine_login_failed', $result['error'] ?? 'Unknown error' );
+		}
+
+		$data = json_decode( $result['data'], true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return new \WP_Error( 'mediavine_login_parse', 'Failed to parse Mediavine login response.' );
+		}
+
+		$error = self::graphqlError( $data );
+		if ( null !== $error ) {
+			return new \WP_Error( 'mediavine_login_api', $error );
+		}
+
+		$sign_in = $data['data']['unidashSignIn'] ?? array();
+
+		if ( ! empty( $sign_in['twoFactorRequired'] ) ) {
+			return new \WP_Error( 'mediavine_2fa_required', 'Mediavine login requires two-factor authentication, which is not supported by this ability.' );
+		}
+
+		$access_token = $sign_in['accessToken'] ?? '';
+
+		if ( empty( $access_token ) ) {
+			return new \WP_Error( 'mediavine_no_token', 'Mediavine login did not return an access token. Check the configured email/password.' );
+		}
+
+		// Cache until shortly before expiry. expiresIn is in seconds; default to
+		// ~50 minutes if absent, and always keep a 60s safety margin.
+		$expires_in = (int) ( $sign_in['expiresIn'] ?? 3000 );
+		$ttl        = max( 60, $expires_in - 60 );
+
+		set_transient( self::TOKEN_TRANSIENT, $access_token, $ttl );
+
+		return $access_token;
+	}
+
+	/**
+	 * Extract a human-readable GraphQL error message, if any.
+	 *
+	 * @param mixed $data Decoded GraphQL response.
+	 * @return string|null Error message or null when there is no error.
+	 */
+	private static function graphqlError( $data ): ?string {
+		if ( ! is_array( $data ) ) {
+			return 'Empty or non-JSON response.';
+		}
+
+		if ( empty( $data['errors'] ) || ! is_array( $data['errors'] ) ) {
+			return null;
+		}
+
+		$messages = array();
+		foreach ( $data['errors'] as $err ) {
+			if ( is_array( $err ) && ! empty( $err['message'] ) ) {
+				$messages[] = (string) $err['message'];
+			}
+		}
+
+		return empty( $messages ) ? 'Unknown GraphQL error.' : implode( '; ', $messages );
+	}
+
+	/**
+	 * Resolve a date input to Y-m-d, falling back to a relative default.
+	 *
+	 * @param string $value   Raw date input.
+	 * @param string $default Relative fallback (e.g. "-28 days").
+	 * @return string Y-m-d date.
+	 */
+	private static function resolveDate( string $value, string $default ): string {
+		$value = sanitize_text_field( $value );
+		$ts    = '' !== $value ? strtotime( $value ) : false;
+		if ( false === $ts ) {
+			$ts = strtotime( $default );
+		}
+		return gmdate( 'Y-m-d', $ts );
+	}
+
+	/**
+	 * Convert a Y-m-d date to Mediavine's MM/DD/YYYY CSV-report format.
+	 *
+	 * @param string $date Y-m-d date.
+	 * @return string MM/DD/YYYY.
+	 */
+	private static function toMdy( string $date ): string {
+		$ts = strtotime( $date );
+		if ( false === $ts ) {
+			$ts = time();
+		}
+		return gmdate( 'm/d/Y', $ts );
+	}
+
+	/**
+	 * Convert a Y-m-d date to an ISO 8601 instant for metricsSummary.
+	 *
+	 * The summary GraphQL query uses ISO timestamps, not MM/DD/YYYY. Start dates
+	 * map to the start of the day, end dates to the end of the day, both in UTC.
+	 *
+	 * @param string $date     Y-m-d date.
+	 * @param bool   $end_of_day Whether this is an end date (end of day).
+	 * @return string ISO 8601 timestamp.
+	 */
+	private static function toIso( string $date, bool $end_of_day ): string {
+		$ts = strtotime( $date );
+		if ( false === $ts ) {
+			$ts = time();
+		}
+		$time = $end_of_day ? '23:59:59.999' : '00:00:00.000';
+		return gmdate( 'Y-m-d', $ts ) . 'T' . $time . 'Z';
+	}
+
+	/**
+	 * Parse a money/number cell into a float (strips $, commas, %).
+	 *
+	 * @param string $value Raw cell.
+	 * @return float
+	 */
+	private static function parseNumber( string $value ): float {
+		$value = preg_replace( '/[^0-9.\-]/', '', $value );
+		return '' === $value ? 0.0 : (float) $value;
+	}
+
+	/**
+	 * Check if Mediavine is configured.
+	 *
+	 * @return bool
+	 */
+	public static function is_configured(): bool {
+		$config = self::get_config();
+		return ! empty( $config['email'] ) && ! empty( $config['password'] );
+	}
+
+	/**
+	 * Get stored configuration.
+	 *
+	 * @return array
+	 */
+	public static function get_config(): array {
+		return get_site_option( self::CONFIG_OPTION, array() );
+	}
+}


### PR DESCRIPTION
## Summary

Adds `datamachine/mediavine-reports` — a DMB ability that fetches per-period, per-URL Mediavine ad revenue **directly over HTTP** (no browser, no Playwright, no cross-host glue). Structural sibling of `GoogleAnalyticsAbilities`.

Closes #47.

## The real (tested 2026-06-21) Mediavine API

PHP `wp_remote_*` reaches the Mediavine publisher API directly from Extra Chill prod — confirmed: a plain GET of the pages CSV returns HTTP 200 with creds, HTTP 401 without (reachability proven from this host). Three surfaces:

1. **Login** — `POST /graphql` `unidashSignIn(...)` mutation → `accessToken` + `expiresIn`. Cached in a transient until shortly before expiry. `twoFactorRequired === true` → clear error (2FA unsupported).
2. **Pages CSV** — `GET /reports/{site_id}/pages.csv?startDate=MM/DD/YYYY&endDate=MM/DD/YYYY&perPage=100000&useMonetizable=false` with `Authorization: Bearer`. Returns `slug,views,revenue,rpm,cpm,viewability,fillRate,impressionsPerPageview`. Default `site_id` = `SW50ZXJuYWxTaXRlOjExNDc2`.
3. **Summary (bonus)** — `metricsSummary(...)` GraphQL, site-level totals. Note: this one uses **ISO timestamps** (`2023-01-01T05:00:00.000Z`), NOT MM/DD/YYYY — handled distinctly in `toIso()` vs `toMdy()`.

## Actions (input `action`)

- `pages` — per-period CSV → parsed rows (typed: views int, money/ratios float), each stamped with `period`.
- `summary` — site-level aggregate row (earnings, pageviews, sessions, rpm…).
- `backfill` — iterate a `periods` list of `{period, start_date, end_date}` → all rows merged, with a per-period summary; one bad month never aborts a multi-year backfill.

Output rows match the tokens `extrachill analytics revenue import` matches loosely, so they drop straight into the revenue store.

## Mirrors GoogleAnalyticsAbilities exactly

- `const CONFIG_OPTION = 'datamachine_mediavine_config'` read via `get_config()` (`get_site_option`); creds `{email, password}` stored **server-side only**, never in code.
- Token cached in a transient; authenticate → fetch → return structured rows.
- Registered on `wp_abilities_api_init`, `PermissionHelper::can_manage`, category `datamachine-analytics`, `show_in_rest => false`.
- Instantiated in `data-machine-business.php` next to `GoogleAnalyticsAbilities`.

## Verification

- `php -l` clean on both files.
- `phpcs --standard=WordPress`: remaining findings (camelCase method names + class-filename) are the **same baseline shared by GoogleAnalyticsAbilities** (GA has 34 of the same class; this file has a strict subset) — not churned, per repo convention. All genuinely-new findings (array alignment, param spacing) fixed via phpcbf.
- Could not run an authed live fetch (creds are not in this env) — code is structured against the documented API shapes; login-mutation body, CSV-URL construction, and MM/DD/YYYY vs ISO date formatting verified by inspection, and endpoint reachability confirmed (HTTP 401 unauthenticated).

## Operator setup

```php
update_site_option( 'datamachine_mediavine_config', array(
    'email'    => '...',
    'password' => '...',
    // optional: 'site_id' => 'SW50ZXJuYWxTaXRlOjExNDc2',
) );
```

CLI wrapper (`wp extrachill analytics revenue fetch`) lands in a companion extrachill-cli PR — merge this first.