### PR TITLE
fix: constrain GSC site_url to the verified property and clarify 403s

### DIFF
--- a/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php
+++ b/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php
@@ -190,7 +190,14 @@ class GoogleSearchConsoleAbilities {
 			);
 		}
 
-		$site_url = ! empty( $input['site_url'] ) ? sanitize_text_field( $input['site_url'] ) : ( $config['site_url'] ?? '' );
+		$site_url = self::resolve_site_url( $input, $config );
+
+		if ( is_wp_error( $site_url ) ) {
+			return array(
+				'success' => false,
+				'error'   => $site_url->get_error_message(),
+			);
+		}
 
 		// Route to specialized handlers for non-analytics actions.
 		if ( 'inspect_url' === $action ) {
@@ -273,7 +280,7 @@ class GoogleSearchConsoleAbilities {
 		if ( ! $result['success'] ) {
 			return array(
 				'success' => false,
-				'error'   => 'Failed to connect to Google Search Console API: ' . ( $result['error'] ?? 'Unknown error' ),
+				'error'   => self::describe_request_error( $result['error'] ?? 'Unknown error', $site_url ),
 			);
 		}
 
@@ -302,6 +309,103 @@ class GoogleSearchConsoleAbilities {
 			'results_count' => count( $rows ),
 			'results'       => $rows,
 		);
+	}
+
+	/**
+	 * Resolve the GSC property to query, constraining any model-supplied site_url
+	 * to the configured property.
+	 *
+	 * The service account is verified on exactly one GSC property (the configured
+	 * `site_url`). Forwarding an arbitrary model-supplied property to Google produces
+	 * an opaque HTTP 403 that reads like an auth outage. To prevent that, a supplied
+	 * site_url is only honoured when it matches the configured property; anything else
+	 * is rejected up front with an actionable error, before any Google request.
+	 *
+	 * Behaviour preserved: with no site_url in the input, the configured property is
+	 * used (the CLI default path that works today).
+	 *
+	 * @param array $input  Ability input.
+	 * @param array $config GSC configuration.
+	 * @return string|\WP_Error Resolved property URL, or WP_Error when the supplied
+	 *                          property is not the configured/verified one.
+	 */
+	private static function resolve_site_url( array $input, array $config ) {
+		$configured = isset( $config['site_url'] ) ? (string) $config['site_url'] : '';
+		$supplied   = ! empty( $input['site_url'] ) ? sanitize_text_field( $input['site_url'] ) : '';
+
+		if ( '' === $supplied ) {
+			return $configured;
+		}
+
+		if ( '' === $configured ) {
+			// Nothing to validate against — honour the supplied value as before.
+			return $supplied;
+		}
+
+		if ( self::normalize_property( $supplied ) === self::normalize_property( $configured ) ) {
+			return $configured;
+		}
+
+		return new \WP_Error(
+			'gsc_property_not_verified',
+			sprintf(
+				'Requested GSC property "%1$s" is not verified for the configured service account. This install is scoped to "%2$s". Omit site_url to query the configured property, or verify "%1$s" for the service account in Google Search Console.',
+				$supplied,
+				$configured
+			)
+		);
+	}
+
+	/**
+	 * Normalize a GSC property URL for comparison.
+	 *
+	 * Treats `https://example.com/`, `https://example.com`, and `sc-domain:example.com`
+	 * as equivalent host-level references so a model-supplied URL-prefix property can
+	 * match a configured domain property (and vice versa).
+	 *
+	 * @param string $property Property string.
+	 * @return string Normalized host key.
+	 */
+	private static function normalize_property( string $property ): string {
+		$property = strtolower( trim( $property ) );
+
+		if ( 0 === strpos( $property, 'sc-domain:' ) ) {
+			$host = substr( $property, strlen( 'sc-domain:' ) );
+		} else {
+			$parsed = wp_parse_url( $property );
+			$host   = $parsed['host'] ?? $property;
+			$path   = isset( $parsed['path'] ) ? trim( $parsed['path'], '/' ) : '';
+			if ( '' !== $path ) {
+				// URL-prefix property with a path is distinct from a domain property.
+				return $host . '/' . $path;
+			}
+		}
+
+		return ltrim( rtrim( $host, '/' ), '/' );
+	}
+
+	/**
+	 * Turn a raw HttpClient error string into an actionable message.
+	 *
+	 * A Google 403 on the searchAnalytics endpoint means the service account is not
+	 * verified for the requested property — not that Data Machine's credential or the
+	 * WP capability gate failed. Surfacing that distinction stops operators from
+	 * misreading a property-scope problem as an auth outage.
+	 *
+	 * @param string $error    Raw error from HttpClient.
+	 * @param string $site_url Property the request targeted.
+	 * @return string Actionable error message.
+	 */
+	private static function describe_request_error( string $error, string $site_url ): string {
+		if ( false !== strpos( $error, 'HTTP 403' ) ) {
+			return sprintf(
+				'Google Search Console returned HTTP 403 for property "%s": the configured service account is not verified for this property. This is a property-authorization issue, not a Data Machine credential or WordPress permission failure. Verify the property for the service account in Google Search Console, or target a verified property. (Raw: %s)',
+				$site_url,
+				$error
+			);
+		}
+
+		return 'Failed to connect to Google Search Console API: ' . $error;
 	}
 
 	/**
@@ -590,7 +694,7 @@ class GoogleSearchConsoleAbilities {
 	 * @return string|\WP_Error Access token or error.
 	 */
 	private static function get_access_token( array $service_account ) {
-		$cached = get_transient( self::TOKEN_TRANSIENT );
+		$cached = get_site_transient( self::TOKEN_TRANSIENT );
 
 		if ( ! empty( $cached ) ) {
 			return $cached;
@@ -641,7 +745,7 @@ class GoogleSearchConsoleAbilities {
 			return new \WP_Error( 'gsc_token_failed', 'Failed to get access token: ' . $error_desc );
 		}
 
-		set_transient( self::TOKEN_TRANSIENT, $body['access_token'], 3500 );
+		set_site_transient( self::TOKEN_TRANSIENT, $body['access_token'], 3500 );
 
 		return $body['access_token'];
 	}

--- a/inc/Tools/GoogleSearchConsole.php
+++ b/inc/Tools/GoogleSearchConsole.php
@@ -201,7 +201,10 @@ class GoogleSearchConsole extends BaseTool {
 	}
 
 	protected function before_config_save( array $config_data ): void {
-		delete_transient( GoogleSearchConsoleAbilities::TOKEN_TRANSIENT );
+		// The service-account credential is network-wide (get_site_option), so its
+		// cached access token is stored as a network transient. Clear the network
+		// transient so a config change invalidates the cache for every blog.
+		delete_site_transient( GoogleSearchConsoleAbilities::TOKEN_TRANSIENT );
 	}
 
 	/**

--- a/tests/gsc-site-url-guard-smoke.php
+++ b/tests/gsc-site-url-guard-smoke.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Pure-PHP smoke test for the GSC site_url property guard and 403 error surface (#59).
+ *
+ * Verifies that:
+ *  - a model-supplied site_url matching the configured property resolves to the
+ *    configured property (no rejection),
+ *  - a mismatched site_url is rejected with a WP_Error before any Google call,
+ *  - domain (sc-domain:) and URL-prefix forms normalize as equivalent,
+ *  - a raw "HTTP 403" HttpClient error is rewritten into an actionable message.
+ *
+ * Run with: php tests/gsc-site-url-guard-smoke.php
+ *
+ * @package DataMachineBusiness\Tests
+ */
+
+namespace {
+	$__gsc_failures = array();
+	$__gsc_passes   = 0;
+
+	// Minimal WP shims required by the abilities file at load + call time.
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			private string $code;
+			private string $message;
+			public function __construct( string $code = '', string $message = '' ) {
+				$this->code    = $code;
+				$this->message = $message;
+			}
+			public function get_error_message(): string {
+				return $this->message;
+			}
+			public function get_error_code(): string {
+				return $this->code;
+			}
+		}
+	}
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $thing ): bool {
+			return $thing instanceof \WP_Error;
+		}
+	}
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $str ) {
+			return trim( (string) $str );
+		}
+	}
+	if ( ! function_exists( 'wp_parse_url' ) ) {
+		function wp_parse_url( $url, $component = -1 ) {
+			return parse_url( $url, $component );
+		}
+	}
+	if ( ! function_exists( '__' ) ) {
+		function __( $text, $domain = 'default' ) {
+			return $text;
+		}
+	}
+	if ( ! function_exists( 'doing_action' ) ) {
+		function doing_action( $action = null ) {
+			return false;
+		}
+	}
+	if ( ! function_exists( 'did_action' ) ) {
+		function did_action( $action ) {
+			return 1;
+		}
+	}
+	if ( ! function_exists( 'add_action' ) ) {
+		function add_action( ...$args ) {
+			return true;
+		}
+	}
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ );
+	}
+	if ( ! defined( 'JSON_ERROR_NONE' ) ) {
+		define( 'JSON_ERROR_NONE', 0 );
+	}
+}
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static function can_manage(): bool {
+			return true;
+		}
+	}
+}
+
+namespace DataMachine\Core {
+	class HttpClient {
+		public static function post( $url, $args = array() ) {
+			return array( 'success' => true, 'data' => '{}', 'status_code' => 200 );
+		}
+		public static function get( $url, $args = array() ) {
+			return array( 'success' => true, 'data' => '{}', 'status_code' => 200 );
+		}
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php';
+
+	function gsc_guard_assert( bool $condition, string $name ): void {
+		global $__gsc_failures, $__gsc_passes;
+		if ( $condition ) {
+			$__gsc_passes++;
+			echo "  \u{2713} {$name}\n";
+			return;
+		}
+		$__gsc_failures[] = $name;
+		echo "  \u{2717} {$name}\n";
+	}
+
+	echo "GSC site_url guard smoke (#59)\n";
+	echo "------------------------------\n";
+
+	$class = new \ReflectionClass( \DataMachineBusiness\Abilities\Analytics\GoogleSearchConsoleAbilities::class );
+
+	$resolve = $class->getMethod( 'resolve_site_url' );
+	$resolve->setAccessible( true );
+
+	$normalize = $class->getMethod( 'normalize_property' );
+	$normalize->setAccessible( true );
+
+	$describe = $class->getMethod( 'describe_request_error' );
+	$describe->setAccessible( true );
+
+	$config = array( 'site_url' => 'sc-domain:extrachill.com' );
+
+	// No supplied site_url -> configured property (CLI default path preserved).
+	$r = $resolve->invoke( null, array(), $config );
+	gsc_guard_assert( 'sc-domain:extrachill.com' === $r, 'no site_url falls back to configured property' );
+
+	// Matching URL-prefix form -> resolves to configured property, no error.
+	$r = $resolve->invoke( null, array( 'site_url' => 'https://extrachill.com/' ), $config );
+	gsc_guard_assert( 'sc-domain:extrachill.com' === $r, 'matching URL-prefix site_url resolves to configured property' );
+
+	// Mismatched subdomain -> WP_Error, never forwarded to Google.
+	$r = $resolve->invoke( null, array( 'site_url' => 'https://studio.extrachill.com/' ), $config );
+	gsc_guard_assert( is_wp_error( $r ), 'mismatched subdomain site_url is rejected with WP_Error' );
+	gsc_guard_assert(
+		is_wp_error( $r ) && 'gsc_property_not_verified' === $r->get_error_code(),
+		'rejection uses gsc_property_not_verified error code'
+	);
+	gsc_guard_assert(
+		is_wp_error( $r ) && false !== strpos( $r->get_error_message(), 'studio.extrachill.com' ),
+		'rejection message names the unauthorized property'
+	);
+
+	// Empty configured property -> supplied value honoured (back-compat).
+	$r = $resolve->invoke( null, array( 'site_url' => 'https://example.com/' ), array() );
+	gsc_guard_assert( 'https://example.com/' === $r, 'empty configured property honours supplied site_url' );
+
+	// Normalization equivalences.
+	gsc_guard_assert(
+		$normalize->invoke( null, 'sc-domain:extrachill.com' ) === $normalize->invoke( null, 'https://extrachill.com/' ),
+		'sc-domain and https URL-prefix normalize equal'
+	);
+	gsc_guard_assert(
+		$normalize->invoke( null, 'https://extrachill.com' ) !== $normalize->invoke( null, 'https://extrachill.com/blog/' ),
+		'domain-level and path-scoped URL-prefix properties normalize distinct'
+	);
+
+	// 403 error surface rewrite.
+	$msg = $describe->invoke( null, 'Google Search Console Ability POST returned HTTP 403', 'sc-domain:extrachill.com' );
+	gsc_guard_assert( false !== strpos( $msg, 'not verified' ), '403 error rewritten to actionable "not verified" message' );
+	gsc_guard_assert( false !== strpos( $msg, 'property-authorization' ), '403 error clarifies it is a property-authorization issue' );
+
+	// Non-403 error passes through unchanged.
+	$msg = $describe->invoke( null, 'timeout', 'sc-domain:extrachill.com' );
+	gsc_guard_assert(
+		false !== strpos( $msg, 'Failed to connect to Google Search Console API: timeout' ),
+		'non-403 error preserves the generic connection-failure message'
+	);
+
+	if ( ! empty( $__gsc_failures ) ) {
+		echo "\nFAILURES:\n";
+		foreach ( $__gsc_failures as $failure ) {
+			echo " - {$failure}\n";
+		}
+		exit( 1 );
+	}
+
+	echo "\n{$__gsc_passes} assertions passed.\n";
+}


### PR DESCRIPTION
## Root cause

`inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php:193` (pre-change):

```php
$site_url = ! empty( $input['site_url'] ) ? sanitize_text_field( $input['site_url'] ) : ( $config['site_url'] ?? '' );
```

`site_url` was a free-form, model-facing parameter (declared in the ability input schema ~lines 96-99, in the tool definition at `inc/Tools/GoogleSearchConsole.php:88-91`, and passed through by `inc/Abilities/Analytics/GscOpportunityAbility.php:280-284`). When an agent supplied a property the **network service account is not verified on** (e.g. `https://studio.extrachill.com/`), that value was forwarded straight to Google's searchAnalytics endpoint, which returned **HTTP 403**. That 403 was wrapped at `GoogleSearchConsoleAbilities.php:276` into the generic `"Failed to connect to Google Search Console API: ... HTTP 403"` — indistinguishable from a credential/auth outage. Reaching the POST means the `permission_callback` (`PermissionHelper::can_manage()`) already passed, so this is a Google property-authorization 403, **not** a WP capability denial or a token-load failure. CLI works because it passes no `site_url` and falls through to the configured `sc-domain:extrachill.com`.

## What changed

**Validation approach chosen: constrain to the configured property (reject on mismatch), not silent coercion of arbitrary properties.** The service account is verified on exactly one property (the configured `site_url`). Silently forwarding any other property is exactly what produced the opaque 403, so a mismatch should fail fast with an explanation rather than hit Google. I chose reject-on-mismatch over "coerce everything to the configured property" because coercion would silently ignore an explicit operator/agent request and could mask a genuine misconfiguration; a clear WP_Error is more debuggable. Matching values (including equivalent `sc-domain:` vs `https://` forms) are honoured.

- **`resolve_site_url( $input, $config )`** — new private helper replacing the inline resolution at line 193:
  - No supplied `site_url` -> configured property (**CLI default path preserved, unchanged behavior**).
  - Supplied value that normalizes-equal to the configured property -> resolves to the configured property.
  - Supplied value that differs -> returns a `WP_Error` (`gsc_property_not_verified`) **before any Google request**, naming both the requested and the configured property and telling the caller to omit `site_url` or verify the property.
  - Empty configured property -> supplied value honoured (back-compat for un-pinned installs).
- **`normalize_property()`** — treats `https://example.com/`, `https://example.com`, and `sc-domain:example.com` as equivalent host-level references, while keeping path-scoped URL-prefix properties (`https://example.com/blog/`) distinct.
- **Error surface** — new **`describe_request_error()`** rewrites a Google `HTTP 403` on the searchAnalytics call into: *"...the configured service account is not verified for this property. This is a property-authorization issue, not a Data Machine credential or WordPress permission failure..."* (raw error preserved in parentheses). Non-403 errors keep the original generic connection-failure message.

## Transient hardening (included)

Included — it was low-risk and directly relevant. The service-account credential is network-wide (`get_site_option( 'datamachine_gsc_config' )`), but the access token was cached per-blog via `get_transient`/`set_transient`, and config-save invalidation (`inc/Tools/GoogleSearchConsole.php`) only cleared the saving blog's copy. Switched to `get_site_transient`/`set_site_transient` in `get_access_token()` and `delete_site_transient()` in `before_config_save()` so the network-scoped credential has a network-scoped cache with network-scoped invalidation. (GA/Mediavine/Amazon token transients were left untouched — different credential scopes/patterns, out of scope for #59.)

## Tests / lint

- `php -l` clean on both edited files.
- **New:** `tests/gsc-site-url-guard-smoke.php` — pure-PHP smoke test (WP shims + reflection) covering the guard, normalization equivalence/distinctness, and the 403 rewrite. **11/11 assertions pass.**
- Existing `tests/gsc-business-registration-smoke.php`: all assertions pass **except** one preexisting failure (`business registers the GSC WP-CLI command`) that is unrelated to this change — the `"datamachine analytics gsc"` needle is absent from `data-machine-business.php` on `origin/main` too, and this PR does not touch that file.
- `homeboy test data-machine-business` could not run in this environment: the runner aborts during "WP Codebox CLI setup" (`no candidate passed 'wp-codebox --version'`) before any test executes — a preexisting sandbox/tooling issue, not a test failure introduced here.

Fixes #59