### PR TITLE
Remove hardcoded Extra Chill knowledge from Analytics abilities (layer purity)

### DIFF
--- a/inc/Abilities/Analytics/ContentFlagsAbility.php
+++ b/inc/Abilities/Analytics/ContentFlagsAbility.php
@@ -179,7 +179,7 @@ class ContentFlagsAbility {
 							),
 							'hostname' => array(
 								'type'        => 'string',
-								'description' => 'Hostname whose pages map to this blog\'s posts (default: extrachill.com).',
+								'description' => 'Hostname whose pages map to this blog\'s posts. Required unless a consumer registers a default via the datamachine_analytics_default_hostname filter.',
 							),
 						),
 					),
@@ -247,12 +247,15 @@ class ContentFlagsAbility {
 		// post that had ANY traffic — the demand flag carries its own session
 		// gate (>=10), so the ranking-honesty gate content-performance uses (>=5)
 		// is not what we want here.
+		// hostname is passed straight through (possibly absent); audit() resolves
+		// it via input -> datamachine_analytics_default_hostname filter and
+		// returns a clear error when neither supplies a host.
 		$performance = ContentPerformanceAbility::audit(
 			array(
 				'category'     => $category,
 				'days'         => isset( $input['days'] ) ? max( 1, (int) $input['days'] ) : ContentPerformanceAbility::DEFAULT_DAYS,
 				'min_sessions' => 1,
-				'hostname'     => ! empty( $input['hostname'] ) ? sanitize_text_field( $input['hostname'] ) : ContentPerformanceAbility::DEFAULT_HOSTNAME,
+				'hostname'     => ! empty( $input['hostname'] ) ? sanitize_text_field( $input['hostname'] ) : '',
 				'sort_by'      => 'duration',
 			)
 		);

--- a/inc/Abilities/Analytics/ContentPerformanceAbility.php
+++ b/inc/Abilities/Analytics/ContentPerformanceAbility.php
@@ -49,19 +49,41 @@ class ContentPerformanceAbility {
 	 */
 	const DEFAULT_MIN_SESSIONS = 5;
 
+	private static bool $registered = false;
+
 	/**
-	 * Default hostname for resolving page paths to posts.
+	 * Resolve the hostname used to map GA page paths to posts.
 	 *
 	 * The GA `engagement` action groups by pagePath only (host-independent), so
 	 * on a multisite GA4 property we constrain to one host to avoid cross-site
 	 * "/" collisions. The category posts are resolved on the current blog via
 	 * url_to_postid(), so this should match the blog the command runs on.
 	 *
-	 * @var string
+	 * Resolution order: explicit input -> the
+	 * `datamachine_analytics_default_hostname` filter (a consumer plugin
+	 * supplies its own site's host) -> empty. This generic layer ships with no
+	 * site baked in; when nothing resolves, the caller must require the input.
+	 *
+	 * @param array $input Ability input.
+	 * @return string Hostname, or '' when neither input nor filter supplies one.
 	 */
-	const DEFAULT_HOSTNAME = 'extrachill.com';
+	public static function resolve_hostname( array $input ): string {
+		if ( ! empty( $input['hostname'] ) ) {
+			return sanitize_text_field( $input['hostname'] );
+		}
 
-	private static bool $registered = false;
+		/**
+		 * Filter the default hostname for analytics page-to-post mapping.
+		 *
+		 * Generic Data Machine layers ship with no site baked in. A consumer
+		 * plugin registers its own site's hostname here so the analytics
+		 * abilities can map GA page paths to local posts without an explicit
+		 * `hostname` input on every call.
+		 *
+		 * @param string $hostname Default hostname. Empty string by default.
+		 */
+		return sanitize_text_field( (string) apply_filters( 'datamachine_analytics_default_hostname', '' ) );
+	}
 
 	public function __construct() {
 		if ( self::$registered ) {
@@ -98,7 +120,7 @@ class ContentPerformanceAbility {
 							),
 							'hostname'     => array(
 								'type'        => 'string',
-								'description' => 'Hostname whose pages map to this blog\'s posts (default: extrachill.com). The GA engagement report is filtered to this host.',
+								'description' => 'Hostname whose pages map to this blog\'s posts. The GA engagement report is filtered to this host. Required unless a consumer registers a default via the datamachine_analytics_default_hostname filter.',
 							),
 							'sort_by'      => array(
 								'type'        => 'string',
@@ -145,13 +167,20 @@ class ContentPerformanceAbility {
 		$category     = sanitize_title( $input['category'] ?? '' );
 		$days         = ! empty( $input['days'] ) ? max( 1, (int) $input['days'] ) : self::DEFAULT_DAYS;
 		$min_sessions = isset( $input['min_sessions'] ) ? max( 1, (int) $input['min_sessions'] ) : self::DEFAULT_MIN_SESSIONS;
-		$hostname     = ! empty( $input['hostname'] ) ? sanitize_text_field( $input['hostname'] ) : self::DEFAULT_HOSTNAME;
+		$hostname     = self::resolve_hostname( $input );
 		$sort_by      = ( 'rate' === ( $input['sort_by'] ?? '' ) ) ? 'rate' : 'duration';
 
 		if ( '' === $category ) {
 			return array(
 				'success' => false,
 				'error'   => 'A category slug is required.',
+			);
+		}
+
+		if ( '' === $hostname ) {
+			return array(
+				'success' => false,
+				'error'   => 'A hostname is required. Pass the "hostname" input or register a default via the datamachine_analytics_default_hostname filter.',
 			);
 		}
 

--- a/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
+++ b/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
@@ -400,18 +400,27 @@ class GoogleAnalyticsAbilities {
 		// network_density groups by hostName x pageReferrer. pageReferrer is a
 		// near-unbounded, high-cardinality dimension, so the single-page GA4 row
 		// cap fills with the largest external/"(other)" referrer buckets and the
-		// small in-network EC->EC referrer rows fall off the end — silently
-		// under-counting in-network referrals. Constrain pageReferrer to EC hosts
-		// server-side so GA4 only returns in-network rows BEFORE the cap applies,
-		// keeping it one cheap API call (there are far fewer than the row cap of
-		// distinct in-network referrer buckets) and making the result
-		// volume-independent.
+		// small in-network referrer rows fall off the end — silently
+		// under-counting in-network referrals. Constrain pageReferrer to the
+		// configured in-network hosts server-side so GA4 only returns in-network
+		// rows BEFORE the cap applies, keeping it one cheap API call (there are
+		// far fewer than the row cap of distinct in-network referrer buckets) and
+		// making the result volume-independent.
 		if ( 'network_density' === $action ) {
-			// Source the EC host set from a filter so it lives in one place
-			// rather than as a brittle inline literal at the call site.
+			/**
+			 * Filter the set of in-network hosts used to constrain the
+			 * network_density referrer query.
+			 *
+			 * Generic Data Machine layers ship with no site baked in. A consumer
+			 * plugin registers its own network's hostnames here. With no consumer
+			 * configured this defaults to an empty list and no referrer
+			 * constraint is applied.
+			 *
+			 * @param array $network_hosts List of in-network hostnames. Empty by default.
+			 */
 			$network_hosts = apply_filters(
 				'datamachine_network_density_hosts',
-				array( 'extrachill.com', 'extrachill.link' )
+				array()
 			);
 
 			$host_expressions = array();
@@ -421,8 +430,8 @@ class GoogleAnalyticsAbilities {
 					continue;
 				}
 				// CONTAINS covers the apex host and every subdomain
-				// (e.g. "extrachill.com" matches both "extrachill.com" and
-				// "community.extrachill.com"), so wildcard subdomains are
+				// (e.g. "example.com" matches both "example.com" and
+				// "sub.example.com"), so wildcard subdomains are
 				// implicit and do not need separate patterns.
 				$host_expressions[] = array(
 					'filter' => array(

--- a/inc/Abilities/Analytics/MediavineReportsAbilities.php
+++ b/inc/Abilities/Analytics/MediavineReportsAbilities.php
@@ -14,8 +14,8 @@
  *   1. GraphQL login mutation (unidashSignIn) -> a Bearer access token, cached
  *      in a transient until it expires.
  *   2. The per-page revenue CSV report (slug,views,revenue,rpm,cpm,viewability,
- *      fillRate,impressionsPerPageview) for a date range — the rows that feed
- *      `extrachill analytics revenue import`.
+ *      fillRate,impressionsPerPageview) for a date range — the rows a consumer
+ *      CLI plugin imports into its revenue store.
  *
  * A bonus `summary` action calls the metricsSummary GraphQL query for
  * site-level totals (note: that query uses ISO timestamps, NOT MM/DD/YYYY).
@@ -63,13 +63,6 @@ class MediavineReportsAbilities {
 	 * @var string
 	 */
 	const API_BASE = 'https://api-publishers.mediavine.com';
-
-	/**
-	 * Default Extra Chill site id (base64 "InternalSite:11476").
-	 *
-	 * @var string
-	 */
-	const DEFAULT_SITE_ID = 'SW50ZXJuYWxTaXRlOjExNDc2';
 
 	/**
 	 * Per-page CSV row cap requested from Mediavine.
@@ -131,7 +124,7 @@ class MediavineReportsAbilities {
 							),
 							'site_id'    => array(
 								'type'        => 'string',
-								'description' => 'Mediavine site id. Defaults to the configured site_id, else the Extra Chill default.',
+								'description' => 'Mediavine site id. Defaults to the configured site_id, else the datamachine_mediavine_default_site_id filter. Required when neither is set.',
 							),
 						),
 					),
@@ -195,9 +188,14 @@ class MediavineReportsAbilities {
 			);
 		}
 
-		$site_id = ! empty( $input['site_id'] )
-			? sanitize_text_field( $input['site_id'] )
-			: ( ! empty( $config['site_id'] ) ? (string) $config['site_id'] : self::DEFAULT_SITE_ID );
+		$site_id = self::resolve_site_id( $input, $config );
+
+		if ( '' === $site_id ) {
+			return array(
+				'success' => false,
+				'error'   => 'A Mediavine site id is required. Pass the "site_id" input, set site_id in the datamachine_mediavine_config option, or register a default via the datamachine_mediavine_default_site_id filter.',
+			);
+		}
 
 		if ( 'summary' === $action ) {
 			return self::fetchSummary( $input, $access_token, $site_id );
@@ -715,6 +713,40 @@ class MediavineReportsAbilities {
 	public static function is_configured(): bool {
 		$config = self::get_config();
 		return ! empty( $config['email'] ) && ! empty( $config['password'] );
+	}
+
+	/**
+	 * Resolve the Mediavine site id to query.
+	 *
+	 * Resolution order: explicit input -> the configured `site_id` in the
+	 * datamachine_mediavine_config option -> the
+	 * `datamachine_mediavine_default_site_id` filter -> empty. This generic
+	 * layer ships with no site id baked in; when nothing resolves, the caller
+	 * must require the input.
+	 *
+	 * @param array $input  Ability input.
+	 * @param array $config Stored Mediavine config.
+	 * @return string Mediavine site id, or '' when nothing supplies one.
+	 */
+	private static function resolve_site_id( array $input, array $config ): string {
+		if ( ! empty( $input['site_id'] ) ) {
+			return sanitize_text_field( $input['site_id'] );
+		}
+
+		if ( ! empty( $config['site_id'] ) ) {
+			return (string) $config['site_id'];
+		}
+
+		/**
+		 * Filter the default Mediavine site id.
+		 *
+		 * Generic Data Machine layers ship with no site id baked in. A consumer
+		 * plugin registers its own Mediavine site id here so the revenue
+		 * abilities can run without an explicit `site_id` input on every call.
+		 *
+		 * @param string $site_id Default Mediavine site id. Empty string by default.
+		 */
+		return sanitize_text_field( (string) apply_filters( 'datamachine_mediavine_default_site_id', '' ) );
 	}
 
 	/**

--- a/inc/Cli/GoogleAnalyticsCommand.php
+++ b/inc/Cli/GoogleAnalyticsCommand.php
@@ -92,7 +92,7 @@ class GoogleAnalyticsCommand extends BaseCommand {
 	 *     wp datamachine analytics ga path_sequence
 	 *
 	 *     # Filter by hostname for multisite
-	 *     wp datamachine analytics ga page_stats --hostname=events.extrachill.com
+	 *     wp datamachine analytics ga page_stats --hostname=events.example.com
 	 *
 	 *     # Compare last 28 days vs previous 28 days
 	 *     wp datamachine analytics ga page_stats --compare

--- a/inc/Runtime/AgentsMdSections.php
+++ b/inc/Runtime/AgentsMdSections.php
@@ -10,9 +10,9 @@
  * The command surface is read from {@see \DataMachineBusiness\Cli\CommandRegistry},
  * the single source of truth shared with the WP-CLI bootstrap. Each command is
  * reflected via the shared `\DataMachine\Engine\AI\CliCommandIntrospector`
- * (the intelligence / extrachill-cli pattern) when present, with a minimal,
- * self-contained fallback so this plugin never hard-depends on an unreleased
- * core class. Every command this plugin owns is a flat `__invoke` command — the
+ * (the shared CLI-introspection pattern a consumer CLI plugin also uses) when
+ * present, with a minimal, self-contained fallback so this plugin never
+ * hard-depends on an unreleased core class. Every command this plugin owns is a flat `__invoke` command — the
  * action is a positional argument, not a WP-CLI subcommand — so each reflects
  * to a single `__default` entry and renders as a headline carrying the
  * command's own short description.

--- a/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
@@ -132,7 +132,7 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
 			array(
 				'page_filter' => '/about/',
-				'hostname'    => 'extrachill.com',
+				'hostname'    => 'example.com',
 				'start_date'  => '2026-01-01',
 				'end_date'    => '2026-01-31',
 			),
@@ -230,12 +230,12 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * network_density must constrain pageReferrer to the in-network EC hosts
-	 * server-side so the GA4 row cap can't truncate the in-network referrer
-	 * long tail. With no other filter, the single dimensionFilter is the OR
-	 * group of pageReferrer CONTAINS expressions for the default host set.
+	 * The generic layer ships with NO in-network host set baked in. With no
+	 * consumer registering the datamachine_network_density_hosts filter, the
+	 * default host list is empty and network_density emits no pageReferrer
+	 * dimensionFilter — the EC-specific default was removed (layer purity).
 	 */
-	public function test_network_density_filters_referrer_to_in_network_hosts(): void {
+	public function test_network_density_emits_no_referrer_filter_by_default(): void {
 		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
 			array(
 				'start_date' => '2026-01-01',
@@ -244,19 +244,48 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 			'network_density'
 		);
 
+		$this->assertArrayNotHasKey(
+			'dimensionFilter',
+			$body,
+			'With no configured in-network hosts, network_density must not emit a referrer filter'
+		);
+	}
+
+	/**
+	 * When a consumer registers multiple in-network hosts via the filter,
+	 * network_density constrains pageReferrer to that host set server-side
+	 * (an orGroup of CONTAINS expressions) so the GA4 row cap can't truncate
+	 * the in-network referrer long tail.
+	 */
+	public function test_network_density_filters_referrer_to_configured_hosts(): void {
+		$callback = static fn() => array( 'example.com', 'example.link' );
+		add_filter( 'datamachine_network_density_hosts', $callback );
+
+		try {
+			$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+				array(
+					'start_date' => '2026-01-01',
+					'end_date'   => '2026-01-31',
+				),
+				'network_density'
+			);
+		} finally {
+			remove_filter( 'datamachine_network_density_hosts', $callback );
+		}
+
 		$this->assertArrayHasKey(
 			'dimensionFilter',
 			$body,
-			'network_density must emit an in-network pageReferrer dimensionFilter'
+			'Configured in-network hosts must emit a pageReferrer dimensionFilter'
 		);
 		$this->assertArrayHasKey(
 			'orGroup',
 			$body['dimensionFilter'],
-			'Default multi-host set must produce an orGroup of pageReferrer expressions'
+			'A multi-host set must produce an orGroup of pageReferrer expressions'
 		);
 
 		$expressions = $body['dimensionFilter']['orGroup']['expressions'];
-		$this->assertCount( 2, $expressions, 'Default EC host set has two hosts' );
+		$this->assertCount( 2, $expressions, 'Configured host set has two hosts' );
 
 		foreach ( $expressions as $expr ) {
 			$filter = $expr['filter'];
@@ -268,12 +297,13 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 			static fn( $e ) => $e['filter']['stringFilter']['value'],
 			$expressions
 		);
-		$this->assertContains( 'extrachill.com', $values );
-		$this->assertContains( 'extrachill.link', $values );
+		$this->assertContains( 'example.com', $values );
+		$this->assertContains( 'example.link', $values );
 	}
 
 	/**
-	 * The in-network host set is config/filter-driven, not an inline literal.
+	 * The in-network host set is config/filter-driven, not an inline literal. A
+	 * single configured host collapses to one (non-grouped) filter expression.
 	 */
 	public function test_network_density_hosts_are_filterable(): void {
 		$callback = static fn() => array( 'example.test' );
@@ -303,14 +333,21 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 	 * counting in-network referrers.
 	 */
 	public function test_network_density_referrer_filter_ands_with_hostname(): void {
-		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
-			array(
-				'hostname'   => 'extrachill.com',
-				'start_date' => '2026-01-01',
-				'end_date'   => '2026-01-31',
-			),
-			'network_density'
-		);
+		$callback = static fn() => array( 'example.com', 'example.link' );
+		add_filter( 'datamachine_network_density_hosts', $callback );
+
+		try {
+			$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+				array(
+					'hostname'   => 'example.com',
+					'start_date' => '2026-01-01',
+					'end_date'   => '2026-01-31',
+				),
+				'network_density'
+			);
+		} finally {
+			remove_filter( 'datamachine_network_density_hosts', $callback );
+		}
 
 		$this->assertArrayHasKey( 'andGroup', $body['dimensionFilter'] );
 		$expressions = $body['dimensionFilter']['andGroup']['expressions'];


### PR DESCRIPTION
## Summary

The `data-machine-business` Analytics abilities baked one specific site's identity (`extrachill.com` / `extrachill.link` / a Mediavine site id) into a **generic, distributable** Data Machine layer — a layer-purity violation, since no Data Machine plugin may know Extra Chill exists. This PR removes every EC literal and replaces each site-specific default with a value resolved from **config** (an explicit ability input or a filter, defaulting to empty). A consumer plugin supplies the real value; the generic layer ships with no site baked in.

Closes Extra-Chill/data-machine-business#54

## Files changed

- `inc/Abilities/Analytics/ContentPerformanceAbility.php` — removed `const DEFAULT_HOSTNAME = 'extrachill.com'`; added `resolve_hostname()` (input → filter); `audit()` now returns a clear error when no hostname resolves; neutral field description.
- `inc/Abilities/Analytics/ContentFlagsAbility.php` — passes `hostname` straight through (no EC fallback); relies on `ContentPerformanceAbility::audit()` to resolve/require it; neutral field description.
- `inc/Abilities/Analytics/GoogleAnalyticsAbilities.php` — `network_density` in-network host list default changed from `['extrachill.com','extrachill.link']` to `[]`; with no consumer configured, no referrer filter is applied; comments made generic.
- `inc/Abilities/Analytics/MediavineReportsAbilities.php` — removed `const DEFAULT_SITE_ID` (the EC base64 site id) and the "Extra Chill default" labeling + `extrachill analytics revenue import` reference; added `resolve_site_id()` (input → configured `site_id` → filter); `fetch()` returns a clear error when none resolves.
- `inc/Cli/GoogleAnalyticsCommand.php` — docblock example host `events.extrachill.com` → `events.example.com`.
- `inc/Runtime/AgentsMdSections.php` — reworded "the intelligence / extrachill-cli pattern" to a generic "shared CLI-introspection pattern a consumer CLI plugin also uses".
- `tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php` — updated to the generic behavior: empty default emits no referrer filter; the host set is filter-driven; neutral test hostnames.

## New filter hooks (what a consumer should register)

| Filter | Default | A consumer registers… |
|--------|---------|------------------------|
| `datamachine_analytics_default_hostname` | `''` | the site's hostname used to map GA page paths → local posts (used by `content-performance` and `content-flags`). When empty and no `hostname` input is given, the ability returns a clear error rather than defaulting to a specific site. |
| `datamachine_network_density_hosts` | `[]` | the list of in-network hostnames constraining the `network_density` `pageReferrer` query. When empty, no referrer constraint is applied. (Hook already existed; only its default changed from the EC literal to `[]`.) |
| `datamachine_mediavine_default_site_id` | `''` | the default Mediavine site id. Resolution order is input → configured `site_id` (in `datamachine_mediavine_config`) → this filter. When none resolve, the ability returns a clear error. |

**EC-side registration is a follow-up, out of scope here.** The real `extrachill.com` hostname, the `['extrachill.com','extrachill.link']` set, and the Mediavine site id will be registered LATER from an Extra Chill plugin via these filters. They are intentionally **not** added anywhere in `data-machine-business` (not even as a config default).

## Verification

- **Acceptance grep (the same grep that proved the violation):**
  ```
  grep -riE 'extrachill|extra[ _]chill' inc/ | grep -v vendor
  ```
  → **zero matches** (also zero across `tests/`).
- `php -l` clean on every touched file.
- `homeboy test data-machine-business`: all 5 Analytics-ability tests pass (28/29 overall).

## Note on the one unrelated test failure

`homeboy test` reports **1 pre-existing, out-of-scope failure**: `GoogleSearchConsoleBusinessTest.php:47` asserts that `data-machine-business.php` contains the string `datamachine analytics gsc`. That string actually lives in `inc/Cli/CommandRegistry.php` (the CLI registration was refactored out of the root plugin file into the registry), so the assertion is stale. This PR does **not** touch `data-machine-business.php`, `inc/Cli/CommandRegistry.php`, `inc/Tools/`, or `inc/Api/` — the failure is independent of this change and should be fixed in a separate PR.

## Behavior contract

- When the filters/inputs **are** supplied → resolution path is sound, abilities behave exactly as before.
- When a required hostname / Mediavine site id is **absent** → the ability returns a clear `success:false` error (not a fatal, not a silent EC default).