### PR TITLE
feat: repoint analytics REST routes to view_analytics cap (GSC/PageSpeed)

### DIFF
--- a/inc/Api/GoogleSearchConsoleAnalytics.php
+++ b/inc/Api/GoogleSearchConsoleAnalytics.php
@@ -43,7 +43,7 @@ class GoogleSearchConsoleAnalytics {
 
 	public static function check_permission( $request ) {
 		$request;
-		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
+		if ( ! PermissionHelper::can( 'view_analytics' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to access analytics data.', 'data-machine-business' ),

--- a/inc/Api/PageSpeedAnalytics.php
+++ b/inc/Api/PageSpeedAnalytics.php
@@ -39,7 +39,7 @@ class PageSpeedAnalytics {
 
 	public static function check_permission( $request ) {
 		$request;
-		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
+		if ( ! PermissionHelper::can( 'view_analytics' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to access analytics data.', 'data-machine-business' ),


### PR DESCRIPTION
## Summary

Repoints this plugin's analytics REST `check_permission` callbacks from `PermissionHelper::can('manage_flows')` to `PermissionHelper::can('view_analytics')`, completing the read-only analytics cap tier introduced in data-machine#2807 (merged) for the routes that live in **this** plugin.

- `inc/Api/GoogleSearchConsoleAnalytics.php` (`POST /datamachine/v1/analytics/gsc`)
- `inc/Api/PageSpeedAnalytics.php` (`POST /datamachine/v1/analytics/pagespeed`)

Closes #57

## GA-route finding (investigated)

GA and Bing are **served by data-machine core's generic router** (`data-machine/inc/Api/Analytics.php`), not by local route files in this plugin. This plugin only contributes them as route→ability map entries via the `datamachine_analytics_ability_map` filter in `data-machine-business.php`:

```php
$ability_map['ga']   = 'datamachine/google-analytics';
$ability_map['bing'] = 'datamachine/bing-webmaster';
```

The core router's `check_permission` was already repointed to `view_analytics` in data-machine#2807. There is **no GA-specific `check_permission` in this repo** (`inc/Api/` contains only `GoogleSearchConsoleAnalytics.php` and `PageSpeedAnalytics.php`; `GoogleAnalyticsAbilities` is the ability impl, not a route). So **GA + Bing need no change here** — they inherit `view_analytics` from core once the grant lands.

## No-regression confirmation

Verified against the **merged** `PermissionHelper` in data-machine (not the older deployed copy):

- `CAPABILITY_MAP['view_analytics'] => 'datamachine_view_analytics'`
- `can()` short-circuit: `if ( 'view_analytics' === $action && self::can_manage() ) { return true; }`

`can_manage()` is `can('manage_flows') || can('manage_settings') || can('manage_agents')`, so every existing admin / `manage_flows` holder automatically passes `can('view_analytics')`. Access is only **widened** to holders of the dedicated read-only `datamachine_view_analytics` cap — those holders can hit these read routes but not the DM write surface (which still gates on `manage_flows`/`manage_settings`/`manage_agents`).

## Layer purity

Diff references only the generic `view_analytics` cap. Zero Extra Chill / team / `access_studio` / vendor references (grepped the diff — clean). The team grant lives entirely in extrachill-users via `user_has_cap`.

## Verification

- `php -l` clean on both changed files.
- No composer scripts / vendor harness defined in this repo; existing `tests/` cover GA ability request-body construction, unrelated to this permission change. No new failures introduced in changed files.