### PR TITLE
fix: preserve SERP-captured GSC visibility

### DIFF
--- a/inc/Abilities/Analytics/GscOpportunityAbility.php
+++ b/inc/Abilities/Analytics/GscOpportunityAbility.php
@@ -255,8 +255,10 @@ class GscOpportunityAbility {
 							'thresholds'           => array( 'type' => 'object' ),
 							'snippet_gap'          => array( 'type' => 'array' ),
 							'page2_demand'         => array( 'type' => 'array' ),
+							'serp_captured'        => array( 'type' => 'array' ),
 							'snippet_gap_count'    => array( 'type' => 'integer' ),
 							'page2_demand_count'   => array( 'type' => 'integer' ),
+							'serp_captured_count'  => array( 'type' => 'integer' ),
 							'definition_box_count' => array( 'type' => 'integer' ),
 							'error'                => array( 'type' => 'string' ),
 						),
@@ -313,22 +315,20 @@ class GscOpportunityAbility {
 			$actions['page'] = 'page_stats';
 		}
 
-		$snippet_gap          = array();
-		$page2_demand         = array();
-		$definition_box_count = 0;
+		$snippet_gap      = array();
+		$page2_demand     = array();
+		$serp_captured    = array();
+		$captured_by_page = array();
+		if ( 'page' === $dimension || 'both' === $dimension ) {
+			$support_input    = self::gsc_input( 'query_page_stats', $start_date, $end_date, $input );
+			$support_result   = $gsc->execute( $support_input );
+			$captured_by_page = ! is_wp_error( $support_result ) && ! empty( $support_result['success'] )
+				? self::captured_impressions_by_page( (array) ( $support_result['results'] ?? array() ), $good_position )
+				: array();
+		}
 
 		foreach ( $actions as $kind => $action ) {
-			$gsc_input = array(
-				'action'     => $action,
-				'start_date' => $start_date,
-				'end_date'   => $end_date,
-				'limit'      => self::FETCH_LIMIT,
-			);
-			foreach ( array( 'site_url', 'url_filter', 'query_filter' ) as $passthrough ) {
-				if ( ! empty( $input[ $passthrough ] ) ) {
-					$gsc_input[ $passthrough ] = sanitize_text_field( $input[ $passthrough ] );
-				}
-			}
+			$gsc_input = self::gsc_input( $action, $start_date, $end_date, $input );
 
 			$result = $gsc->execute( $gsc_input );
 
@@ -353,7 +353,6 @@ class GscOpportunityAbility {
 				}
 
 				$impressions = (int) ( $row['impressions'] ?? 0 );
-				$clicks      = (int) ( $row['clicks'] ?? 0 );
 				$ctr         = (float) ( $row['ctr'] ?? 0.0 );
 				$position    = (float) ( $row['position'] ?? 0.0 );
 
@@ -368,35 +367,28 @@ class GscOpportunityAbility {
 					&& $expected_ctr > 0.0
 					&& $ctr < ( $expected_ctr * $ctr_gap_factor )
 				) {
-					$recoverable    = (int) round( $impressions * max( 0.0, $expected_ctr - $ctr ) );
 					$definition_box = self::is_definition_box( $label, $position, $ctr, $expected_ctr, $good_position );
 
-					if ( $definition_box ) {
-						// SERP-captured (definition-box) query: the near-0% CTR
-						// is structural (Google answers inline), not a
-						// title/meta problem. Keep the row visible so the
-						// operator still sees "this high-impression query
-						// exists but is unrecoverable", but zero its
-						// recoverable estimate so it cannot dominate the
-						// ranking and bury actionable rows. See the
-						// DEFINITION_BOX_PATTERNS docblock for the rationale.
-						$recoverable = 0;
+					if ( $definition_box && 'query' === $kind ) {
+						$serp_captured[] = self::opportunity_row( $kind, $label, $row, $expected_ctr, 0 ) + array(
+							'definition_box' => true,
+							'serp_captured'  => true,
+						);
+						continue;
 					}
 
-					if ( $recoverable > 0 || $definition_box ) {
-						$row_out = array(
-							'type'               => $kind,
-							'target'             => $label,
-							'position'           => round( $position, 1 ),
-							'impressions'        => $impressions,
-							'clicks'             => $clicks,
-							'current_ctr'        => round( $ctr, 4 ),
-							'expected_ctr'       => round( $expected_ctr, 4 ),
-							'recoverable_clicks' => $recoverable,
-						);
-						if ( $definition_box ) {
-							$row_out['definition_box'] = true;
-							++$definition_box_count;
+					$captured    = 'page' === $kind ? (int) ( $captured_by_page[ $label ] ?? 0 ) : 0;
+					$actionable  = max( 0, $impressions - $captured );
+					$recoverable = (int) round( $actionable * max( 0.0, $expected_ctr - $ctr ) );
+					if ( $recoverable > 0 ) {
+						$row_out = self::opportunity_row( $kind, $label, $row, $expected_ctr, $recoverable );
+						if ( $captured > 0 ) {
+							$row_out += array(
+								'serp_captured_impressions' => $captured,
+								'actionable_impressions' => $actionable,
+								'serp_captured_share'    => round( $captured / $impressions, 4 ),
+								'serp_captured_observed_only' => true,
+							);
 						}
 						$snippet_gap[] = $row_out;
 					}
@@ -426,17 +418,9 @@ class GscOpportunityAbility {
 			}
 		}
 
-		// Rank both classes by estimated recoverable clicks (descending).
-		$by_recoverable = static function ( array $a, array $b ): int {
-			return $b['recoverable_clicks'] <=> $a['recoverable_clicks'];
-		};
-		usort( $snippet_gap, $by_recoverable );
-		usort( $page2_demand, $by_recoverable );
-
-		if ( $limit > 0 ) {
-			$snippet_gap  = array_slice( $snippet_gap, 0, $limit );
-			$page2_demand = array_slice( $page2_demand, 0, $limit );
-		}
+		$snippet_gap   = self::sort_and_limit( $snippet_gap, 'recoverable_clicks', $limit );
+		$page2_demand  = self::sort_and_limit( $page2_demand, 'recoverable_clicks', $limit );
+		$serp_captured = self::sort_and_limit( $serp_captured, 'impressions', $limit );
 
 		return array(
 			'success'              => true,
@@ -456,9 +440,54 @@ class GscOpportunityAbility {
 			),
 			'snippet_gap'          => $snippet_gap,
 			'page2_demand'         => $page2_demand,
+			'serp_captured'        => $serp_captured,
 			'snippet_gap_count'    => count( $snippet_gap ),
 			'page2_demand_count'   => count( $page2_demand ),
-			'definition_box_count' => $definition_box_count,
+			'serp_captured_count'  => count( $serp_captured ),
+			'definition_box_count' => count( $serp_captured ),
+		);
+	}
+
+	public static function captured_impressions_by_page( array $rows, float $good_position = self::DEFAULT_GOOD_POSITION ): array {
+		$captured = array();
+		foreach ( $rows as $row ) {
+			$keys = (array) ( $row['keys'] ?? array() );
+			if ( count( $keys ) < 2 ) {
+				continue;
+			}
+			$position = (float) ( $row['position'] ?? 0 );
+			if ( self::is_definition_box( (string) $keys[0], $position, (float) ( $row['ctr'] ?? 0 ), self::expected_ctr( $position ), $good_position ) ) {
+				$captured[ (string) $keys[1] ] = ( $captured[ (string) $keys[1] ] ?? 0 ) + (int) ( $row['impressions'] ?? 0 );
+			}
+		}
+		return $captured;
+	}
+
+	public static function sort_and_limit( array $rows, string $field, int $limit = 0 ): array {
+		usort( $rows, static fn( array $a, array $b ): int => ( $b[ $field ] ?? 0 ) <=> ( $a[ $field ] ?? 0 ) );
+		return $limit > 0 ? array_slice( $rows, 0, $limit ) : $rows;
+	}
+
+	private static function gsc_input( string $action, string $start_date, string $end_date, array $input ): array {
+		$output = compact( 'action', 'start_date', 'end_date' ) + array( 'limit' => self::FETCH_LIMIT );
+		foreach ( array( 'site_url', 'url_filter', 'query_filter' ) as $key ) {
+			if ( ! empty( $input[ $key ] ) ) {
+				$output[ $key ] = sanitize_text_field( $input[ $key ] );
+			}
+		}
+		return $output;
+	}
+
+	private static function opportunity_row( string $kind, string $label, array $row, float $expected_ctr, int $recoverable ): array {
+		return array(
+			'type'               => $kind,
+			'target'             => $label,
+			'position'           => round( (float) $row['position'], 1 ),
+			'impressions'        => (int) $row['impressions'],
+			'clicks'             => (int) ( $row['clicks'] ?? 0 ),
+			'current_ctr'        => round( (float) ( $row['ctr'] ?? 0 ), 4 ),
+			'expected_ctr'       => round( $expected_ctr, 4 ),
+			'recoverable_clicks' => $recoverable,
 		);
 	}
 
@@ -513,14 +542,14 @@ class GscOpportunityAbility {
 	 * are ordered cheapest-first (rank, then CTR, then the regex) so the common
 	 * non-matching rows short-circuit before pattern matching.
 	 *
-	 * @param string $query        Query string (row label).
-	 * @param float  $position     SERP position.
-	 * @param float  $ctr          Current CTR (fraction).
-	 * @param float  $expected_ctr Position-expected CTR (fraction).
+	 * @param string $query         Query string (row label).
+	 * @param float  $position      SERP position.
+	 * @param float  $ctr           Current CTR (fraction).
+	 * @param float  $expected_ctr  Position-expected CTR (fraction).
 	 * @param float  $good_position Good-rank cutoff (position <= this is strong).
 	 * @return bool True when the row is a SERP-captured definition-box query.
 	 */
-	private static function is_definition_box( string $query, float $position, float $ctr, float $expected_ctr, float $good_position ): bool {
+	public static function is_definition_box( string $query, float $position, float $ctr, float $expected_ctr, float $good_position ): bool {
 
 		// Leg (b) — strong rank.
 		if ( $position > $good_position || $expected_ctr <= 0.0 ) {

--- a/tests/Unit/Abilities/Analytics/GscOpportunityAbilityTest.php
+++ b/tests/Unit/Abilities/Analytics/GscOpportunityAbilityTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Unit tests for GscOpportunityAbility's deterministic transformations.
+ *
+ * @package DataMachine\Tests\Unit\Abilities\Analytics
+ */
+
+namespace DataMachine\Tests\Unit\Abilities\Analytics;
+
+use DataMachineBusiness\Abilities\Analytics\GscOpportunityAbility;
+use WP_UnitTestCase;
+
+class GscOpportunityAbilityTest extends WP_UnitTestCase {
+
+	public function test_definition_box_classifier_preserves_song_intent(): void {
+		$expected_ctr = GscOpportunityAbility::expected_ctr( 3.8 );
+
+		$this->assertTrue( GscOpportunityAbility::is_definition_box( 'diggity meaning', 3.8, 0.00005, $expected_ctr, 5.0 ) );
+		$this->assertFalse( GscOpportunityAbility::is_definition_box( 'no diggity meaning', 3.8, 0.02, $expected_ctr, 5.0 ) );
+		$this->assertFalse( GscOpportunityAbility::is_definition_box( 'no diggity lyrics meaning', 3.8, 0.0005, $expected_ctr, 5.0 ) );
+	}
+
+	public function test_captured_bucket_is_independently_sorted_and_limited(): void {
+		$actionable = GscOpportunityAbility::sort_and_limit(
+			array(
+				array(
+					'target'             => 'small gap',
+					'recoverable_clicks' => 10,
+				),
+				array(
+					'target'             => 'large gap',
+					'recoverable_clicks' => 100,
+				),
+			),
+			'recoverable_clicks',
+			1
+		);
+		$captured   = GscOpportunityAbility::sort_and_limit(
+			array(
+				array(
+					'target'             => 'minor meaning',
+					'impressions'        => 100,
+					'recoverable_clicks' => 0,
+				),
+				array(
+					'target'             => 'diggity meaning',
+					'impressions'        => 354000,
+					'recoverable_clicks' => 0,
+				),
+			),
+			'impressions',
+			1
+		);
+
+		$this->assertSame( 'large gap', $actionable[0]['target'] );
+		$this->assertSame( 'diggity meaning', $captured[0]['target'] );
+		$this->assertNotContains( 'diggity meaning', array_column( $actionable, 'target' ) );
+	}
+
+	public function test_captured_query_impressions_qualify_page_aggregate(): void {
+		$page = 'https://extrachill.com/the-meaning-of-blackstreets-no-diggity/';
+		$map  = GscOpportunityAbility::captured_impressions_by_page(
+			array(
+				array(
+					'keys'        => array( 'diggity meaning', $page ),
+					'impressions' => 340000,
+					'ctr'         => 0.00005,
+					'position'    => 3.8,
+				),
+				array(
+					'keys'        => array( 'no diggity meaning', $page ),
+					'impressions' => 14588,
+					'ctr'         => 0.2427,
+					'position'    => 3.8,
+				),
+			)
+		);
+
+		$this->assertSame( 340000, $map[ $page ] );
+		$this->assertSame( 14588, 354588 - $map[ $page ] );
+		$this->assertLessThan( 5000, (int) round( ( 354588 - $map[ $page ] ) * ( 0.10 - 0.0004 ) ) );
+	}
+
+	public function test_normal_page_has_no_captured_adjustment(): void {
+		$page = 'https://extrachill.com/normal-article/';
+		$map  = GscOpportunityAbility::captured_impressions_by_page(
+			array(
+				array(
+					'keys'        => array( 'normal article', $page ),
+					'impressions' => 10000,
+					'ctr'         => 0.01,
+					'position'    => 3.0,
+				),
+			)
+		);
+
+		$this->assertArrayNotHasKey( $page, $map );
+		$this->assertSame( 900, (int) round( 10000 * ( 0.10 - 0.01 ) ) );
+	}
+}


### PR DESCRIPTION
## Summary
- move structurally zero-click definitional queries into an additive, independently ranked `serp_captured` bucket so actionable `snippet_gap` rows retain their own top-N
- qualify page-level recoverable estimates by subtracting observed SERP-captured query impressions from matching query-page support rows
- preserve all existing payload keys, including `definition_box_count`, while adding `serp_captured`, `serp_captured_count`, and page qualification fields

## Root cause
The existing scorer zeroed definition-box recoverability but left those rows in `snippet_gap`. Sorting and limiting then hid them behind actionable rows. Page aggregates had no query text, so the classifier could not see that a large share of impressions came from SERP-captured queries and treated the full aggregate as recoverable.

## Additive contract
`snippet_gap` remains the actionable, recoverable-click-ranked list. `serp_captured` is independently sorted by impressions and independently limited. Existing response keys and row schemas remain valid; `definition_box_count` is retained as a compatibility alias for the returned `serp_captured_count`.

Qualified page rows add `serp_captured_impressions`, `actionable_impressions`, `serp_captured_share`, and `serp_captured_observed_only`. Normal pages receive no additional row fields and retain the previous calculation.

## No Diggity behavior
Before: the limited report omitted the zeroed `diggity meaning` query while the No Diggity page reported roughly 354K impressions and 35K recoverable clicks.

After: `diggity meaning` remains visible in `serp_captured` with zero recoverable clicks. With 340,000 observed captured impressions in the synthetic live-shaped case, the page estimate uses 14,588 actionable impressions rather than all 354,588 impressions, reducing the estimate below 5,000 clicks. `no diggity meaning` and `no diggity lyrics meaning` remain normal actionable queries.

## Page qualification algorithm
For page or combined audits, request `query_page_stats` for the same date window and filters. Classify each returned query-page row with the existing three-leg pattern/rank/CTR detector, sum captured impressions by exact page URL, and compute:

`actionable_impressions = max(0, page_impressions - observed_captured_impressions)`

`recoverable_clicks = actionable_impressions * max(0, expected_ctr - current_ctr)`

GSC can truncate support rows at the 25,000-row fetch limit. The subtraction is therefore explicitly observed-only, not a claim that query support is complete; qualified rows expose `serp_captured_observed_only: true`.

## Compatibility
The change is additive. Existing `snippet_gap`, `page2_demand`, counts, thresholds, and `definition_box_count` remain present. No production injection seam was added.

## Verification
- `php -l` passed for both touched files
- scoped PHPCS passed with zero findings
- Homeboy architecture audit passed
- `git diff --check` passed
- targeted PHPUnit could not start because the installed Homeboy WP Codebox runtime lacks the required `buildWordPressPhpunitRecipe` recipe-builder export
- PHPStan was invoked but the installed Homeboy PHPStan PHAR fails during bootstrap with `PharException: manifest cannot be larger than 100 MB`; Homeboy reported the aggregate lint gate successful after PHPCS

## Follow-up
`extrachill-cli` should render the additive `serp_captured` bucket independently from `snippet_gap`, label those rows as structural/zero-recoverable, display the observed-only page qualification fields, and explain that query-page support may be truncated.

Fixes #65