### PR TITLE
fix: discount SERP-captured definition-box queries in GSC opportunity scorer

### DIFF
--- a/inc/Abilities/Analytics/GscOpportunityAbility.php
+++ b/inc/Abilities/Analytics/GscOpportunityAbility.php
@@ -133,6 +133,51 @@ class GscOpportunityAbility {
 	 */
 	const FETCH_LIMIT = 25000;
 
+	/**
+	 * Definition-box (zero-click) query detection — bare-definitional patterns.
+	 *
+	 * Some queries are bare-word definitional searches — "<term> meaning",
+	 * "define <term>" — where Google answers inline via a definition panel, an
+	 * AI Overview, or a featured snippet, and the organic result is structurally
+	 * never seen. For those, a near-0% CTR at a strong rank is STRUCTURAL
+	 * (SERP-captured), not a fixable title/meta problem. Scoring them as
+	 * snippet-gap "recoverable clicks" produces phantom top-of-list
+	 * opportunities that dominate the ranking and bury genuinely recoverable
+	 * song/context-intent queries underneath them on the same page.
+	 *
+	 * Each entry is a fully-delimited PCRE pattern. A match means the query has
+	 * a DEFINITIONAL shape. Match ALONE is never sufficient to flag a row — it
+	 * is only leg (a) of a three-leg signature; see is_definition_box() and
+	 * DEFINITION_BOX_CTR_FRACTION. The patterns are deliberately conservative
+	 * on term length so song-intent queries ("no diggity lyrics meaning") and
+	 * natural-language questions ("what does X mean in <song>") do not match;
+	 * even if one slipped through, the CTR leg (c) would still protect it.
+	 *
+	 * @var string[]
+	 */
+	const DEFINITION_BOX_PATTERNS = array(
+		// "<term> meaning" / "<term> definition(s)" — term is 1-2 words.
+		'/^(?:[\w\'-]+(?:\s+[\w\'-]+)?)\s+(?:meaning|definitions?)$/i',
+		// "define <term>" / "definition(s) of <term>" / "meaning of <term>".
+		'/^(?:define|definitions?\s+of|meaning\s+of)\s+\S+/i',
+	);
+
+	/**
+	 * CTR-ratio threshold for the definition-box signature (leg c).
+	 *
+	 * Flag a definitional-pattern query only when its current CTR is below this
+	 * fraction of the position-expected CTR. 0.1 means "an order of magnitude
+	 * below baseline" — the leg that separates a genuinely SERP-captured query
+	 * ("diggity meaning", CTR 0.005% at a rank expecting 10% → ratio 0.0005,
+	 * far below 0.1) from a modestly-recoverable song-intent query on the SAME
+	 * page at nearly the SAME rank ("no diggity meaning", CTR 1.0% expecting 7%
+	 * → ratio 0.14, above 0.1). The 200x CTR gap between the two IS the
+	 * definition-box signature; this threshold encodes it.
+	 *
+	 * @var float
+	 */
+	const DEFINITION_BOX_CTR_FRACTION = 0.1;
+
 	private static bool $registered = false;
 
 	public function __construct() {
@@ -204,15 +249,16 @@ class GscOpportunityAbility {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'            => array( 'type' => 'boolean' ),
-							'window'             => array( 'type' => 'object' ),
-							'dimension'          => array( 'type' => 'string' ),
-							'thresholds'         => array( 'type' => 'object' ),
-							'snippet_gap'        => array( 'type' => 'array' ),
-							'page2_demand'       => array( 'type' => 'array' ),
-							'snippet_gap_count'  => array( 'type' => 'integer' ),
-							'page2_demand_count' => array( 'type' => 'integer' ),
-							'error'              => array( 'type' => 'string' ),
+							'success'              => array( 'type' => 'boolean' ),
+							'window'               => array( 'type' => 'object' ),
+							'dimension'            => array( 'type' => 'string' ),
+							'thresholds'           => array( 'type' => 'object' ),
+							'snippet_gap'          => array( 'type' => 'array' ),
+							'page2_demand'         => array( 'type' => 'array' ),
+							'snippet_gap_count'    => array( 'type' => 'integer' ),
+							'page2_demand_count'   => array( 'type' => 'integer' ),
+							'definition_box_count' => array( 'type' => 'integer' ),
+							'error'                => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'audit' ),
@@ -267,8 +313,9 @@ class GscOpportunityAbility {
 			$actions['page'] = 'page_stats';
 		}
 
-		$snippet_gap  = array();
-		$page2_demand = array();
+		$snippet_gap          = array();
+		$page2_demand         = array();
+		$definition_box_count = 0;
 
 		foreach ( $actions as $kind => $action ) {
 			$gsc_input = array(
@@ -321,9 +368,23 @@ class GscOpportunityAbility {
 					&& $expected_ctr > 0.0
 					&& $ctr < ( $expected_ctr * $ctr_gap_factor )
 				) {
-					$recoverable = (int) round( $impressions * max( 0.0, $expected_ctr - $ctr ) );
-					if ( $recoverable > 0 ) {
-						$snippet_gap[] = array(
+					$recoverable    = (int) round( $impressions * max( 0.0, $expected_ctr - $ctr ) );
+					$definition_box = self::is_definition_box( $label, $position, $ctr, $expected_ctr, $good_position );
+
+					if ( $definition_box ) {
+						// SERP-captured (definition-box) query: the near-0% CTR
+						// is structural (Google answers inline), not a
+						// title/meta problem. Keep the row visible so the
+						// operator still sees "this high-impression query
+						// exists but is unrecoverable", but zero its
+						// recoverable estimate so it cannot dominate the
+						// ranking and bury actionable rows. See the
+						// DEFINITION_BOX_PATTERNS docblock for the rationale.
+						$recoverable = 0;
+					}
+
+					if ( $recoverable > 0 || $definition_box ) {
+						$row_out = array(
 							'type'               => $kind,
 							'target'             => $label,
 							'position'           => round( $position, 1 ),
@@ -333,6 +394,11 @@ class GscOpportunityAbility {
 							'expected_ctr'       => round( $expected_ctr, 4 ),
 							'recoverable_clicks' => $recoverable,
 						);
+						if ( $definition_box ) {
+							$row_out['definition_box'] = true;
+							++$definition_box_count;
+						}
+						$snippet_gap[] = $row_out;
 					}
 					continue;
 				}
@@ -373,14 +439,14 @@ class GscOpportunityAbility {
 		}
 
 		return array(
-			'success'            => true,
-			'dimension'          => $dimension,
-			'window'             => array(
+			'success'              => true,
+			'dimension'            => $dimension,
+			'window'               => array(
 				'start_date' => $start_date,
 				'end_date'   => $end_date,
 				'days'       => $days,
 			),
-			'thresholds'         => array(
+			'thresholds'           => array(
 				'min_impressions'       => $min_impressions,
 				'good_position'         => $good_position,
 				'ctr_gap_factor'        => $ctr_gap_factor,
@@ -388,10 +454,11 @@ class GscOpportunityAbility {
 				'page2_max_position'    => self::DEFAULT_PAGE2_MAX_POSITION,
 				'page2_target_position' => self::PAGE2_TARGET_POSITION,
 			),
-			'snippet_gap'        => $snippet_gap,
-			'page2_demand'       => $page2_demand,
-			'snippet_gap_count'  => count( $snippet_gap ),
-			'page2_demand_count' => count( $page2_demand ),
+			'snippet_gap'          => $snippet_gap,
+			'page2_demand'         => $page2_demand,
+			'snippet_gap_count'    => count( $snippet_gap ),
+			'page2_demand_count'   => count( $page2_demand ),
+			'definition_box_count' => $definition_box_count,
 		);
 	}
 
@@ -420,6 +487,59 @@ class GscOpportunityAbility {
 		$last_key = array_key_last( $baseline );
 
 		return $baseline[ $last_key ];
+	}
+
+	/**
+	 * Detect whether a query row is a SERP-captured definition-box query.
+	 *
+	 * A definition-box query is a bare-word definitional search ("<term>
+	 * meaning") where Google answers inline and the organic result is never
+	 * seen. Returns true ONLY when ALL THREE legs of the signature hold:
+	 *
+	 *   (a) PATTERN — the query matches a bare-definitional shape (see
+	 *       DEFINITION_BOX_PATTERNS). "Contains the word meaning" alone is NOT
+	 *       enough: legit song-intent queries like "no diggity lyrics meaning"
+	 *       or "what does X mean in <song>" must stay fully scored.
+	 *   (b) RANK — position <= good_position. A definition box only suppresses
+	 *       the organic result when the page is actually ranking well; a page-2
+	 *       row is not SERP-captured, it is just not ranking (and cannot reach
+	 *       this method anyway, since page-2 rows fall into CLASS 2).
+	 *   (c) CTR — current CTR is an order of magnitude below the position
+	 *       baseline (ctr < expected_ctr * DEFINITION_BOX_CTR_FRACTION). This
+	 *       is the leg that separates "diggity meaning" (0.005% CTR) from "no
+	 *       diggity meaning" (1.0% CTR) at the same rank on the same page.
+	 *
+	 * Any single leg is noise; all three together are the signature. The checks
+	 * are ordered cheapest-first (rank, then CTR, then the regex) so the common
+	 * non-matching rows short-circuit before pattern matching.
+	 *
+	 * @param string $query        Query string (row label).
+	 * @param float  $position     SERP position.
+	 * @param float  $ctr          Current CTR (fraction).
+	 * @param float  $expected_ctr Position-expected CTR (fraction).
+	 * @param float  $good_position Good-rank cutoff (position <= this is strong).
+	 * @return bool True when the row is a SERP-captured definition-box query.
+	 */
+	private static function is_definition_box( string $query, float $position, float $ctr, float $expected_ctr, float $good_position ): bool {
+
+		// Leg (b) — strong rank.
+		if ( $position > $good_position || $expected_ctr <= 0.0 ) {
+			return false;
+		}
+
+		// Leg (c) — catastrophic CTR: an order of magnitude below baseline.
+		if ( $ctr >= ( $expected_ctr * self::DEFINITION_BOX_CTR_FRACTION ) ) {
+			return false;
+		}
+
+		// Leg (a) — definitional pattern.
+		foreach ( self::DEFINITION_BOX_PATTERNS as $pattern ) {
+			if ( preg_match( $pattern, $query ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
## Bug

CLASS 1 (snippet/CTR gap) in `GscOpportunityAbility::audit()` scored every good-rank, low-CTR row as `recoverable_clicks = impressions * (expected_ctr - ctr)` with no awareness that some queries are **definition-box / zero-click queries** — bare-word definitional searches where Google answers inline (definition panel, AI Overview, featured snippet) and the organic result is structurally never seen. For those, a near-0% CTR is **structural (SERP-captured)**, not a fixable title/meta problem.

This caused a single high-volume definition-box query to inflate a page to a phantom top-of-list "recoverable clicks" opportunity that buried genuinely recoverable queries underneath it.

### Exhibit (real GSC data, 6-month window, same page)

| Query | Impressions | Position | CTR | recoverable_clicks (BEFORE) |
|---|---|---|---|---|
| `diggity meaning` | 320,129 | 3.76 | 0.005% | **~31,997** → sorts #1 (FALSE — definition-box) |
| `no diggity meaning` | 6,046 | 4.0 | 1.0% | 357 (real, modestly recoverable) |
| `no diggity lyrics meaning` | 551 | 2.1 | 6.0% | 50 (healthy-ish) |

The **200x CTR gap** between `diggity meaning` (0.005%) and `no diggity meaning` (1.0%) on the **same page** at nearly the **same position** IS the definition-box signature.

## Fix — three-leg definition-box signature

Detection requires **ALL THREE** legs (any one alone is noise):

1. **(a) PATTERN** — the query matches a bare-definitional shape (`DEFINITION_BOX_PATTERNS`): `^<term> (meaning|definition)$` with a 1-2 word term, or `^(define|definition of|meaning of) <term>$`.
2. **(b) RANK** — `position <= good_position` (a definition box only suppresses the organic result when the page is actually ranking well).
3. **(c) CTR** — `ctr < expected_ctr * DEFINITION_BOX_CTR_FRACTION` (0.1 = an order of magnitude below baseline). This is the leg that separates `diggity meaning` (ratio 0.0005) from `no diggity meaning` (ratio 0.14).

### Why "contains the word meaning" alone was rejected

Song-intent queries like `no diggity lyrics meaning` (CTR 6%) and `what does bag it up mean in no diggity` are legit high-CTR queries that must stay fully scored. Matching on the word "meaning" alone would false-positive on all of them. The pattern leg constrains the query SHAPE, but the CTR-ratio leg is the real discriminator — even if a song-intent query happened to match the pattern, its healthy CTR would keep it above the 0.1 threshold.

## Handling option chosen: (b) flag + discount

The row is **kept in `snippet_gap` for visibility** but:
- `recoverable_clicks` is zeroed → it can no longer dominate the ranking
- `definition_box => true` is added → the operator sees "this high-impression query exists but is SERP-captured / unrecoverable"

This was chosen over (a) exclude (silently deletes data the operator should see) and (c) separate bucket (adds a new top-level key that requires more presenter changes). Option (b) is additive and backward-compatible.

## Before / after (exhibit row)

| | `diggity meaning` recoverable_clicks | Sort position in snippet_gap |
|---|---|---|
| **Before** | 31,997 | **#1** (phantom — dominates the report) |
| **After** | 0 (`definition_box => true`) | **#3** (bottom — visible but non-dominating) |

The real top opportunity is now `no diggity meaning` (357 recoverable clicks).

## Confirmation: song-intent queries remain fully scored

- ✅ `no diggity meaning` — recoverable_clicks = **357** (unchanged, no flag). CTR ratio 0.14 > 0.1 threshold → correctly NOT definition-box.
- ✅ `no diggity lyrics meaning` — recoverable_clicks = **50** (unchanged, no flag). Does not match the 1-2 word definitional pattern AND CTR ratio 0.4 >> 0.1.

Verified with a standalone PHP reflection script feeding the three exhibit rows through `is_definition_box()` + the scoring logic. All assertions passed.

## CLASS 2 (page-2 demand) — no change needed

Page-2 rows are position 8-15. The "strong rank" leg (b) requires `position <= good_position` (default 5.0). A row cannot be simultaneously <= 5.0 and >= 8.0, so CLASS 2 rows can never match the definition-box signature. Additionally, definition-box rows enter CLASS 1 (they have good rank + low CTR) and `continue` before reaching CLASS 2. No guard needed.

## Contract changes (additive / backward-compatible)

- `snippet_gap` rows: new optional `definition_box` (bool) key on flagged rows only. Existing keys unchanged.
- Return payload: new `definition_box_count` (int) key. Existing keys (`success`, `dimension`, `window`, `thresholds`, `snippet_gap`, `page2_demand`, `snippet_gap_count`, `page2_demand_count`) all preserved.
- Output schema: `definition_box_count` added as an integer property.

## Follow-up needed (different repo)

The CLI presenter `extrachill-cli/inc/Commands/Analytics/GscOpportunitiesCommand.php` renders `snippet_gap` rows with a fixed column set (`type, target, position, impressions, current_ctr, expected_ctr, recoverable_clicks`). The new `definition_box => true` flag and zeroed `recoverable_clicks` are backward-compatible — the existing presenter will render the row normally (just showing 0 recoverable clicks). A nice-to-have follow-up in `extrachill-cli` would be to annotate definition-box rows (e.g. a `[SERP-captured]` marker in the target column) and surface `definition_box_count` in the summary line. That is a separate repo and was **not** edited here.

## Verification

- PHP lint: clean (`php -l`)
- PHPStan: passed
- PHPCS: 0 errors, 0 warnings on this file (314 pre-existing warnings in other files remain)
- Behavioral test: all assertions passed (exhibit rows + false-positive guards for song-intent queries)