### PR TITLE
feat: auto-scope GSC ability to subsite on a genuine subdomain

### DIFF
--- a/docs/ai-tools/google-search-console.md
+++ b/docs/ai-tools/google-search-console.md
@@ -98,6 +98,7 @@ URL & Sitemap actions:
 
 **url_filter** (string)
 - Filter results to URLs containing this string
+- Subsite auto-scoping: on a multisite subsite whose host is a genuine subdomain of the configured `sc-domain:` domain property, when neither `site_url` nor `url_filter` is supplied the ability auto-applies a `url_filter` of that subsite's URL prefix — so a subsite context returns subsite-scoped rows. The main site returns the whole-domain rollup, and passing an explicit `site_url` or `url_filter` overrides this.
 
 **query_filter** (string)
 - Filter results to queries containing this string

--- a/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php
+++ b/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php
@@ -192,6 +192,16 @@ class GoogleSearchConsoleAbilities {
 
 		$site_url = ! empty( $input['site_url'] ) ? sanitize_text_field( $input['site_url'] ) : ( $config['site_url'] ?? '' );
 
+		// Auto-scope analytics queries to the current subsite when running on a
+		// genuine subdomain of the configured sc-domain: property and the caller
+		// supplied neither an explicit site_url nor an explicit url_filter.
+		if ( empty( $input['site_url'] ) && empty( $input['url_filter'] ) ) {
+			$auto_prefix = self::computeSubsiteUrlPrefix( $site_url, home_url() );
+			if ( '' !== $auto_prefix ) {
+				$input['url_filter'] = $auto_prefix;
+			}
+		}
+
 		// Route to specialized handlers for non-analytics actions.
 		if ( 'inspect_url' === $action ) {
 			return self::inspectUrl( $input, $access_token, $site_url );
@@ -665,6 +675,59 @@ class GoogleSearchConsoleAbilities {
 	public static function is_configured(): bool {
 		$config = self::get_config();
 		return ! empty( $config['service_account_json'] );
+	}
+
+	/**
+	 * Compute an auto url_filter prefix that scopes GSC analytics to the current
+	 * subsite when it is a genuine subdomain of the configured domain property.
+	 *
+	 * Returns the current blog's URL prefix (e.g. https://studio.extrachill.com/)
+	 * only when ALL of the following hold:
+	 *  - the configured property is a domain property (sc-domain:...);
+	 *  - the current blog's home host is a genuine subdomain of the
+	 *    domain-property host (host !== domain host, but ends with .domain host).
+	 *
+	 * The main site (blog whose host equals the domain-property host, with or
+	 * without a leading www) and any non-subdomain context return '' so the
+	 * whole-domain rollup is preserved. A URL-prefix property (https://...) also
+	 * returns '' — it already scopes itself and needs no page filter.
+	 *
+	 * Pure function (no WP state) so it is unit-testable; callers pass home_url().
+	 *
+	 * @param string $site_url The resolved GSC property URL (sc-domain: or https://).
+	 * @param string $home_url The current blog's home URL (from home_url()).
+	 * @return string URL prefix to filter on, or '' to leave the query unscoped.
+	 */
+	public static function computeSubsiteUrlPrefix( string $site_url, string $home_url ): string {
+		// Only domain properties (sc-domain:) support page-level subsite scoping.
+		if ( 0 !== strpos( $site_url, 'sc-domain:' ) ) {
+			return '';
+		}
+
+		$domain_host = strtolower( trim( substr( $site_url, strlen( 'sc-domain:' ) ) ) );
+		if ( '' === $domain_host ) {
+			return '';
+		}
+
+		$home_host = strtolower( (string) wp_parse_url( $home_url, PHP_URL_HOST ) );
+		if ( '' === $home_host ) {
+			return '';
+		}
+
+		// Main site / property root: host matches the domain property exactly
+		// (with or without a leading www). Preserve the rollup — no filter.
+		if ( $home_host === $domain_host || 'www.' . $domain_host === $home_host ) {
+			return '';
+		}
+
+		// Genuine subdomain: host ends with ".{$domain_host}".
+		if ( substr( $home_host, -strlen( '.' . $domain_host ) ) !== '.' . $domain_host ) {
+			return '';
+		}
+
+		// Scope to this subsite's URL prefix. trailingslashit keeps the filter
+		// tight to this host's pages under a GSC "page contains" match.
+		return trailingslashit( $home_url );
 	}
 
 	/**

--- a/tests/Unit/Abilities/Analytics/GoogleSearchConsoleAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/GoogleSearchConsoleAbilitiesTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Unit tests for GoogleSearchConsoleAbilities subsite auto-scoping.
+ *
+ * Covers the enhancement where the datamachine/google-search-console ability
+ * always queried the configured sc-domain: property and returned the whole
+ * domain rollup regardless of which subsite it ran on. When neither an explicit
+ * site_url nor url_filter is supplied and the current blog is a genuine
+ * subdomain of the configured domain property, the ability now auto-applies a
+ * url_filter of that subsite's URL prefix so page-level results are scoped to
+ * the subsite. The main site (host equals the domain property) and URL-prefix
+ * properties are left unscoped so the rollup behavior is preserved.
+ *
+ * @package DataMachine\Tests\Unit\Abilities\Analytics
+ */
+
+namespace DataMachine\Tests\Unit\Abilities\Analytics;
+
+use DataMachineBusiness\Abilities\Analytics\GoogleSearchConsoleAbilities;
+use WP_UnitTestCase;
+
+class GoogleSearchConsoleAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * A genuine subdomain of the configured sc-domain: property gets scoped to
+	 * its own trailing-slashed URL prefix.
+	 */
+	public function test_subdomain_gets_scoped_to_its_url_prefix(): void {
+		$prefix = GoogleSearchConsoleAbilities::computeSubsiteUrlPrefix(
+			'sc-domain:extrachill.com',
+			'https://studio.extrachill.com'
+		);
+
+		$this->assertSame( 'https://studio.extrachill.com/', $prefix );
+	}
+
+	/**
+	 * The main site (host equals the domain-property host) is NOT scoped so the
+	 * whole-domain rollup is preserved.
+	 */
+	public function test_main_site_is_not_scoped(): void {
+		$this->assertSame(
+			'',
+			GoogleSearchConsoleAbilities::computeSubsiteUrlPrefix(
+				'sc-domain:extrachill.com',
+				'https://extrachill.com'
+			)
+		);
+	}
+
+	/**
+	 * A www.-prefixed main site host still counts as the property root, not a
+	 * subdomain — no scoping.
+	 */
+	public function test_www_main_site_is_not_scoped(): void {
+		$this->assertSame(
+			'',
+			GoogleSearchConsoleAbilities::computeSubsiteUrlPrefix(
+				'sc-domain:extrachill.com',
+				'https://www.extrachill.com'
+			)
+		);
+	}
+
+	/**
+	 * A URL-prefix property (https://...) already scopes itself — no page filter
+	 * is derived even from a subdomain-looking home URL.
+	 */
+	public function test_url_prefix_property_is_never_scoped(): void {
+		$this->assertSame(
+			'',
+			GoogleSearchConsoleAbilities::computeSubsiteUrlPrefix(
+				'https://extrachill.com/',
+				'https://studio.extrachill.com'
+			)
+		);
+	}
+
+	/**
+	 * An unrelated host that merely ends with the domain string but is not a
+	 * dot-delimited subdomain must not be scoped (guards against a naive
+	 * suffix match, e.g. notextrachill.com).
+	 */
+	public function test_lookalike_host_is_not_scoped(): void {
+		$this->assertSame(
+			'',
+			GoogleSearchConsoleAbilities::computeSubsiteUrlPrefix(
+				'sc-domain:extrachill.com',
+				'https://notextrachill.com'
+			)
+		);
+	}
+
+	/**
+	 * A completely different domain is never scoped.
+	 */
+	public function test_foreign_domain_is_not_scoped(): void {
+		$this->assertSame(
+			'',
+			GoogleSearchConsoleAbilities::computeSubsiteUrlPrefix(
+				'sc-domain:extrachill.com',
+				'https://example.com'
+			)
+		);
+	}
+
+	/**
+	 * An empty sc-domain host yields no scoping (defensive).
+	 */
+	public function test_empty_domain_host_is_not_scoped(): void {
+		$this->assertSame(
+			'',
+			GoogleSearchConsoleAbilities::computeSubsiteUrlPrefix(
+				'sc-domain:',
+				'https://studio.extrachill.com'
+			)
+		);
+	}
+
+	/**
+	 * Host comparison is case-insensitive.
+	 */
+	public function test_scoping_is_case_insensitive(): void {
+		$this->assertSame(
+			'https://Studio.ExtraChill.com/',
+			GoogleSearchConsoleAbilities::computeSubsiteUrlPrefix(
+				'sc-domain:ExtraChill.com',
+				'https://Studio.ExtraChill.com'
+			)
+		);
+	}
+
+	/**
+	 * A deeper multi-label subdomain is still a genuine subdomain and gets
+	 * scoped to its own prefix.
+	 */
+	public function test_deep_subdomain_is_scoped(): void {
+		$this->assertSame(
+			'https://a.b.extrachill.com/',
+			GoogleSearchConsoleAbilities::computeSubsiteUrlPrefix(
+				'sc-domain:extrachill.com',
+				'https://a.b.extrachill.com'
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Summary

The `datamachine/google-search-console` ability always queried the configured `sc-domain:` domain property and returned the **whole-domain rollup** on every subsite, so calling it from `--url=studio.extrachill.com` returned numbers identical to the main site. This adds opt-in, guarded per-subsite auto-scoping via the existing `url_filter` page-dimension path.

Fixes #60.

## Mechanism

- **File:** `inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php`
- `site_url` resolves from the network-wide `get_site_option('datamachine_gsc_config')` (~L193), so the same property string resolved on every subsite. Unlike `BingWebmasterAbilities.php` (`?? get_site_url()`), GSC had no per-blog derivation.
- Per-subsite scoping against a GSC **domain** property is done by filtering the `page` dimension with a URL prefix (`url_filter` -> `page`/`contains`, ~L232-238) — not a different property.

## What changed

1. **Guarded auto-scope block** inserted immediately after `site_url` resolution (~L193), before the `$filters` build. When neither an explicit `site_url` nor `url_filter` is supplied, it derives a subsite `url_filter` from `home_url()` and applies it into `$input['url_filter']` so the existing filter plumbing does the rest.
2. **New self-contained helper** `computeSubsiteUrlPrefix( string $site_url, string $home_url ): string` appended near `get_config()`. It is a **pure function** (WP-state-free; caller passes `home_url()`) so it is directly unit-testable and stays localized.
3. **Doc note** under `url_filter` in `docs/ai-tools/google-search-console.md`: one line stating subsite context auto-scopes and the main site returns the rollup.

## Guardrails enforced (behavior preservation)

- **Main site unchanged:** when the current blog host equals the domain-property host (with or without a leading `www.`), the helper returns `''` — no filter, full rollup preserved.
- **Domain properties only:** if the configured property is a URL-prefix property (`https://...`), the helper returns `''` and does nothing (it already scopes itself).
- **Explicit intent wins:** if the caller passed `site_url` OR `url_filter`, the auto-scope block does not run.
- **Genuine subdomain only:** the host must end with `.{domain_host}` (dot-delimited), so lookalikes like `notextrachill.com` are NOT scoped. Comparison is case-insensitive.

## Test / lint results

- `php -l` clean on the ability and the new test file.
- New unit test `tests/Unit/Abilities/Analytics/GoogleSearchConsoleAbilitiesTest.php` (mirrors the existing `GoogleAnalyticsAbilitiesTest` pattern of testing a pure static method) covering: subdomain scoped, main site not scoped, `www.` main not scoped, URL-prefix property never scoped, lookalike host not scoped, foreign domain not scoped, empty `sc-domain:` host, case-insensitivity, and deep multi-label subdomain.
- `homeboy test data-machine-business` could NOT run here due to a host infra issue (`wp-codebox was found, but no candidate passed 'wp-codebox --version'`) — unrelated to this change. The pure helper logic was verified out-of-band by stubbing `wp_parse_url`/`trailingslashit`: **all 9 cases pass**.

## Note on concurrent work

A sibling PR (#59, branch `fix-gsc-403-siteurl`) edits the same file around the same region (~L193). This change was kept surgical and localized (one guarded block + one appended helper) to minimize conflict, but a rebase/merge may still be needed.