### PR TITLE
refactor: centralize business ability registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This plugin extends Data Machine with business-focused integrations including:
 
 - WordPress 6.9+
 - PHP 8.2+
-- Data Machine core plugin (required)
+- Data Machine core plugin 0.151.0+ (required)
 
 ## Installation
 

--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -55,7 +55,7 @@ if ( file_exists( $datamachine_business_autoloader ) ) {
  * we test for the dependency.
  */
 function datamachine_business_load_handlers() {
-	if ( ! class_exists( 'DataMachine\\Core\\Steps\\Publish\\Handlers\\PublishHandler' ) ) {
+	if ( ! class_exists( 'DataMachine\\Core\\Steps\\Publish\\Handlers\\PublishHandler' ) || ! class_exists( 'DataMachine\\Abilities\\AbilityRegistration' ) ) {
 		add_action( 'admin_notices', function () {
 			?>
 			<div class="notice notice-error">

--- a/inc/Abilities/Analytics/BingWebmasterAbilities.php
+++ b/inc/Abilities/Analytics/BingWebmasterAbilities.php
@@ -114,11 +114,7 @@ class BingWebmasterAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Analytics/ContentFlagsAbility.php
+++ b/inc/Abilities/Analytics/ContentFlagsAbility.php
@@ -208,11 +208,7 @@ class ContentFlagsAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Analytics/ContentPerformanceAbility.php
+++ b/inc/Abilities/Analytics/ContentPerformanceAbility.php
@@ -150,11 +150,7 @@ class ContentPerformanceAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
+++ b/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
@@ -225,11 +225,7 @@ class GoogleAnalyticsAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php
+++ b/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php
@@ -136,11 +136,7 @@ class GoogleSearchConsoleAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Analytics/GscOpportunityAbility.php
+++ b/inc/Abilities/Analytics/GscOpportunityAbility.php
@@ -270,11 +270,7 @@ class GscOpportunityAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Analytics/MediavineReportsAbilities.php
+++ b/inc/Abilities/Analytics/MediavineReportsAbilities.php
@@ -146,11 +146,7 @@ class MediavineReportsAbilities {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} elseif ( ! did_action( 'wp_abilities_api_init' ) ) {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/Discord/FetchMessagesDiscordAbility.php
+++ b/inc/Abilities/Discord/FetchMessagesDiscordAbility.php
@@ -75,11 +75,7 @@ class FetchMessagesDiscordAbility {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Discord/PostMessageDiscordAbility.php
+++ b/inc/Abilities/Discord/PostMessageDiscordAbility.php
@@ -70,11 +70,7 @@ class PostMessageDiscordAbility {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/GoogleDrive/DownloadGoogleDriveAbility.php
+++ b/inc/Abilities/GoogleDrive/DownloadGoogleDriveAbility.php
@@ -91,11 +91,7 @@ class DownloadGoogleDriveAbility {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/GoogleDrive/FetchGoogleDriveAbility.php
+++ b/inc/Abilities/GoogleDrive/FetchGoogleDriveAbility.php
@@ -94,11 +94,7 @@ class FetchGoogleDriveAbility {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/GoogleDrive/ListGoogleDriveFilesAbility.php
+++ b/inc/Abilities/GoogleDrive/ListGoogleDriveFilesAbility.php
@@ -112,11 +112,7 @@ class ListGoogleDriveFilesAbility {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/GoogleDrive/ReadGoogleDriveDocAbility.php
+++ b/inc/Abilities/GoogleDrive/ReadGoogleDriveDocAbility.php
@@ -95,11 +95,7 @@ class ReadGoogleDriveDocAbility {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/GoogleSheets/FetchGoogleSheetsAbility.php
+++ b/inc/Abilities/GoogleSheets/FetchGoogleSheetsAbility.php
@@ -71,11 +71,7 @@ class FetchGoogleSheetsAbility {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/GoogleSheets/PublishGoogleSheetsAbility.php
+++ b/inc/Abilities/GoogleSheets/PublishGoogleSheetsAbility.php
@@ -75,11 +75,7 @@ class PublishGoogleSheetsAbility {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/MediaHygiene/MediaHygieneAbility.php
+++ b/inc/Abilities/MediaHygiene/MediaHygieneAbility.php
@@ -87,11 +87,7 @@ class MediaHygieneAbility {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 
 		self::$registered = true;
 	}

--- a/inc/Abilities/PageSpeed/PageSpeedAbility.php
+++ b/inc/Abilities/PageSpeed/PageSpeedAbility.php
@@ -85,11 +85,7 @@ class PageSpeedAbility {
 			);
 		};
 
-		if ( doing_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public static function run_audit( array $input ): array {

--- a/inc/Abilities/Sendy/SendyAbilities.php
+++ b/inc/Abilities/Sendy/SendyAbilities.php
@@ -48,12 +48,7 @@ class SendyAbilities {
 			return;
 		}
 
-		$callback = array( $this, 'register_abilities' );
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( array( $this, 'register_abilities' ) );
 
 		self::$registered = true;
 	}

--- a/inc/Abilities/Slack/FetchMessagesSlackAbility.php
+++ b/inc/Abilities/Slack/FetchMessagesSlackAbility.php
@@ -75,11 +75,7 @@ class FetchMessagesSlackAbility {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function checkPermission(): bool {

--- a/inc/Abilities/Slack/PostMessageSlackAbility.php
+++ b/inc/Abilities/Slack/PostMessageSlackAbility.php
@@ -83,11 +83,7 @@ class PostMessageSlackAbility {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
 	public function checkPermission(): bool {

--- a/tests/ability-registration-lifecycle-smoke.php
+++ b/tests/ability-registration-lifecycle-smoke.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Lifecycle smoke checks for Business ability registration.
+ *
+ * Run with: php tests/ability-registration-lifecycle-smoke.php
+ *
+ * @package DataMachineBusiness\Tests
+ */
+
+$root              = dirname( __DIR__ );
+$data_machine_root = getenv( 'DATA_MACHINE_PATH' ) ?: dirname( $root ) . '/data-machine';
+$helper_path       = $data_machine_root . '/inc/Abilities/AbilityRegistration.php';
+$failures          = array();
+$passes            = 0;
+$actions           = array();
+$registered        = array();
+$action_state      = array(
+	'doing' => false,
+	'did'   => 0,
+);
+
+function assert_ability_registration( bool $condition, string $name, array &$failures, int &$passes ): void {
+	if ( $condition ) {
+		$passes++;
+		echo "  PASS {$name}\n";
+		return;
+	}
+
+	$failures[] = $name;
+	echo "  FAIL {$name}\n";
+}
+
+function doing_action( string $hook ): bool {
+	global $action_state;
+	return 'wp_abilities_api_init' === $hook && $action_state['doing'];
+}
+
+function did_action( string $hook ): int {
+	global $action_state;
+	return 'wp_abilities_api_init' === $hook ? $action_state['did'] : 0;
+}
+
+function add_action( string $hook, callable $callback ): void {
+	global $actions;
+	$actions[ $hook ][] = $callback;
+}
+
+function do_action( string $hook ): void {
+	global $actions, $action_state;
+	$action_state['doing'] = true;
+	foreach ( $actions[ $hook ] ?? array() as $callback ) {
+		$callback();
+	}
+	$action_state['doing'] = false;
+	$action_state['did']++;
+}
+
+function wp_register_ability( string $name, array $args ): void {
+	global $registered;
+	$registered[ $name ] = $args;
+}
+
+function __( string $text, string $domain = '' ): string {
+	return $text;
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $root . '/' );
+}
+
+assert_ability_registration(
+	file_exists( $helper_path ),
+	'Data Machine AbilityRegistration helper is available',
+	$failures,
+	$passes
+);
+
+if ( ! file_exists( $helper_path ) ) {
+	exit( 1 );
+}
+
+require_once $helper_path;
+require_once $root . '/inc/Abilities/PageSpeed/PageSpeedAbility.php';
+
+$registered = array();
+new \DataMachineBusiness\Abilities\PageSpeed\PageSpeedAbility();
+assert_ability_registration(
+	empty( $registered ) && isset( $actions['wp_abilities_api_init'][0] ),
+	'construction before wp_abilities_api_init defers registration',
+	$failures,
+	$passes
+);
+
+do_action( 'wp_abilities_api_init' );
+assert_ability_registration(
+	isset( $registered['datamachine/pagespeed'] ),
+	'queued registration runs during wp_abilities_api_init',
+	$failures,
+	$passes
+);
+
+$reflection = new ReflectionProperty( \DataMachineBusiness\Abilities\PageSpeed\PageSpeedAbility::class, 'registered' );
+$reflection->setValue( false );
+$actions    = array();
+$registered = array();
+
+new \DataMachineBusiness\Abilities\PageSpeed\PageSpeedAbility();
+assert_ability_registration(
+	empty( $registered ) && empty( $actions ),
+	'construction after wp_abilities_api_init does not register late',
+	$failures,
+	$passes
+);
+
+$ability_files = array(
+	'inc/Abilities/Analytics/BingWebmasterAbilities.php',
+	'inc/Abilities/Analytics/ContentFlagsAbility.php',
+	'inc/Abilities/Analytics/ContentPerformanceAbility.php',
+	'inc/Abilities/Analytics/GoogleAnalyticsAbilities.php',
+	'inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php',
+	'inc/Abilities/Analytics/GscOpportunityAbility.php',
+	'inc/Abilities/Analytics/MediavineReportsAbilities.php',
+	'inc/Abilities/Discord/FetchMessagesDiscordAbility.php',
+	'inc/Abilities/Discord/PostMessageDiscordAbility.php',
+	'inc/Abilities/GoogleDrive/DownloadGoogleDriveAbility.php',
+	'inc/Abilities/GoogleDrive/FetchGoogleDriveAbility.php',
+	'inc/Abilities/GoogleDrive/ListGoogleDriveFilesAbility.php',
+	'inc/Abilities/GoogleDrive/ReadGoogleDriveDocAbility.php',
+	'inc/Abilities/GoogleSheets/FetchGoogleSheetsAbility.php',
+	'inc/Abilities/GoogleSheets/PublishGoogleSheetsAbility.php',
+	'inc/Abilities/MediaHygiene/MediaHygieneAbility.php',
+	'inc/Abilities/PageSpeed/PageSpeedAbility.php',
+	'inc/Abilities/Sendy/SendyAbilities.php',
+	'inc/Abilities/Slack/FetchMessagesSlackAbility.php',
+	'inc/Abilities/Slack/PostMessageSlackAbility.php',
+);
+
+foreach ( $ability_files as $ability_file ) {
+	$source = file_get_contents( $root . '/' . $ability_file );
+	assert_ability_registration(
+		false !== strpos( $source, 'AbilityRegistration::on_abilities_api_init' ),
+		"{$ability_file} uses the canonical lifecycle helper",
+		$failures,
+		$passes
+	);
+}
+
+if ( ! empty( $failures ) ) {
+	echo "\nFAILURES:\n" . implode( "\n", $failures ) . "\n";
+	exit( 1 );
+}
+
+echo "\n{$passes} assertions passed.\n";


### PR DESCRIPTION
## Summary
- Route all 20 Data Machine Business ability registrations through Data Machine's canonical `AbilityRegistration::on_abilities_api_init()` lifecycle helper.
- Preserve canonical timing: constructors before `wp_abilities_api_init` queue registrations; constructors after the action do not register late. Covers Analytics, Google Drive/Sheets, Slack, Discord, PageSpeed, Media Hygiene, and Sendy abilities.
- Require Data Machine 0.151.0+, the first release containing the helper, and retain conditional dependency gating when the helper is unavailable.

## Tests
- `DATA_MACHINE_PATH=/var/www/extrachill.com/wp-content/plugins/data-machine php tests/ability-registration-lifecycle-smoke.php` (24 assertions)
- `homeboy review audit data-machine-business --changed-since origin/main --profile pr --json-summary`
- `homeboy review lint data-machine-business --file tests/ability-registration-lifecycle-smoke.php --summary`
- `homeboy review test data-machine-business --changed-since origin/main --skip-lint` was terminated by the isolated Codebox wrapper with exit 143 before producing test output; the direct smoke above passed.

Fixes #72