### PR TITLE
fix: allow public/anonymous use of sendy-subscribe ability

### DIFF
--- a/inc/Abilities/Sendy/SendyAbilities.php
+++ b/inc/Abilities/Sendy/SendyAbilities.php
@@ -129,7 +129,7 @@ class SendyAbilities {
 				),
 				'output_schema'       => array( 'type' => 'object' ),
 				'execute_callback'    => array( $this, 'execute_subscribe' ),
-				'permission_callback' => array( $this, 'check_permission' ),
+				'permission_callback' => array( $this, 'check_subscribe_permission' ),
 				'meta'                => array( 'show_in_rest' => false ),
 			)
 		);
@@ -213,12 +213,31 @@ class SendyAbilities {
 	}
 
 	/**
-	 * Shared permission gate.
+	 * Management permission gate for privileged Sendy abilities
+	 * (push-campaign, metrics).
 	 *
 	 * @return bool
 	 */
 	public function check_permission(): bool {
 		return PermissionHelper::can_manage();
+	}
+
+	/**
+	 * Public permission gate for the subscribe ability.
+	 *
+	 * Subscribing an email to a list is an inherently public/anonymous action:
+	 * it backs the front-end newsletter signup form, which is submitted by
+	 * logged-out visitors. Gating it behind a management capability breaks every
+	 * real signup (it only "works" via WP-CLI, which bypasses permissions).
+	 *
+	 * Abuse is already mitigated upstream — the EC signup form is protected by
+	 * Cloudflare Turnstile, and Sendy itself dedupes repeat addresses — so this
+	 * primitive is intentionally open.
+	 *
+	 * @return bool
+	 */
+	public function check_subscribe_permission(): bool {
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`inc/Abilities/Sendy/SendyAbilities.php` gated all three Sendy abilities (subscribe, push-campaign, metrics) behind a single `check_permission()` → `PermissionHelper::can_manage()`. This PR splits the subscribe ability onto its own public permission callback.

## Root cause

One permission gate conflated three different trust levels. `can_manage()` (requires `manage_flows || manage_settings || manage_agents`) is correct for **push-campaign** and **metrics**, but wrong for `datamachine/sendy-subscribe`. Subscribing an email is an inherently **public/anonymous** action — it backs the front-end newsletter signup form, submitted by logged-out visitors. The shared gate therefore failed every real signup; it only appeared to "work" via WP-CLI, which bypasses permissions entirely.

## Before / after permission model

| Ability | Before | After |
|---|---|---|
| `datamachine/sendy-subscribe` | `can_manage()` | **public (`true`)** |
| `datamachine/sendy-push-campaign` | `can_manage()` | `can_manage()` (unchanged) |
| `datamachine/sendy-metrics` | `can_manage()` | `can_manage()` (unchanged) |

The subscribe ability now uses a dedicated `check_subscribe_permission()` returning `true`. Abuse is already mitigated upstream — the EC signup form is protected by Cloudflare Turnstile, and Sendy itself dedupes repeat addresses — so this primitive is intentionally open.

The fix is layer-pure: it lives in the primitive that owns the permission decision, not worked around in `extrachill-newsletter`.

## Prod evidence

Production `debug.log` shows 11 real signup failures since 22-Jun-2026:
> `Newsletter subscription failed: Ability datamachine/sendy-subscribe does not have necessary permission.`

## Verification

- `php -l inc/Abilities/Sendy/SendyAbilities.php` → clean.
- Confirmed only subscribe (line 132) switched to `check_subscribe_permission`; push-campaign (168) and metrics (203) remain on `check_permission`.

Closes Extra-Chill/data-machine-business#52