### PR TITLE
Fix Mediavine reporting API contract

### DIFF
--- a/inc/Abilities/Analytics/MediavineReportsAbilities.php
+++ b/inc/Abilities/Analytics/MediavineReportsAbilities.php
@@ -13,7 +13,7 @@
  *
  *   1. GraphQL login mutation (unidashSignIn) -> a Bearer access token, cached
  *      in a transient until it expires.
- *   2. The per-page revenue CSV report (slug,views,revenue,rpm,cpm,viewability,
+ *   2. The pagesSummary GraphQL report (slug,views,revenue,rpm,cpm,viewability,
  *      fillRate,impressionsPerPageview) for a date range — the rows a consumer
  *      CLI plugin imports into its revenue store.
  *
@@ -65,7 +65,7 @@ class MediavineReportsAbilities {
 	const API_BASE = 'https://api-publishers.mediavine.com';
 
 	/**
-	 * Per-page CSV row cap requested from Mediavine.
+	 * Per-page row cap requested from Mediavine.
 	 *
 	 * @var int
 	 */
@@ -88,7 +88,7 @@ class MediavineReportsAbilities {
 				'datamachine/mediavine-reports',
 				array(
 					'label'               => 'Mediavine Reports',
-					'description'         => 'Fetch per-period, per-URL Mediavine ad revenue directly from the Mediavine publisher API (GraphQL login + CSV report). Actions: pages (per-period per-URL revenue rows: slug,views,revenue,rpm,cpm,viewability,fillRate,impressionsPerPageview,period), summary (site-level aggregate totals: earnings, pageviews, sessions, rpm), backfill (iterate a list of periods, returning pages rows per period for a full revenue-arc backfill). Credentials live server-side in the datamachine_mediavine_config option.',
+					'description'         => 'Fetch per-period, per-URL Mediavine ad revenue directly from the Mediavine publisher GraphQL API. Actions: pages (per-period per-URL revenue rows: slug,views,revenue,rpm,cpm,viewability,fillRate,impressionsPerPageview,period), summary (site-level aggregate totals: earnings, pageviews, sessions, rpm), backfill (iterate a list of periods, returning pages rows per period for a full revenue-arc backfill). Credentials live server-side in the datamachine_mediavine_config option.',
 					'category'            => 'datamachine-analytics',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -96,7 +96,7 @@ class MediavineReportsAbilities {
 						'properties' => array(
 							'action'     => array(
 								'type'        => 'string',
-								'description' => 'Action: pages (per-period per-URL CSV rows), summary (aggregate totals), backfill (iterate periods).',
+								'description' => 'Action: pages (per-period per-URL rows), summary (aggregate totals), backfill (iterate periods).',
 							),
 							'start_date' => array(
 								'type'        => 'string',
@@ -124,7 +124,7 @@ class MediavineReportsAbilities {
 							),
 							'site_id'    => array(
 								'type'        => 'string',
-								'description' => 'Mediavine site id. Defaults to the configured site_id, else the datamachine_mediavine_default_site_id filter. Required when neither is set.',
+								'description' => 'Mediavine GraphQL global InternalSite ID. A numeric internal site id is also accepted and encoded. Legacy site slugs are not accepted by the reporting API.',
 							),
 						),
 					),
@@ -194,6 +194,14 @@ class MediavineReportsAbilities {
 			return array(
 				'success' => false,
 				'error'   => 'A Mediavine site id is required. Pass the "site_id" input, set site_id in the datamachine_mediavine_config option, or register a default via the datamachine_mediavine_default_site_id filter.',
+			);
+		}
+
+		$site_id = self::normalizeReportSiteId( $site_id );
+		if ( is_wp_error( $site_id ) ) {
+			return array(
+				'success' => false,
+				'error'   => $site_id->get_error_message(),
 			);
 		}
 
@@ -312,12 +320,11 @@ class MediavineReportsAbilities {
 	}
 
 	/**
-	 * GET the per-page revenue CSV and parse it into structured rows.
+	 * Fetch the current pagesSummary GraphQL report and normalize its rows.
 	 *
-	 * The CSV header is slug,views,revenue,rpm,cpm,viewability,fillRate,
-	 * impressionsPerPageview — exactly the tokens the revenue importer matches
-	 * loosely. Each parsed row carries those fields plus the supplied period so
-	 * the consumer can stamp the revenue arc.
+	 * GraphQL fields are normalized to slug,views,revenue,rpm,cpm,viewability,
+	 * fillRate,impressionsPerPageview — exactly the established public row shape.
+	 * Each parsed row also carries the supplied period for revenue-arc grouping.
 	 *
 	 * @param string $access_token Bearer token.
 	 * @param string $site_id      Mediavine site id.
@@ -327,32 +334,94 @@ class MediavineReportsAbilities {
 	 * @return array|\WP_Error Parsed rows or error.
 	 */
 	private static function fetchPagesRows( string $access_token, string $site_id, string $start_date, string $end_date, string $period ) {
-		$url = self::API_BASE . '/reports/' . rawurlencode( $site_id ) . '/pages.csv?' . http_build_query(
-			array(
-				'startDate'      => self::toMdy( $start_date ),
-				'endDate'        => self::toMdy( $end_date ),
-				'perPage'        => self::PAGES_PER_PAGE,
-				'useMonetizable' => 'false',
-			)
-		);
-
-		$result = HttpClient::get(
-			$url,
+		$result = HttpClient::post(
+			self::API_BASE . '/graphql',
 			array(
 				'timeout' => 60,
 				'headers' => array(
 					'Authorization' => 'Bearer ' . $access_token,
-					'Accept'        => 'text/csv',
+					'Content-Type'  => 'application/json',
 				),
-				'context' => 'Mediavine Pages CSV',
+				'body'    => wp_json_encode( self::buildPagesRequestBody( $site_id, $start_date, $end_date ) ),
+				'context' => 'Mediavine pagesSummary',
 			)
 		);
 
 		if ( empty( $result['success'] ) ) {
-			return new \WP_Error( 'mediavine_pages_failed', 'Failed to fetch Mediavine pages CSV: ' . ( $result['error'] ?? 'Unknown error' ) );
+			return new \WP_Error( 'mediavine_pages_transport', 'Mediavine pages report transport or authorization failure: ' . ( $result['error'] ?? 'Unknown error' ) );
 		}
 
-		return self::parsePagesCsv( (string) ( $result['data'] ?? '' ), $period );
+		$data = json_decode( (string) ( $result['data'] ?? '' ), true );
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return new \WP_Error( 'mediavine_pages_parse', 'Mediavine pages report returned invalid JSON.' );
+		}
+
+		$error = self::graphqlError( $data );
+		if ( null !== $error ) {
+			return new \WP_Error( 'mediavine_pages_schema', 'Mediavine pages report schema or authorization error: ' . $error );
+		}
+
+		return self::parsePagesResponse( $data, $period );
+	}
+
+	/**
+	 * Build the current pagesSummary request contract.
+	 */
+	public static function buildPagesRequestBody( string $site_id, string $start_date, string $end_date ): array {
+		return array(
+			'query'         => 'query PagesSummaryQuery($data: GetPagesSummaryInput!){ pagesSummary(data:$data){ meta{ totalCount reportStart reportEnd } pages{ path pageviews pageRevenue rpm cpm viewability fillrate impressionsPerPageView } } }',
+			'operationName' => 'PagesSummaryQuery',
+			'variables'     => array(
+				'data' => array(
+					'siteId'    => $site_id,
+					'startDate' => self::toIso( $start_date, false ),
+					'endDate'   => self::toIso( $end_date, true ),
+					'page'      => 1,
+					'perPage'   => self::PAGES_PER_PAGE,
+					'sort'      => 'pageRevenue',
+					'direction' => 'desc',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Normalize a pagesSummary response into the established ability row shape.
+	 *
+	 * @return array|\WP_Error
+	 */
+	public static function parsePagesResponse( array $data, string $period ) {
+		$payload = $data['data']['pagesSummary'] ?? null;
+		if ( ! is_array( $payload ) || ! isset( $payload['pages'] ) || ! is_array( $payload['pages'] ) ) {
+			return new \WP_Error( 'mediavine_pages_contract', 'Mediavine pages report response is missing pagesSummary.pages.' );
+		}
+
+		if ( empty( $payload['pages'] ) ) {
+			return new \WP_Error( 'mediavine_pages_empty', 'Mediavine pages report returned no page-level rows for the requested date range.' );
+		}
+
+		$rows = array();
+		foreach ( $payload['pages'] as $page ) {
+			if ( ! is_array( $page ) || empty( $page['path'] ) ) {
+				continue;
+			}
+
+			$rows[] = array(
+				'slug'                   => (string) $page['path'],
+				'views'                  => (int) ( $page['pageviews'] ?? 0 ),
+				'revenue'                => (float) ( $page['pageRevenue'] ?? 0 ),
+				'rpm'                    => (float) ( $page['rpm'] ?? 0 ),
+				'cpm'                    => (float) ( $page['cpm'] ?? 0 ),
+				'viewability'            => (float) ( $page['viewability'] ?? 0 ),
+				'fillRate'               => (float) ( $page['fillrate'] ?? 0 ),
+				'impressionsPerPageview' => (float) ( $page['impressionsPerPageView'] ?? 0 ),
+				'period'                 => $period,
+			);
+		}
+
+		return empty( $rows )
+			? new \WP_Error( 'mediavine_pages_empty', 'Mediavine pages report contained no usable page-level rows.' )
+			: $rows;
 	}
 
 	/**
@@ -463,7 +532,7 @@ class MediavineReportsAbilities {
 		$start_date = self::resolveDate( $input['start_date'] ?? '', '-28 days' );
 		$end_date   = self::resolveDate( $input['end_date'] ?? '', '-1 day' );
 
-		$query = 'query MetricsSummaryQuery($data: MetricsSummaryInput!){ metricsSummary(data:$data){ summary{ earnings pageviews sessions cpm sessionRpm pageRpm paidImpressions } } }';
+		$query = 'query MetricsSummaryQuery($data: GetMetricsSummaryInput!){ metricsSummary(data:$data){ summary{ earnings pageviews sessions cpm sessionRpm pageRpm paidImpressions } } }';
 
 		$body = array(
 			'query'         => $query,
@@ -515,6 +584,12 @@ class MediavineReportsAbilities {
 		}
 
 		$summary = $data['data']['metricsSummary']['summary'] ?? array();
+		if ( empty( $summary ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Mediavine summary report returned no summary data for the requested date range.',
+			);
+		}
 
 		$row = array(
 			'period'          => sanitize_text_field( $input['period'] ?? '' ),
@@ -649,30 +724,40 @@ class MediavineReportsAbilities {
 	 * Resolve a date input to Y-m-d, falling back to a relative default.
 	 *
 	 * @param string $value   Raw date input.
-	 * @param string $default Relative fallback (e.g. "-28 days").
+	 * @param string $fallback Relative fallback (e.g. "-28 days").
 	 * @return string Y-m-d date.
 	 */
-	private static function resolveDate( string $value, string $default ): string {
+	private static function resolveDate( string $value, string $fallback ): string {
 		$value = sanitize_text_field( $value );
 		$ts    = '' !== $value ? strtotime( $value ) : false;
 		if ( false === $ts ) {
-			$ts = strtotime( $default );
+			$ts = strtotime( $fallback );
 		}
 		return gmdate( 'Y-m-d', $ts );
 	}
 
 	/**
-	 * Convert a Y-m-d date to Mediavine's MM/DD/YYYY CSV-report format.
+	 * Normalize the configured identifier for current report operations.
 	 *
-	 * @param string $date Y-m-d date.
-	 * @return string MM/DD/YYYY.
+	 * Current reports require a Relay global InternalSite ID. Numeric internal
+	 * ids are accepted as a convenience; legacy dashboard slugs cannot be
+	 * resolved with publisher credentials and therefore fail explicitly.
+	 *
+	 * @return string|\WP_Error
 	 */
-	private static function toMdy( string $date ): string {
-		$ts = strtotime( $date );
-		if ( false === $ts ) {
-			$ts = time();
+	private static function normalizeReportSiteId( string $site_id ) {
+		if ( ctype_digit( $site_id ) ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Relay global ID encoding, not obfuscation.
+			return base64_encode( 'InternalSite:' . $site_id );
 		}
-		return gmdate( 'm/d/Y', $ts );
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Validate the Relay global ID type.
+		$decoded = base64_decode( $site_id, true );
+		if ( false !== $decoded && str_starts_with( $decoded, 'InternalSite:' ) ) {
+			return $site_id;
+		}
+
+		return new \WP_Error( 'mediavine_site_id_contract', 'Mediavine reporting requires a GraphQL global InternalSite ID (or numeric internal site id); legacy site slugs are no longer accepted.' );
 	}
 
 	/**

--- a/tests/Unit/Abilities/Analytics/MediavineReportsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/MediavineReportsAbilitiesTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Current Mediavine reporting contract tests.
+ *
+ * @package DataMachine\Tests\Unit\Abilities\Analytics
+ */
+
+namespace DataMachine\Tests\Unit\Abilities\Analytics;
+
+use DataMachineBusiness\Abilities\Analytics\MediavineReportsAbilities;
+use WP_UnitTestCase;
+
+class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
+
+	public function test_pages_request_uses_current_graphql_contract(): void {
+		$body = MediavineReportsAbilities::buildPagesRequestBody( 'global-id', '2026-06-01', '2026-06-30' );
+
+		$this->assertSame( 'PagesSummaryQuery', $body['operationName'] );
+		$this->assertStringContainsString( 'GetPagesSummaryInput!', $body['query'] );
+		$this->assertStringContainsString( 'pagesSummary(data:$data)', $body['query'] );
+		$this->assertSame( 'global-id', $body['variables']['data']['siteId'] );
+		$this->assertSame( '2026-06-01T00:00:00.000Z', $body['variables']['data']['startDate'] );
+		$this->assertSame( '2026-06-30T23:59:59.999Z', $body['variables']['data']['endDate'] );
+		$this->assertSame( 100000, $body['variables']['data']['perPage'] );
+	}
+
+	public function test_pages_response_maps_current_fields_to_public_row_contract(): void {
+		$response = array(
+			'data' => array(
+				'pagesSummary' => array(
+					'meta'  => array( 'totalCount' => 1 ),
+					'pages' => array(
+						array(
+							'path'                   => '/music/example/',
+							'pageviews'              => 1250.0,
+							'pageRevenue'            => 18.75,
+							'rpm'                    => 15.0,
+							'cpm'                    => 2.5,
+							'viewability'            => 0.72,
+							'fillrate'               => 0.94,
+							'impressionsPerPageView' => 4.2,
+						),
+					),
+				),
+			),
+		);
+
+		$rows = MediavineReportsAbilities::parsePagesResponse( $response, '2026-06' );
+
+		$this->assertFalse( is_wp_error( $rows ) );
+		$this->assertSame( '/music/example/', $rows[0]['slug'] );
+		$this->assertSame( 1250, $rows[0]['views'] );
+		$this->assertSame( 18.75, $rows[0]['revenue'] );
+		$this->assertSame( 0.94, $rows[0]['fillRate'] );
+		$this->assertSame( 4.2, $rows[0]['impressionsPerPageview'] );
+		$this->assertSame( '2026-06', $rows[0]['period'] );
+	}
+
+	public function test_empty_pages_response_is_distinct_failure(): void {
+		$result = MediavineReportsAbilities::parsePagesResponse(
+			array( 'data' => array( 'pagesSummary' => array( 'pages' => array() ) ) ),
+			'2026-06'
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'mediavine_pages_empty', $result->get_error_code() );
+	}
+
+	public function test_summary_query_uses_current_input_type(): void {
+		$source = file_get_contents( dirname( __DIR__, 4 ) . '/inc/Abilities/Analytics/MediavineReportsAbilities.php' );
+
+		$this->assertStringContainsString( 'GetMetricsSummaryInput!', $source );
+		$this->assertStringNotContainsString( '$data: MetricsSummaryInput!', $source );
+	}
+}


### PR DESCRIPTION
## Summary
- replace the permission-gated legacy pages CSV export with the current `pagesSummary(data: GetPagesSummaryInput!)` GraphQL report
- update aggregate reporting to `GetMetricsSummaryInput!` and preserve the existing ability result shapes
- distinguish authentication, site-ID contract, transport/authorization, GraphQL schema, malformed response, and empty-report failures
- add focused request/response contract tests for current page-level and summary operations

## Verified contract
Authenticated schema introspection and read-only requests against the configured publisher account confirmed:
- `metricsSummary(data: GetMetricsSummaryInput!)` returns the existing summary fields
- `pagesSummary(data: GetPagesSummaryInput!)` returns `meta` and page rows with `path`, `pageviews`, `pageRevenue`, `rpm`, `cpm`, `viewability`, `fillrate`, and `impressionsPerPageView`
- both updated operations returned HTTP 200 using a Relay global `InternalSite` ID
- the legacy configured slug is rejected by GraphQL as an invalid global ID; numeric internal IDs are encoded for convenience, while legacy slugs now produce a precise configuration error

## Test evidence
- `php -l` passes for both changed PHP files
- focused PHPCS passes for the implementation and test file
- `git diff --check` passes
- read-only live probes returned HTTP 200 for summary and page-level reports; no revenue rows were written and no sensitive values were printed
- PHPUnit could not start because the local Homeboy WP Codebox runner lacks a compatible `buildWordPressPhpunitRecipe` export
- PHPStan could not start because the locally installed PHAR reports `manifest cannot be larger than 100 MB`

## Residual risk
The configured `site_id` must be changed from the legacy dashboard slug to its GraphQL global `InternalSite` ID (or numeric internal ID) when this change is deployed. Publisher credentials cannot query the available-site lookup surfaces, so the generic ability cannot safely resolve a slug itself.

Fixes #66