### PR TITLE
fix: restore GSC row click initialization

### DIFF
--- a/inc/Abilities/Analytics/GscOpportunityAbility.php
+++ b/inc/Abilities/Analytics/GscOpportunityAbility.php
@@ -353,6 +353,7 @@ class GscOpportunityAbility {
 				}
 
 				$impressions = (int) ( $row['impressions'] ?? 0 );
+				$clicks      = (int) ( $row['clicks'] ?? 0 );
 				$ctr         = (float) ( $row['ctr'] ?? 0.0 );
 				$position    = (float) ( $row['position'] ?? 0.0 );
 


### PR DESCRIPTION
## Summary

- restore per-row `clicks` initialization removed during the #68 scoring refactor
- prevent page-2 opportunity rows from referencing an undefined variable
- preserve the GSC click count in the existing output contract

Fixes #69.

## Verification

- `php -l inc/Abilities/Analytics/GscOpportunityAbility.php`
- reproduced live on v0.13.2 before the fix via `wp extrachill analytics gsc-opportunities`