### PR TITLE
fix: enumerate flat __invoke command actions in AGENTS.md section

### DIFF
--- a/inc/Cli/Commands/BingWebmasterCommand.php
+++ b/inc/Cli/Commands/BingWebmasterCommand.php
@@ -15,6 +15,26 @@ defined( 'ABSPATH' ) || exit;
 class BingWebmasterCommand extends BaseCommand {
 
 	/**
+	 * Available actions for this flat `__invoke` command.
+	 *
+	 * The action is a positional argument dispatched inside `__invoke`, so it
+	 * is invisible to method reflection. This static accessor is the
+	 * machine-readable source consumed by the AGENTS.md section renderer
+	 * without instantiating the command. Keep in sync with the `## OPTIONS`
+	 * `<action>` list.
+	 *
+	 * @return array<string,string> Action name => short description.
+	 */
+	public static function actions(): array {
+		return array(
+			'query_stats'   => 'Top search queries by clicks',
+			'traffic_stats' => 'Rank and traffic stats over time',
+			'page_stats'    => 'Top pages by traffic',
+			'crawl_stats'   => 'Crawl activity statistics',
+		);
+	}
+
+	/**
 	 * Query Bing Webmaster Tools analytics.
 	 *
 	 * ## OPTIONS

--- a/inc/Cli/GoogleAnalyticsCommand.php
+++ b/inc/Cli/GoogleAnalyticsCommand.php
@@ -21,6 +21,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 class GoogleAnalyticsCommand extends BaseCommand {
 
 	/**
+	 * Available actions for this flat `__invoke` command.
+	 *
+	 * The action is a positional argument dispatched inside `__invoke`, so it
+	 * is invisible to method reflection. This static accessor is the
+	 * machine-readable source consumed by the AGENTS.md section renderer
+	 * without instantiating the command. Keep in sync with the `## OPTIONS`
+	 * `<action>` list.
+	 *
+	 * @return array<string,string> Action name => short description.
+	 */
+	public static function actions(): array {
+		return array(
+			'page_stats'        => 'Top pages by sessions, views, and engagement',
+			'traffic_sources'   => 'Sessions grouped by source and medium',
+			'date_stats'        => 'Daily session and engagement trends',
+			'realtime'          => 'Real-time active users',
+			'top_events'        => 'Top events by count',
+			'user_demographics' => 'Sessions by country and device',
+			'landing_pages'     => 'Top landing pages by entrances and engagement',
+			'engagement'        => 'Aggregate engagement metrics per page',
+			'new_vs_returning'  => 'New vs returning user split',
+			'network_density'   => 'Cross-site journey density via referrer host',
+			'path_sequence'     => 'Ordered cross-host path sequences (funnel report)',
+		);
+	}
+
+	/**
 	 * Query Google Analytics (GA4) data.
 	 *
 	 * ## OPTIONS

--- a/inc/Cli/GoogleSearchConsoleCommand.php
+++ b/inc/Cli/GoogleSearchConsoleCommand.php
@@ -17,6 +17,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 class GoogleSearchConsoleCommand extends BaseCommand {
 
 	/**
+	 * Available actions for this flat `__invoke` command.
+	 *
+	 * The action is a positional argument dispatched inside `__invoke`, so it
+	 * is invisible to method reflection. This static accessor is the
+	 * machine-readable source consumed by the AGENTS.md section renderer (and
+	 * available to any introspector) without instantiating the command.
+	 *
+	 * Keep in sync with the `## OPTIONS` `<action>` list and the ability's
+	 * valid-actions check.
+	 *
+	 * @return array<string,string> Action name => short description.
+	 */
+	public static function actions(): array {
+		return array(
+			'query_stats'        => 'Top search queries by clicks and impressions',
+			'page_stats'         => 'Top pages by clicks and impressions',
+			'query_page_stats'   => 'Combined query/page breakdown per URL',
+			'date_stats'         => 'Performance trends by date',
+			'inspect_url'        => 'URL Inspection — index status, coverage, mobile usability',
+			'list_sitemaps'      => 'List submitted sitemaps',
+			'get_sitemap'        => 'Get details for a single sitemap',
+			'submit_sitemap'     => 'Submit a sitemap for crawling',
+		);
+	}
+
+	/**
 	 * Query Google Search Console analytics.
 	 *
 	 * ## OPTIONS

--- a/inc/Cli/MediaHygieneCommand.php
+++ b/inc/Cli/MediaHygieneCommand.php
@@ -19,6 +19,27 @@ defined( 'ABSPATH' ) || exit;
 class MediaHygieneCommand extends BaseCommand {
 
 	/**
+	 * Available actions for this flat `__invoke` command.
+	 *
+	 * The action is a positional argument dispatched inside `__invoke`, so it
+	 * is invisible to method reflection. This static accessor is the
+	 * machine-readable source consumed by the AGENTS.md section renderer
+	 * without instantiating the command. Keep in sync with the `## OPTIONS`
+	 * `<action>` list.
+	 *
+	 * @return array<string,string> Action name => short description.
+	 */
+	public static function actions(): array {
+		return array(
+			'diagnose'       => 'Summary of dead-weight media across detectors',
+			'orphan-files'   => 'Files on disk with no attachment record',
+			'unused'         => 'Attachments not referenced in any content',
+			'delete-orphans' => 'Delete orphan files (requires --apply)',
+			'delete-unused'  => 'Delete unused attachments (requires --apply)',
+		);
+	}
+
+	/**
 	 * Inspect and clean dead-weight media (orphan files + unreferenced attachments).
 	 *
 	 * ## OPTIONS

--- a/inc/Cli/PageSpeedCommand.php
+++ b/inc/Cli/PageSpeedCommand.php
@@ -15,6 +15,25 @@ defined( 'ABSPATH' ) || exit;
 class PageSpeedCommand extends BaseCommand {
 
 	/**
+	 * Available actions for this flat `__invoke` command.
+	 *
+	 * The action is a positional argument dispatched inside `__invoke`, so it
+	 * is invisible to method reflection. This static accessor is the
+	 * machine-readable source consumed by the AGENTS.md section renderer
+	 * without instantiating the command. Keep in sync with the `## OPTIONS`
+	 * `<action>` list.
+	 *
+	 * @return array<string,string> Action name => short description.
+	 */
+	public static function actions(): array {
+		return array(
+			'analyze'       => 'Full PageSpeed/Lighthouse audit',
+			'performance'   => 'Core Web Vitals focus',
+			'opportunities' => 'Optimization suggestions',
+		);
+	}
+
+	/**
 	 * Run PageSpeed Insights (Lighthouse) audits.
 	 *
 	 * ## OPTIONS

--- a/inc/Runtime/AgentsMdSections.php
+++ b/inc/Runtime/AgentsMdSections.php
@@ -20,7 +20,9 @@
  * Context safety: callbacks run on `plugins_loaded` in web/cron compose
  * contexts, NOT only under WP-CLI. Reflection over autoloadable command classes
  * never touches the live WP_CLI runner and never instantiates the command
- * classes.
+ * classes. The flat-`__invoke` action list is read from a static `actions()`
+ * method (when a command declares one) via a static call — also instantiation-
+ * free — so action enumeration stays context-safe.
  *
  * @package DataMachineBusiness\Runtime
  */
@@ -98,6 +100,17 @@ final class AgentsMdSections {
 				$lines[] = '' !== $summary
 					? sprintf( '- `%s %s <action>` — %s', $wp, $command, $summary )
 					: sprintf( '- `%s %s <action>`', $wp, $command );
+
+				// Flat commands carry their verbs as a positional <action>
+				// argument dispatched inside __invoke, which reflection cannot
+				// see. When the command exposes a static actions() accessor,
+				// enumerate each action as a bullet so AGENTS.md shows the real
+				// surface (mirrors the extrachill-cli subcommand-bullet depth).
+				foreach ( self::flat_invoke_actions( $class ) as $name => $description ) {
+					$lines[] = '' !== $description
+						? sprintf( '  - `%s` — %s', $name, $description )
+						: sprintf( '  - `%s`', $name );
+				}
 				continue;
 			}
 
@@ -172,6 +185,61 @@ MD;
 		$only = $subcommands[0];
 
 		return ( isset( $only['name'] ) && '__default' === $only['name'] ) ? $only : null;
+	}
+
+	/**
+	 * Read the action list for a flat `__invoke` command, when available.
+	 *
+	 * Flat `__invoke` commands dispatch their verbs from a positional
+	 * `<action>` argument inside `__invoke` (a switch/match), so the valid
+	 * action names are invisible to method reflection. A command may declare
+	 * them as a public static `actions()` accessor returning either:
+	 *
+	 *   - An associative `array<string,string>` of `action => short description`.
+	 *   - An indexed `array<int,string>` of bare action names.
+	 *
+	 * Both shapes are normalized to `array<string,string>` (missing
+	 * descriptions become ''). This is context-safe: a static method call
+	 * never instantiates the command class, so it is safe to run from
+	 * `plugins_loaded` in web/cron compose contexts. Returns an empty array
+	 * when the class is absent or declares no `actions()` accessor, leaving
+	 * the bare headline (no action bullets) as the graceful fallback.
+	 *
+	 * @param class-string $command_class Fully-qualified command class name.
+	 * @return array<string,string> Action name => short description.
+	 */
+	private static function flat_invoke_actions( string $command_class ): array {
+		if ( ! class_exists( $command_class ) || ! method_exists( $command_class, 'actions' ) ) {
+			return array();
+		}
+
+		try {
+			$actions = call_user_func( array( $command_class, 'actions' ) );
+		} catch ( \Throwable $e ) {
+			return array();
+		}
+
+		if ( ! is_array( $actions ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $actions as $key => $value ) {
+			if ( is_int( $key ) ) {
+				// Indexed array: the value is the action name.
+				if ( is_string( $value ) && '' !== $value ) {
+					$normalized[ $value ] = '';
+				}
+				continue;
+			}
+
+			// Associative array: key is the action, value is the description.
+			if ( is_string( $key ) && '' !== $key ) {
+				$normalized[ $key ] = is_string( $value ) ? $value : '';
+			}
+		}
+
+		return $normalized;
 	}
 
 	/**

--- a/tests/Unit/AgentsMdActionsTest.php
+++ b/tests/Unit/AgentsMdActionsTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Tests for the AGENTS.md flat-`__invoke` action enumeration.
+ *
+ * Verifies that each flat `__invoke` command declares a static actions()
+ * accessor and that the GSC command exposes the documented action set, so the
+ * composed AGENTS.md section enumerates actions instead of bare command lines.
+ *
+ * @package DataMachineBusiness\Tests
+ */
+
+class AgentsMdActionsTest extends \PHPUnit\Framework\TestCase {
+
+	private string $root;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->root = dirname( __DIR__, 2 );
+	}
+
+	/**
+	 * Every command class mapped by CommandRegistry must declare a static
+	 * actions() accessor so the AGENTS.md renderer can enumerate its verbs.
+	 *
+	 * @dataProvider provide_command_classes
+	 */
+	public function test_command_class_declares_static_actions( string $relative_path ): void {
+		$source = $this->read_file( $relative_path );
+
+		$this->assertStringContainsString(
+			'public static function actions(): array',
+			$source,
+			"{$relative_path} must declare a public static actions() accessor for AGENTS.md action enumeration."
+		);
+	}
+
+	public function provide_command_classes(): array {
+		return array(
+			'GSC'        => array( 'inc/Cli/GoogleSearchConsoleCommand.php' ),
+			'GA'         => array( 'inc/Cli/GoogleAnalyticsCommand.php' ),
+			'PageSpeed'  => array( 'inc/Cli/PageSpeedCommand.php' ),
+			'Media'      => array( 'inc/Cli/MediaHygieneCommand.php' ),
+			'Bing'       => array( 'inc/Cli/Commands/BingWebmasterCommand.php' ),
+		);
+	}
+
+	public function test_gsc_command_actions_cover_documented_set(): void {
+		$source = $this->read_file( 'inc/Cli/GoogleSearchConsoleCommand.php' );
+
+		$expected = array(
+			'query_stats',
+			'page_stats',
+			'query_page_stats',
+			'date_stats',
+			'inspect_url',
+			'list_sitemaps',
+			'get_sitemap',
+			'submit_sitemap',
+		);
+
+		foreach ( $expected as $action ) {
+			$this->assertStringContainsString(
+				"'{$action}'",
+				$source,
+				"GSC actions() must include the '{$action}' action."
+			);
+		}
+	}
+
+	public function test_renderer_calls_flat_invoke_actions_helper(): void {
+		$source = $this->read_file( 'inc/Runtime/AgentsMdSections.php' );
+
+		// The renderer must read the static actions() accessor for flat commands.
+		$this->assertStringContainsString( 'flat_invoke_actions', $source );
+		$this->assertStringContainsString(
+			"call_user_func( array( \$command_class, 'actions' ) )",
+			$source
+		);
+	}
+
+	private function read_file( string $relative_path ): string {
+		$contents = file_get_contents( $this->root . '/' . $relative_path );
+		$this->assertIsString( $contents );
+		return $contents;
+	}
+}

--- a/tests/verify-render.php
+++ b/tests/verify-render.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Standalone verification of the AGENTS.md renderer action enumeration.
+ *
+ * Stubs the minimal dependencies (BaseCommand, ABSPATH, apply_filters) so the
+ * real AgentsMdSections::render() can run outside WordPress against the real
+ * CommandRegistry + command classes (which declare static actions()).
+ */
+
+namespace DataMachine\Cli {
+	// Stub the BaseCommand parent the command classes extend. The static
+	// actions() accessor never reaches instance methods, so an empty stub is
+	// enough to let the class files load.
+	if ( ! class_exists( 'DataMachine\Cli\BaseCommand' ) ) {
+		class BaseCommand {}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', '/var/www/extrachill.com/' );
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( $tag, $value ) {
+			return $value;
+		}
+	}
+
+	$root = dirname( __DIR__ );
+
+	require_once $root . '/inc/Cli/GoogleSearchConsoleCommand.php';
+	require_once $root . '/inc/Cli/GoogleAnalyticsCommand.php';
+	require_once $root . '/inc/Cli/PageSpeedCommand.php';
+	require_once $root . '/inc/Cli/MediaHygieneCommand.php';
+	require_once $root . '/inc/Cli/Commands/BingWebmasterCommand.php';
+	require_once $root . '/inc/Cli/CommandRegistry.php';
+	require_once $root . '/inc/Runtime/AgentsMdSections.php';
+
+	$output = \DataMachineBusiness\Runtime\AgentsMdSections::render();
+
+	echo $output;
+	echo "\n\n--- ASSERTIONS ---\n";
+
+	$gsc_actions = array(
+		'query_stats', 'page_stats', 'query_page_stats', 'date_stats',
+		'inspect_url', 'list_sitemaps', 'get_sitemap', 'submit_sitemap',
+	);
+
+	$failures = array();
+	foreach ( $gsc_actions as $action ) {
+		if ( false === strpos( $output, '`' . $action . '`' ) ) {
+			$failures[] = "GSC action '{$action}' missing from rendered output";
+		}
+	}
+
+	// Confirm a non-GSC action also appears.
+	if ( false === strpos( $output, '`realtime`' ) ) {
+		$failures[] = "GA action 'realtime' missing from rendered output";
+	}
+	if ( false === strpos( $output, '`diagnose`' ) ) {
+		$failures[] = "Media action 'diagnose' missing from rendered output";
+	}
+
+	if ( empty( $failures ) ) {
+		echo "PASS: all expected actions are enumerated in the rendered section.\n";
+		exit( 0 );
+	}
+
+	foreach ( $failures as $f ) {
+		echo "FAIL: {$f}\n";
+	}
+	exit( 1 );
+}


### PR DESCRIPTION
## Problem

The composed `AGENTS.md` **Data Machine Business** section rendered only bare command lines (e.g. `wp datamachine analytics gsc <action>`) with **no action list** — unlike the Extra Chill CLI section, which fully enumerates every action. Because the section hid its actions, an agent reading AGENTS.md could not discover that `datamachine analytics gsc` supports `query_stats, page_stats, query_page_stats, date_stats, inspect_url, list_sitemaps, get_sitemap, submit_sitemap` and wasted cycles speculating before finding `inspect_url`.

## Root cause

Every DMB command is a **flat `__invoke` command**: the action is a positional `<action>` argument dispatched inside `__invoke` (a switch/match), not separate WP-CLI subcommand methods. So `CliCommandIntrospector::describe_class()` / the local `reflect_class()` fallback only ever find **one** thing — `__invoke` → `__default` — and the renderer emits the bare `<command> <action>` line (see `AgentsMdSections.php` lines 94-102). The valid action names lived only in the runtime switch and the docblock prose, invisible to reflection.

## Approach — static `actions()` accessor (why this over alternatives)

Considered two options:

1. **Parse the `<action>` docblock description** (e.g. `Action to perform: query_stats, page_stats, ...`). Rejected: the prose format is inconsistent across commands (comma-separated, pipe-separated, and parenthetical-with-descriptions), making robust parsing fragile and the prose is not a machine-readable source.
2. **Add a `public static function actions(): array`** to each flat `__invoke` command returning its `action => short description` map. **Chosen.** This is the minimal, explicit, machine-readable declaration. The renderer reads it via a **static call** (no instantiation), so it stays context-safe for `plugins_loaded` web/cron compose. Degrades gracefully: when a command declares no `actions()`, the bare headline remains.

This mirrors how the extrachill-cli section gets its depth — but via a static accessor instead of method reflection, because DMB commands have no reflectable subcommand methods.

## Before / after (GSC line)

**Before:**
```
- `wp datamachine analytics gsc <action>` — Query Google Search Console analytics
```

**After:**
```
- `wp datamachine analytics gsc <action>` — Query Google Search Console analytics
  - `query_stats` — Top search queries by clicks and impressions
  - `page_stats` — Top pages by clicks and impressions
  - `query_page_stats` — Combined query/page breakdown per URL
  - `date_stats` — Performance trends by date
  - `inspect_url` — URL Inspection — index status, coverage, mobile usability
  - `list_sitemaps` — List submitted sitemaps
  - `get_sitemap` — Get details for a single sitemap
  - `submit_sitemap` — Submit a sitemap for crawling
```

All five commands (ga, gsc, bing, pagespeed, media) now enumerate their actions.

## Context safety

- The renderer runs on `plugins_loaded` in web/cron compose contexts, NOT only WP-CLI.
- `flat_invoke_actions()` uses `call_user_func( array( $class, 'actions' ) )` — a **static call that never instantiates the command class**, wrapped in try/catch.
- When the class is absent or declares no `actions()`, it returns `[]` and the bare headline is preserved (graceful fallback).
- Verified end-to-end by stubbing the minimal dependencies and running `AgentsMdSections::render()` against the real `CommandRegistry` + command classes — all expected actions (including `inspect_url`) appear. See `tests/verify-render.php`.

## Verification

- `tests/Unit/AgentsMdActionsTest.php` — PHPUnit test asserting every command class declares `static actions()` and the GSC action set is covered.
- `tests/verify-render.php` — standalone PHP script that renders the full section and asserts the GSC/GA/Media actions are present.
- PHPStan analysis passed. PHP lint clean. (Pre-existing PHPCS repo-wide findings and the pre-existing `GoogleSearchConsoleBusinessTest` stale-string failure are unrelated to this change.)