### PR TITLE
feat: preserve Mediavine report provenance for downstream attribution

### DIFF
--- a/inc/Abilities/Analytics/MediavineReportsAbilities.php
+++ b/inc/Abilities/Analytics/MediavineReportsAbilities.php
@@ -71,6 +71,32 @@ class MediavineReportsAbilities {
 	 */
 	const PAGES_PER_PAGE = 100000;
 
+	/**
+	 * Whether the upstream page-report schema exposes row-level host attribution.
+	 *
+	 * Proven by introspection of the Mediavine publisher GraphQL API
+	 * (api-publishers.mediavine.com): the `pagesSummary` query returns rows of
+	 * type `PageReport`, which exposes `path` (a URL path) plus a per-row
+	 * `siteId`/`date` that come back null for aggregate (date-range) queries,
+	 * but NO hostname, canonical URL, or domain field. Downstream attribution
+	 * that relies on a host must therefore treat every page row as
+	 * host-unattributed and resolve ownership through its own out-of-band
+	 * mapping rather than guessing from the path.
+	 *
+	 * @var bool
+	 */
+	const HOST_ATTRIBUTION_AVAILABLE = false;
+
+	/**
+	 * Human-readable reason for HOST_ATTRIBUTION_AVAILABLE.
+	 *
+	 * References the actual upstream type (`PageReport`) so the limitation is
+	 * traceable to the source schema rather than an Extra Chill assumption.
+	 *
+	 * @var string
+	 */
+	const HOST_ATTRIBUTION_REASON = 'Mediavine PageReport exposes path only; hostname, canonical URL, and domain are not part of the upstream pagesSummary GraphQL schema.';
+
 	private static bool $registered = false;
 
 	public function __construct() {
@@ -88,7 +114,7 @@ class MediavineReportsAbilities {
 				'datamachine/mediavine-reports',
 				array(
 					'label'               => 'Mediavine Reports',
-					'description'         => 'Fetch per-period, per-URL Mediavine ad revenue directly from the Mediavine publisher GraphQL API. Actions: pages (per-period per-URL revenue rows: slug,views,revenue,rpm,cpm,viewability,fillRate,impressionsPerPageview,period), summary (site-level aggregate totals: earnings, pageviews, sessions, rpm), backfill (iterate a list of periods, returning pages rows per period for a full revenue-arc backfill). Credentials live server-side in the datamachine_mediavine_config option.',
+					'description'         => 'Fetch per-period, per-URL Mediavine ad revenue directly from the Mediavine publisher GraphQL API. Actions: pages (per-period per-URL revenue rows: slug,views,revenue,rpm,cpm,viewability,fillRate,impressionsPerPageview,period), summary (site-level aggregate totals: earnings, pageviews, sessions, rpm), backfill (iterate a list of periods, returning pages rows per period for a full revenue-arc backfill). Every result batch and each backfill period summary carries a `provenance` block: the requested Mediavine site id, the requested and canonical report period, the source action/query identity, and an explicit host_attribution.available=false flag (the upstream PageReport type exposes path only, never hostname/domain). Credentials live server-side in the datamachine_mediavine_config option.',
 					'category'            => 'datamachine-analytics',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -136,6 +162,43 @@ class MediavineReportsAbilities {
 							'results_count' => array( 'type' => 'integer' ),
 							'results'       => array( 'type' => 'array' ),
 							'periods'       => array( 'type' => 'array' ),
+							'provenance'    => array(
+								'type'        => 'object',
+								'description' => 'Source provenance carried on every result batch: the requested Mediavine site id, requested and canonical report period, source action/query identity, and whether row-level host attribution is available. When host_attribution.available is false (it always is for pagesSummary), consumers must NOT infer a host from the row path.',
+								'properties'  => array(
+									'source'           => array(
+										'type'       => 'object',
+										'properties' => array(
+											'ability'   => array( 'type' => 'string' ),
+											'action'    => array( 'type' => 'string' ),
+											'operation' => array( 'type' => 'string' ),
+											'api'       => array( 'type' => 'string' ),
+										),
+									),
+									'site'             => array(
+										'type'       => 'object',
+										'properties' => array(
+											'requested_id' => array( 'type' => 'string' ),
+											'internal_id'  => array( 'type' => 'string' ),
+										),
+									),
+									'period'           => array(
+										'type'       => 'object',
+										'properties' => array(
+											'requested' => array( 'type' => 'object' ),
+											'canonical' => array( 'type' => 'object' ),
+											'row_count' => array( 'type' => 'integer' ),
+										),
+									),
+									'host_attribution' => array(
+										'type'       => 'object',
+										'properties' => array(
+											'available' => array( 'type' => 'boolean' ),
+											'reason'    => array( 'type' => 'string' ),
+										),
+									),
+								),
+							),
 							'error'         => array( 'type' => 'string' ),
 						),
 					),
@@ -225,14 +288,34 @@ class MediavineReportsAbilities {
 		$end_date   = self::resolveDate( $input['end_date'] ?? '', '-1 day' );
 		$period     = sanitize_text_field( $input['period'] ?? '' );
 
-		$rows = self::fetchPagesRows( $access_token, $site_id, $start_date, $end_date, $period );
+		$parsed = self::fetchPagesRows( $access_token, $site_id, $start_date, $end_date, $period );
 
-		if ( is_wp_error( $rows ) ) {
+		if ( is_wp_error( $parsed ) ) {
 			return array(
 				'success' => false,
-				'error'   => $rows->get_error_message(),
+				'error'   => $parsed->get_error_message(),
 			);
 		}
+
+		return self::buildPagesResult( $site_id, $start_date, $end_date, $period, $parsed );
+	}
+
+	/**
+	 * Assemble the `pages` action response, including source provenance.
+	 *
+	 * Pure (no HTTP) so the batch-level shape — rows plus provenance — is
+	 * unit-testable without a network round-trip.
+	 *
+	 * @param string $site_id     Resolved (relay-encoded) Mediavine site id.
+	 * @param string $start_date  Requested window start (Y-m-d).
+	 * @param string $end_date    Requested window end (Y-m-d).
+	 * @param string $period      Period label stamped on rows.
+	 * @param array  $parsed      Parsed payload from parsePagesPayload() {rows, meta}.
+	 * @return array
+	 */
+	public static function buildPagesResult( string $site_id, string $start_date, string $end_date, string $period, array $parsed ): array {
+		$rows = $parsed['rows'] ?? array();
+		$meta = $parsed['meta'] ?? array();
 
 		return array(
 			'success'       => true,
@@ -245,6 +328,7 @@ class MediavineReportsAbilities {
 			),
 			'results_count' => count( $rows ),
 			'results'       => $rows,
+			'provenance'    => self::buildProvenance( 'pages', 'PagesSummaryQuery', $site_id, $start_date, $end_date, $meta ),
 		);
 	}
 
@@ -283,26 +367,77 @@ class MediavineReportsAbilities {
 			$start_date = self::resolveDate( $entry['start_date'] ?? '', '-28 days' );
 			$end_date   = self::resolveDate( $entry['end_date'] ?? '', '-1 day' );
 
-			$rows = self::fetchPagesRows( $access_token, $site_id, $start_date, $end_date, $period );
+			$parsed = self::fetchPagesRows( $access_token, $site_id, $start_date, $end_date, $period );
 
-			if ( is_wp_error( $rows ) ) {
-				$period_summaries[] = array(
-					'period'     => $period,
-					'start_date' => $start_date,
-					'end_date'   => $end_date,
-					'rows'       => 0,
-					'error'      => $rows->get_error_message(),
-				);
+			if ( is_wp_error( $parsed ) ) {
+				$period_summaries[] = self::buildBackfillPeriodSummary( $site_id, $period, $start_date, $end_date, 0, array(), $parsed->get_error_message() );
 				continue;
 			}
 
+			$rows               = $parsed['rows'] ?? array();
 			$all_rows           = array_merge( $all_rows, $rows );
-			$period_summaries[] = array(
-				'period'     => $period,
-				'start_date' => $start_date,
-				'end_date'   => $end_date,
-				'rows'       => count( $rows ),
-			);
+			$period_summaries[] = self::buildBackfillPeriodSummary( $site_id, $period, $start_date, $end_date, count( $rows ), $parsed['meta'] ?? array() );
+		}
+
+		return self::buildBackfillResult( $site_id, $period_summaries, $all_rows );
+	}
+
+	/**
+	 * Assemble a single backfill period summary, including source provenance.
+	 *
+	 * Provenance is carried per-period (not only at the top level) so a
+	 * downstream consumer can attribute each batch independently, including a
+	 * period that failed to fetch (provenance still records what was requested).
+	 *
+	 * @param string $site_id     Resolved (relay-encoded) Mediavine site id.
+	 * @param string $period      Period label.
+	 * @param string $start_date  Requested window start (Y-m-d).
+	 * @param string $end_date    Requested window end (Y-m-d).
+	 * @param int    $row_count   Rows fetched for this period.
+	 * @param array  $meta        Canonical meta from upstream (reportStart/reportEnd/totalCount).
+	 * @param string|null $error  Optional per-period error message.
+	 * @return array
+	 */
+	public static function buildBackfillPeriodSummary( string $site_id, string $period, string $start_date, string $end_date, int $row_count, array $meta = array(), ?string $error = null ): array {
+		$summary = array(
+			'period'     => $period,
+			'start_date' => $start_date,
+			'end_date'   => $end_date,
+			'rows'       => $row_count,
+			'provenance' => self::buildProvenance( 'pages', 'PagesSummaryQuery', $site_id, $start_date, $end_date, $meta ),
+		);
+
+		if ( null !== $error ) {
+			$summary['error'] = $error;
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Assemble the top-level backfill response, including source provenance.
+	 *
+	 * The top-level provenance spans the full requested range (min start to
+	 * max end across periods) so consumers know the overall window without
+	 * re-deriving it from the period list.
+	 *
+	 * @param string $site_id          Resolved (relay-encoded) Mediavine site id.
+	 * @param array  $period_summaries Per-period summaries (each carries its own provenance).
+	 * @param array  $all_rows         Flattened rows across all periods.
+	 * @return array
+	 */
+	public static function buildBackfillResult( string $site_id, array $period_summaries, array $all_rows ): array {
+		$span_start = '';
+		$span_end   = '';
+		foreach ( $period_summaries as $ps ) {
+			$s = isset( $ps['start_date'] ) ? (string) $ps['start_date'] : '';
+			$e = isset( $ps['end_date'] ) ? (string) $ps['end_date'] : '';
+			if ( '' !== $s && ( '' === $span_start || $s < $span_start ) ) {
+				$span_start = $s;
+			}
+			if ( '' !== $e && ( '' === $span_end || $e > $span_end ) ) {
+				$span_end = $e;
+			}
 		}
 
 		return array(
@@ -312,22 +447,25 @@ class MediavineReportsAbilities {
 			'periods'       => $period_summaries,
 			'results_count' => count( $all_rows ),
 			'results'       => $all_rows,
+			'provenance'    => self::buildProvenance( 'backfill', 'PagesSummaryQuery', $site_id, $span_start, $span_end, array() ),
 		);
 	}
 
 	/**
-	 * Fetch the current pagesSummary GraphQL report and normalize its rows.
+	 * Fetch the current pagesSummary GraphQL report and normalize its payload.
 	 *
 	 * GraphQL fields are normalized to slug,views,revenue,rpm,cpm,viewability,
 	 * fillRate,impressionsPerPageview — exactly the established public row shape.
 	 * Each parsed row also carries the supplied period for revenue-arc grouping.
+	 * The upstream `meta` block (totalCount/reportStart/reportEnd) is preserved
+	 * so the canonical report period survives into the provenance block.
 	 *
 	 * @param string $access_token Bearer token.
 	 * @param string $site_id      Mediavine site id.
 	 * @param string $start_date   Window start (Y-m-d).
 	 * @param string $end_date     Window end (Y-m-d).
 	 * @param string $period       Period label to stamp on each row.
-	 * @return array|\WP_Error Parsed rows or error.
+	 * @return array|\WP_Error Parsed payload {rows, meta} or error.
 	 */
 	private static function fetchPagesRows( string $access_token, string $site_id, string $start_date, string $end_date, string $period ) {
 		$result = HttpClient::post(
@@ -357,7 +495,7 @@ class MediavineReportsAbilities {
 			return new \WP_Error( 'mediavine_pages_schema', 'Mediavine pages report schema or authorization error: ' . $error );
 		}
 
-		return self::parsePagesResponse( $data, $period );
+		return self::parsePagesPayload( $data, $period );
 	}
 
 	/**
@@ -384,13 +522,43 @@ class MediavineReportsAbilities {
 	/**
 	 * Normalize a pagesSummary response into the established ability row shape.
 	 *
+	 * Backward-compatible wrapper: returns only the parsed rows (or WP_Error).
+	 * New callers should use parsePagesPayload() to also receive the canonical
+	 * upstream meta block (reportStart/reportEnd/totalCount).
+	 *
 	 * @return array|\WP_Error
 	 */
 	public static function parsePagesResponse( array $data, string $period ) {
+		$parsed = self::parsePagesPayload( $data, $period );
+
+		if ( is_wp_error( $parsed ) ) {
+			return $parsed;
+		}
+
+		return $parsed['rows'];
+	}
+
+	/**
+	 * Normalize a pagesSummary response into rows plus the canonical meta block.
+	 *
+	 * The established row shape is preserved exactly
+	 * (slug,views,revenue,rpm,cpm,viewability,fillRate,impressionsPerPageview,period)
+	 * so existing consumers are unaffected. The upstream `meta`
+	 * (totalCount/reportStart/reportEnd) is captured separately so the canonical
+	 * report period can be propagated into source provenance. Note: the upstream
+	 * `PageReport` type exposes `path` (a URL path) but no hostname/domain, so
+	 * no host field is read here — host attribution is reported as unavailable
+	 * in the provenance block rather than synthesized.
+	 *
+	 * @return array|\WP_Error {rows: array, meta: array} or error.
+	 */
+	public static function parsePagesPayload( array $data, string $period ) {
 		$payload = $data['data']['pagesSummary'] ?? null;
 		if ( ! is_array( $payload ) || ! isset( $payload['pages'] ) || ! is_array( $payload['pages'] ) ) {
 			return new \WP_Error( 'mediavine_pages_contract', 'Mediavine pages report response is missing pagesSummary.pages.' );
 		}
+
+		$raw_meta = is_array( $payload['meta'] ?? null ) ? $payload['meta'] : array();
 
 		if ( empty( $payload['pages'] ) ) {
 			return new \WP_Error( 'mediavine_pages_empty', 'Mediavine pages report returned no page-level rows for the requested date range.' );
@@ -415,9 +583,114 @@ class MediavineReportsAbilities {
 			);
 		}
 
-		return empty( $rows )
-			? new \WP_Error( 'mediavine_pages_empty', 'Mediavine pages report contained no usable page-level rows.' )
-			: $rows;
+		if ( empty( $rows ) ) {
+			return new \WP_Error( 'mediavine_pages_empty', 'Mediavine pages report contained no usable page-level rows.' );
+		}
+
+		return array(
+			'rows' => $rows,
+			'meta' => self::normalizeReportMeta( $raw_meta ),
+		);
+	}
+
+	/**
+	 * Normalize the upstream `meta` (ReportMeta) block into a typed array.
+	 *
+	 * reportStart/reportEnd arrive as MM/DD/YYYY strings (e.g. "2026/06/01");
+	 * they are preserved verbatim as the canonical period rather than
+	 * re-formatted, so consumers can see exactly what the upstream reported.
+	 *
+	 * @param array $meta Raw meta block.
+	 * @return array
+	 */
+	public static function normalizeReportMeta( array $meta ): array {
+		return array(
+			'totalCount'  => array_key_exists( 'totalCount', $meta ) ? (int) $meta['totalCount'] : null,
+			'reportStart' => array_key_exists( 'reportStart', $meta ) ? (string) $meta['reportStart'] : null,
+			'reportEnd'   => array_key_exists( 'reportEnd', $meta ) ? (string) $meta['reportEnd'] : null,
+		);
+	}
+
+	/**
+	 * Build the source provenance block for a result batch.
+	 *
+	 * Provenance preserves exactly what the upstream source can truthfully
+	 * provide:
+	 *   - the requested Mediavine site id (relay-encoded) plus its decoded
+	 *     numeric internal id when derivable;
+	 *   - the requested report window (Y-m-d, what the caller asked for) and
+	 *     the canonical report period (the upstream meta reportStart/reportEnd);
+	 *   - the source action and GraphQL operation identity;
+	 *   - an explicit host_attribution.available flag. This is always false for
+	 *     pagesSummary because the upstream `PageReport` type exposes `path`
+	 *     only — proven by schema introspection, not assumed. Consumers must
+	 *     not infer a host from the row path.
+	 *
+	 * @param string $action            Ability action (pages|summary|backfill).
+	 * @param string $operation         GraphQL operation name.
+	 * @param string $requested_site_id Relay-encoded Mediavine site id used in the request.
+	 * @param string $start_date        Requested window start (Y-m-d).
+	 * @param string $end_date          Requested window end (Y-m-d).
+	 * @param array  $meta              Normalized canonical meta block.
+	 * @return array
+	 */
+	public static function buildProvenance( string $action, string $operation, string $requested_site_id, string $start_date, string $end_date, array $meta = array() ): array {
+		return array(
+			'source'           => array(
+				'ability'   => 'datamachine/mediavine-reports',
+				'action'    => $action,
+				'operation' => $operation,
+				'api'       => self::API_BASE . '/graphql',
+			),
+			'site'             => array(
+				'requested_id' => $requested_site_id,
+				'internal_id'  => self::decodeInternalSiteId( $requested_site_id ),
+			),
+			'period'           => array(
+				'requested' => array(
+					'start' => $start_date,
+					'end'   => $end_date,
+				),
+				'canonical' => array(
+					'start' => $meta['reportStart'] ?? null,
+					'end'   => $meta['reportEnd'] ?? null,
+				),
+				'row_count' => array_key_exists( 'totalCount', $meta ) ? $meta['totalCount'] : null,
+			),
+			'host_attribution' => array(
+				'available' => self::HOST_ATTRIBUTION_AVAILABLE,
+				'reason'    => self::HOST_ATTRIBUTION_REASON,
+			),
+		);
+	}
+
+	/**
+	 * Decode a numeric internal site id from a relay-encoded or raw site id.
+	 *
+	 * Reporting requests use a Relay global id ("Base64(InternalSite:<n>)").
+	 * A plain numeric id is passed through. Returns null when the id cannot be
+	 * resolved to a numeric internal id (e.g. a legacy slug).
+	 *
+	 * @param string $requested_site_id Site id used in the request.
+	 * @return string|null Numeric internal id, or null.
+	 */
+	public static function decodeInternalSiteId( string $requested_site_id ): ?string {
+		if ( '' === $requested_site_id ) {
+			return null;
+		}
+
+		if ( ctype_digit( $requested_site_id ) ) {
+			return $requested_site_id;
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Read a Relay global ID type prefix.
+		$decoded = base64_decode( $requested_site_id, true );
+		if ( false !== $decoded && str_starts_with( $decoded, 'InternalSite:' ) ) {
+			$numeric = substr( $decoded, strlen( 'InternalSite:' ) );
+			return ctype_digit( $numeric ) ? $numeric : null;
+		}
+
+		return null;
 	}
 
 	/**
@@ -528,7 +801,7 @@ class MediavineReportsAbilities {
 		$start_date = self::resolveDate( $input['start_date'] ?? '', '-28 days' );
 		$end_date   = self::resolveDate( $input['end_date'] ?? '', '-1 day' );
 
-		$query = 'query MetricsSummaryQuery($data: GetMetricsSummaryInput!){ metricsSummary(data:$data){ summary{ earnings pageviews sessions cpm sessionRpm pageRpm paidImpressions } } }';
+		$query = 'query MetricsSummaryQuery($data: GetMetricsSummaryInput!){ metricsSummary(data:$data){ meta{ totalCount reportStart reportEnd } summary{ earnings pageviews sessions cpm sessionRpm pageRpm paidImpressions } } }';
 
 		$body = array(
 			'query'         => $query,
@@ -579,7 +852,8 @@ class MediavineReportsAbilities {
 			);
 		}
 
-		$summary = $data['data']['metricsSummary']['summary'] ?? array();
+		$payload = $data['data']['metricsSummary'] ?? array();
+		$summary = $payload['summary'] ?? array();
 		if ( empty( $summary ) ) {
 			return array(
 				'success' => false,
@@ -598,6 +872,25 @@ class MediavineReportsAbilities {
 			'paidImpressions' => (int) ( $summary['paidImpressions'] ?? 0 ),
 		);
 
+		$meta = self::normalizeReportMeta( is_array( $payload['meta'] ?? null ) ? $payload['meta'] : array() );
+
+		return self::buildSummaryResult( $site_id, $start_date, $end_date, $row, $meta );
+	}
+
+	/**
+	 * Assemble the `summary` action response, including source provenance.
+	 *
+	 * Pure (no HTTP) so the summary batch shape — including provenance and the
+	 * canonical period — is unit-testable without a network round-trip.
+	 *
+	 * @param string $site_id     Resolved (relay-encoded) Mediavine site id.
+	 * @param string $start_date  Requested window start (Y-m-d).
+	 * @param string $end_date    Requested window end (Y-m-d).
+	 * @param array  $row         Normalized summary row.
+	 * @param array  $meta        Normalized canonical meta block.
+	 * @return array
+	 */
+	public static function buildSummaryResult( string $site_id, string $start_date, string $end_date, array $row, array $meta = array() ): array {
 		return array(
 			'success'       => true,
 			'action'        => 'summary',
@@ -608,6 +901,7 @@ class MediavineReportsAbilities {
 			),
 			'results_count' => 1,
 			'results'       => array( $row ),
+			'provenance'    => self::buildProvenance( 'summary', 'MetricsSummaryQuery', $site_id, $start_date, $end_date, $meta ),
 		);
 	}
 

--- a/inc/Abilities/Analytics/MediavineReportsAbilities.php
+++ b/inc/Abilities/Analytics/MediavineReportsAbilities.php
@@ -268,7 +268,10 @@ class MediavineReportsAbilities {
 					'required'   => array( 'ability', 'action', 'operation', 'api' ),
 					'properties' => array(
 						'ability'   => array( 'type' => 'string' ),
-						'action'    => array( 'type' => 'string', 'enum' => array( 'pages', 'summary', 'backfill' ) ),
+						'action'    => array(
+							'type' => 'string',
+							'enum' => array( 'pages', 'summary', 'backfill' ),
+						),
 						'operation' => array( 'type' => 'string' ),
 						'api'       => array( 'type' => 'string' ),
 					),

--- a/inc/Abilities/Analytics/MediavineReportsAbilities.php
+++ b/inc/Abilities/Analytics/MediavineReportsAbilities.php
@@ -18,7 +18,7 @@
  *      CLI plugin imports into its revenue store.
  *
  * A bonus `summary` action calls the metricsSummary GraphQL query for
- * site-level totals (note: that query uses ISO timestamps, NOT MM/DD/YYYY).
+ * site-level totals (request variables use ISO timestamps).
  *
  * Structurally this mirrors GoogleAnalyticsAbilities: a CONFIG_OPTION read via
  * get_config(), a token cached in a transient, authenticate -> fetch -> return
@@ -88,14 +88,21 @@ class MediavineReportsAbilities {
 	const HOST_ATTRIBUTION_AVAILABLE = false;
 
 	/**
-	 * Human-readable reason for HOST_ATTRIBUTION_AVAILABLE.
+	 * Human-readable page-report reason for HOST_ATTRIBUTION_AVAILABLE.
 	 *
 	 * References the actual upstream type (`PageReport`) so the limitation is
 	 * traceable to the source schema rather than an Extra Chill assumption.
 	 *
 	 * @var string
 	 */
-	const HOST_ATTRIBUTION_REASON = 'Mediavine PageReport exposes path only; hostname, canonical URL, and domain are not part of the upstream pagesSummary GraphQL schema.';
+	const PAGES_HOST_ATTRIBUTION_REASON = 'Mediavine PageReport exposes path only; hostname, canonical URL, and domain are not part of the upstream pagesSummary GraphQL schema.';
+
+	/**
+	 * Human-readable host attribution reason for aggregate summary reports.
+	 *
+	 * @var string
+	 */
+	const SUMMARY_HOST_ATTRIBUTION_REASON = 'Mediavine metricsSummary returns site-level aggregate metrics without row-level URL or host dimensions.';
 
 	private static bool $registered = false;
 
@@ -154,54 +161,7 @@ class MediavineReportsAbilities {
 							),
 						),
 					),
-					'output_schema'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'success'       => array( 'type' => 'boolean' ),
-							'action'        => array( 'type' => 'string' ),
-							'results_count' => array( 'type' => 'integer' ),
-							'results'       => array( 'type' => 'array' ),
-							'periods'       => array( 'type' => 'array' ),
-							'provenance'    => array(
-								'type'        => 'object',
-								'description' => 'Source provenance carried on every result batch: the requested Mediavine site id, requested and canonical report period, source action/query identity, and whether row-level host attribution is available. When host_attribution.available is false (it always is for pagesSummary), consumers must NOT infer a host from the row path.',
-								'properties'  => array(
-									'source'           => array(
-										'type'       => 'object',
-										'properties' => array(
-											'ability'   => array( 'type' => 'string' ),
-											'action'    => array( 'type' => 'string' ),
-											'operation' => array( 'type' => 'string' ),
-											'api'       => array( 'type' => 'string' ),
-										),
-									),
-									'site'             => array(
-										'type'       => 'object',
-										'properties' => array(
-											'requested_id' => array( 'type' => 'string' ),
-											'internal_id'  => array( 'type' => 'string' ),
-										),
-									),
-									'period'           => array(
-										'type'       => 'object',
-										'properties' => array(
-											'requested' => array( 'type' => 'object' ),
-											'canonical' => array( 'type' => 'object' ),
-											'row_count' => array( 'type' => 'integer' ),
-										),
-									),
-									'host_attribution' => array(
-										'type'       => 'object',
-										'properties' => array(
-											'available' => array( 'type' => 'boolean' ),
-											'reason'    => array( 'type' => 'string' ),
-										),
-									),
-								),
-							),
-							'error'         => array( 'type' => 'string' ),
-						),
-					),
+					'output_schema'       => self::outputSchema(),
 					'execute_callback'    => array( self::class, 'fetch' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => false ),
@@ -210,6 +170,137 @@ class MediavineReportsAbilities {
 		};
 
 		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
+	}
+
+	/**
+	 * Return the complete public output contract for every action.
+	 */
+	public static function outputSchema(): array {
+		$result_properties = array(
+			'slug'                   => array( 'type' => 'string' ),
+			'views'                  => array( 'type' => 'integer' ),
+			'revenue'                => array( 'type' => 'number' ),
+			'rpm'                    => array( 'type' => 'number' ),
+			'cpm'                    => array( 'type' => 'number' ),
+			'viewability'            => array( 'type' => 'number' ),
+			'fillRate'               => array( 'type' => 'number' ),
+			'impressionsPerPageview' => array( 'type' => 'number' ),
+			'period'                 => array( 'type' => 'string' ),
+			'earnings'               => array( 'type' => 'number' ),
+			'pageviews'              => array( 'type' => 'integer' ),
+			'sessions'               => array( 'type' => 'integer' ),
+			'sessionRpm'             => array( 'type' => 'number' ),
+			'pageRpm'                => array( 'type' => 'number' ),
+			'paidImpressions'        => array( 'type' => 'integer' ),
+		);
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'success' ),
+			'properties' => array(
+				'success'       => array( 'type' => 'boolean' ),
+				'action'        => array(
+					'type' => 'string',
+					'enum' => array( 'pages', 'summary', 'backfill' ),
+				),
+				'site_id'       => array(
+					'type'        => 'string',
+					'description' => 'Normalized Relay global InternalSite ID sent to Mediavine.',
+				),
+				'period'        => array( 'type' => 'string' ),
+				'date_range'    => array(
+					'type'       => 'object',
+					'required'   => array( 'start_date', 'end_date' ),
+					'properties' => array(
+						'start_date' => array( 'type' => 'string' ),
+						'end_date'   => array( 'type' => 'string' ),
+					),
+				),
+				'results_count' => array( 'type' => 'integer' ),
+				'results'       => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'properties' => $result_properties,
+					),
+				),
+				'periods'       => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'required'   => array( 'period', 'start_date', 'end_date', 'rows', 'provenance' ),
+						'properties' => array(
+							'period'     => array( 'type' => 'string' ),
+							'start_date' => array( 'type' => 'string' ),
+							'end_date'   => array( 'type' => 'string' ),
+							'rows'       => array( 'type' => 'integer' ),
+							'provenance' => self::provenanceSchema(),
+							'error'      => array( 'type' => 'string' ),
+						),
+					),
+				),
+				'provenance'    => self::provenanceSchema(),
+				'error'         => array( 'type' => 'string' ),
+			),
+		);
+	}
+
+	/**
+	 * Return the source provenance output contract.
+	 */
+	private static function provenanceSchema(): array {
+		$date_pair = array(
+			'type'       => 'object',
+			'required'   => array( 'start', 'end' ),
+			'properties' => array(
+				'start' => array( 'type' => array( 'string', 'null' ) ),
+				'end'   => array( 'type' => array( 'string', 'null' ) ),
+			),
+		);
+
+		return array(
+			'type'        => 'object',
+			'description' => 'Source provenance for the requested site, normalized report identity, period boundaries, and host attribution support.',
+			'required'    => array( 'source', 'site', 'period', 'host_attribution' ),
+			'properties'  => array(
+				'source'           => array(
+					'type'       => 'object',
+					'required'   => array( 'ability', 'action', 'operation', 'api' ),
+					'properties' => array(
+						'ability'   => array( 'type' => 'string' ),
+						'action'    => array( 'type' => 'string', 'enum' => array( 'pages', 'summary', 'backfill' ) ),
+						'operation' => array( 'type' => 'string' ),
+						'api'       => array( 'type' => 'string' ),
+					),
+				),
+				'site'             => array(
+					'type'       => 'object',
+					'required'   => array( 'requested_id', 'relay_id', 'internal_id' ),
+					'properties' => array(
+						'requested_id' => array( 'type' => 'string' ),
+						'relay_id'     => array( 'type' => 'string' ),
+						'internal_id'  => array( 'type' => array( 'string', 'null' ) ),
+					),
+				),
+				'period'           => array(
+					'type'       => 'object',
+					'required'   => array( 'requested', 'canonical', 'row_count' ),
+					'properties' => array(
+						'requested' => $date_pair,
+						'canonical' => $date_pair,
+						'row_count' => array( 'type' => array( 'integer', 'null' ) ),
+					),
+				),
+				'host_attribution' => array(
+					'type'       => 'object',
+					'required'   => array( 'available', 'reason' ),
+					'properties' => array(
+						'available' => array( 'type' => 'boolean' ),
+						'reason'    => array( 'type' => 'string' ),
+					),
+				),
+			),
+		);
 	}
 
 	/**
@@ -247,16 +338,16 @@ class MediavineReportsAbilities {
 			);
 		}
 
-		$site_id = self::resolve_site_id( $input, $config );
+		$requested_site_id = self::resolve_site_id( $input, $config );
 
-		if ( '' === $site_id ) {
+		if ( '' === $requested_site_id ) {
 			return array(
 				'success' => false,
 				'error'   => 'A Mediavine site id is required. Pass the "site_id" input, set site_id in the datamachine_mediavine_config option, or register a default via the datamachine_mediavine_default_site_id filter.',
 			);
 		}
 
-		$site_id = self::normalizeReportSiteId( $site_id );
+		$site_id = self::normalizeReportSiteId( $requested_site_id );
 		if ( is_wp_error( $site_id ) ) {
 			return array(
 				'success' => false,
@@ -265,14 +356,14 @@ class MediavineReportsAbilities {
 		}
 
 		if ( 'summary' === $action ) {
-			return self::fetchSummary( $input, $access_token, $site_id );
+			return self::fetchSummary( $input, $access_token, $requested_site_id, $site_id );
 		}
 
 		if ( 'backfill' === $action ) {
-			return self::fetchBackfill( $input, $access_token, $site_id );
+			return self::fetchBackfill( $input, $access_token, $requested_site_id, $site_id );
 		}
 
-		return self::fetchPages( $input, $access_token, $site_id );
+		return self::fetchPages( $input, $access_token, $requested_site_id, $site_id );
 	}
 
 	/**
@@ -280,10 +371,11 @@ class MediavineReportsAbilities {
 	 *
 	 * @param array  $input        Ability input.
 	 * @param string $access_token Bearer token.
-	 * @param string $site_id      Mediavine site id.
+	 * @param string $requested_site_id Original site id supplied by the caller or configuration.
+	 * @param string $site_id      Normalized Relay global Mediavine site id.
 	 * @return array
 	 */
-	private static function fetchPages( array $input, string $access_token, string $site_id ): array {
+	private static function fetchPages( array $input, string $access_token, string $requested_site_id, string $site_id ): array {
 		$start_date = self::resolveDate( $input['start_date'] ?? '', '-28 days' );
 		$end_date   = self::resolveDate( $input['end_date'] ?? '', '-1 day' );
 		$period     = sanitize_text_field( $input['period'] ?? '' );
@@ -297,7 +389,7 @@ class MediavineReportsAbilities {
 			);
 		}
 
-		return self::buildPagesResult( $site_id, $start_date, $end_date, $period, $parsed );
+		return self::buildPagesResult( $requested_site_id, $site_id, $start_date, $end_date, $period, $parsed );
 	}
 
 	/**
@@ -306,14 +398,15 @@ class MediavineReportsAbilities {
 	 * Pure (no HTTP) so the batch-level shape — rows plus provenance — is
 	 * unit-testable without a network round-trip.
 	 *
-	 * @param string $site_id     Resolved (relay-encoded) Mediavine site id.
+	 * @param string $requested_site_id Original site id supplied by the caller or configuration.
+	 * @param string $site_id     Normalized Relay global Mediavine site id.
 	 * @param string $start_date  Requested window start (Y-m-d).
 	 * @param string $end_date    Requested window end (Y-m-d).
 	 * @param string $period      Period label stamped on rows.
 	 * @param array  $parsed      Parsed payload from parsePagesPayload() {rows, meta}.
 	 * @return array
 	 */
-	public static function buildPagesResult( string $site_id, string $start_date, string $end_date, string $period, array $parsed ): array {
+	public static function buildPagesResult( string $requested_site_id, string $site_id, string $start_date, string $end_date, string $period, array $parsed ): array {
 		$rows = $parsed['rows'] ?? array();
 		$meta = $parsed['meta'] ?? array();
 
@@ -328,7 +421,7 @@ class MediavineReportsAbilities {
 			),
 			'results_count' => count( $rows ),
 			'results'       => $rows,
-			'provenance'    => self::buildProvenance( 'pages', 'PagesSummaryQuery', $site_id, $start_date, $end_date, $meta ),
+			'provenance'    => self::buildProvenance( 'pages', 'PagesSummaryQuery', $requested_site_id, $site_id, $start_date, $end_date, $meta ),
 		);
 	}
 
@@ -342,10 +435,11 @@ class MediavineReportsAbilities {
 	 *
 	 * @param array  $input        Ability input.
 	 * @param string $access_token Bearer token.
-	 * @param string $site_id      Mediavine site id.
+	 * @param string $requested_site_id Original site id supplied by the caller or configuration.
+	 * @param string $site_id      Normalized Relay global Mediavine site id.
 	 * @return array
 	 */
-	private static function fetchBackfill( array $input, string $access_token, string $site_id ): array {
+	private static function fetchBackfill( array $input, string $access_token, string $requested_site_id, string $site_id ): array {
 		$periods = $input['periods'] ?? array();
 
 		if ( ! is_array( $periods ) || empty( $periods ) ) {
@@ -370,16 +464,16 @@ class MediavineReportsAbilities {
 			$parsed = self::fetchPagesRows( $access_token, $site_id, $start_date, $end_date, $period );
 
 			if ( is_wp_error( $parsed ) ) {
-				$period_summaries[] = self::buildBackfillPeriodSummary( $site_id, $period, $start_date, $end_date, 0, array(), $parsed->get_error_message() );
+				$period_summaries[] = self::buildBackfillPeriodSummary( $requested_site_id, $site_id, $period, $start_date, $end_date, 0, array(), $parsed->get_error_message() );
 				continue;
 			}
 
 			$rows               = $parsed['rows'] ?? array();
 			$all_rows           = array_merge( $all_rows, $rows );
-			$period_summaries[] = self::buildBackfillPeriodSummary( $site_id, $period, $start_date, $end_date, count( $rows ), $parsed['meta'] ?? array() );
+			$period_summaries[] = self::buildBackfillPeriodSummary( $requested_site_id, $site_id, $period, $start_date, $end_date, count( $rows ), $parsed['meta'] ?? array() );
 		}
 
-		return self::buildBackfillResult( $site_id, $period_summaries, $all_rows );
+		return self::buildBackfillResult( $requested_site_id, $site_id, $period_summaries, $all_rows );
 	}
 
 	/**
@@ -389,7 +483,8 @@ class MediavineReportsAbilities {
 	 * downstream consumer can attribute each batch independently, including a
 	 * period that failed to fetch (provenance still records what was requested).
 	 *
-	 * @param string $site_id     Resolved (relay-encoded) Mediavine site id.
+	 * @param string $requested_site_id Original site id supplied by the caller or configuration.
+	 * @param string $site_id     Normalized Relay global Mediavine site id.
 	 * @param string $period      Period label.
 	 * @param string $start_date  Requested window start (Y-m-d).
 	 * @param string $end_date    Requested window end (Y-m-d).
@@ -398,13 +493,13 @@ class MediavineReportsAbilities {
 	 * @param string|null $error  Optional per-period error message.
 	 * @return array
 	 */
-	public static function buildBackfillPeriodSummary( string $site_id, string $period, string $start_date, string $end_date, int $row_count, array $meta = array(), ?string $error = null ): array {
+	public static function buildBackfillPeriodSummary( string $requested_site_id, string $site_id, string $period, string $start_date, string $end_date, int $row_count, array $meta = array(), ?string $error = null ): array {
 		$summary = array(
 			'period'     => $period,
 			'start_date' => $start_date,
 			'end_date'   => $end_date,
 			'rows'       => $row_count,
-			'provenance' => self::buildProvenance( 'pages', 'PagesSummaryQuery', $site_id, $start_date, $end_date, $meta ),
+			'provenance' => self::buildProvenance( 'backfill', 'PagesSummaryQuery', $requested_site_id, $site_id, $start_date, $end_date, $meta ),
 		);
 
 		if ( null !== $error ) {
@@ -421,12 +516,13 @@ class MediavineReportsAbilities {
 	 * max end across periods) so consumers know the overall window without
 	 * re-deriving it from the period list.
 	 *
-	 * @param string $site_id          Resolved (relay-encoded) Mediavine site id.
+	 * @param string $requested_site_id Original site id supplied by the caller or configuration.
+	 * @param string $site_id          Normalized Relay global Mediavine site id.
 	 * @param array  $period_summaries Per-period summaries (each carries its own provenance).
 	 * @param array  $all_rows         Flattened rows across all periods.
 	 * @return array
 	 */
-	public static function buildBackfillResult( string $site_id, array $period_summaries, array $all_rows ): array {
+	public static function buildBackfillResult( string $requested_site_id, string $site_id, array $period_summaries, array $all_rows ): array {
 		$span_start = '';
 		$span_end   = '';
 		foreach ( $period_summaries as $ps ) {
@@ -447,7 +543,7 @@ class MediavineReportsAbilities {
 			'periods'       => $period_summaries,
 			'results_count' => count( $all_rows ),
 			'results'       => $all_rows,
-			'provenance'    => self::buildProvenance( 'backfill', 'PagesSummaryQuery', $site_id, $span_start, $span_end, array() ),
+			'provenance'    => self::buildProvenance( 'backfill', 'PagesSummaryQuery', $requested_site_id, $site_id, $span_start, $span_end, array() ),
 		);
 	}
 
@@ -596,7 +692,7 @@ class MediavineReportsAbilities {
 	/**
 	 * Normalize the upstream `meta` (ReportMeta) block into a typed array.
 	 *
-	 * reportStart/reportEnd arrive as MM/DD/YYYY strings (e.g. "2026/06/01");
+	 * reportStart/reportEnd arrive as YYYY/MM/DD strings (e.g. "2026/06/01");
 	 * they are preserved verbatim as the canonical period rather than
 	 * re-formatted, so consumers can see exactly what the upstream reported.
 	 *
@@ -628,13 +724,16 @@ class MediavineReportsAbilities {
 	 *
 	 * @param string $action            Ability action (pages|summary|backfill).
 	 * @param string $operation         GraphQL operation name.
-	 * @param string $requested_site_id Relay-encoded Mediavine site id used in the request.
+	 * @param string $requested_site_id Original site id supplied by input, config, or filter.
+	 * @param string $relay_site_id     Normalized Relay global site id used in the request.
 	 * @param string $start_date        Requested window start (Y-m-d).
 	 * @param string $end_date          Requested window end (Y-m-d).
 	 * @param array  $meta              Normalized canonical meta block.
 	 * @return array
 	 */
-	public static function buildProvenance( string $action, string $operation, string $requested_site_id, string $start_date, string $end_date, array $meta = array() ): array {
+	public static function buildProvenance( string $action, string $operation, string $requested_site_id, string $relay_site_id, string $start_date, string $end_date, array $meta = array() ): array {
+		$host_reason = 'summary' === $action ? self::SUMMARY_HOST_ATTRIBUTION_REASON : self::PAGES_HOST_ATTRIBUTION_REASON;
+
 		return array(
 			'source'           => array(
 				'ability'   => 'datamachine/mediavine-reports',
@@ -644,7 +743,8 @@ class MediavineReportsAbilities {
 			),
 			'site'             => array(
 				'requested_id' => $requested_site_id,
-				'internal_id'  => self::decodeInternalSiteId( $requested_site_id ),
+				'relay_id'     => $relay_site_id,
+				'internal_id'  => self::decodeInternalSiteId( $relay_site_id ),
 			),
 			'period'           => array(
 				'requested' => array(
@@ -659,7 +759,7 @@ class MediavineReportsAbilities {
 			),
 			'host_attribution' => array(
 				'available' => self::HOST_ATTRIBUTION_AVAILABLE,
-				'reason'    => self::HOST_ATTRIBUTION_REASON,
+				'reason'    => $host_reason,
 			),
 		);
 	}
@@ -788,16 +888,17 @@ class MediavineReportsAbilities {
 	/**
 	 * Fetch the site-level metricsSummary aggregate.
 	 *
-	 * NOTE: metricsSummary uses ISO 8601 timestamps (e.g. 2023-01-01T05:00:00.000Z),
-	 * NOT the MM/DD/YYYY format the CSV report uses. The Y-m-d window is converted
-	 * to the start/end-of-day ISO instants here.
+	 * NOTE: metricsSummary request variables use ISO 8601 timestamps (e.g.
+	 * 2023-01-01T05:00:00.000Z). ReportMeta response boundaries use YYYY/MM/DD.
+	 * The Y-m-d input window is converted to start/end-of-day ISO instants here.
 	 *
 	 * @param array  $input        Ability input.
 	 * @param string $access_token Bearer token.
-	 * @param string $site_id      Mediavine site id.
+	 * @param string $requested_site_id Original site id supplied by the caller or configuration.
+	 * @param string $site_id      Normalized Relay global Mediavine site id.
 	 * @return array
 	 */
-	private static function fetchSummary( array $input, string $access_token, string $site_id ): array {
+	private static function fetchSummary( array $input, string $access_token, string $requested_site_id, string $site_id ): array {
 		$start_date = self::resolveDate( $input['start_date'] ?? '', '-28 days' );
 		$end_date   = self::resolveDate( $input['end_date'] ?? '', '-1 day' );
 
@@ -874,7 +975,7 @@ class MediavineReportsAbilities {
 
 		$meta = self::normalizeReportMeta( is_array( $payload['meta'] ?? null ) ? $payload['meta'] : array() );
 
-		return self::buildSummaryResult( $site_id, $start_date, $end_date, $row, $meta );
+		return self::buildSummaryResult( $requested_site_id, $site_id, $start_date, $end_date, $row, $meta );
 	}
 
 	/**
@@ -883,14 +984,15 @@ class MediavineReportsAbilities {
 	 * Pure (no HTTP) so the summary batch shape — including provenance and the
 	 * canonical period — is unit-testable without a network round-trip.
 	 *
-	 * @param string $site_id     Resolved (relay-encoded) Mediavine site id.
+	 * @param string $requested_site_id Original site id supplied by the caller or configuration.
+	 * @param string $site_id     Normalized Relay global Mediavine site id.
 	 * @param string $start_date  Requested window start (Y-m-d).
 	 * @param string $end_date    Requested window end (Y-m-d).
 	 * @param array  $row         Normalized summary row.
 	 * @param array  $meta        Normalized canonical meta block.
 	 * @return array
 	 */
-	public static function buildSummaryResult( string $site_id, string $start_date, string $end_date, array $row, array $meta = array() ): array {
+	public static function buildSummaryResult( string $requested_site_id, string $site_id, string $start_date, string $end_date, array $row, array $meta = array() ): array {
 		return array(
 			'success'       => true,
 			'action'        => 'summary',
@@ -901,7 +1003,7 @@ class MediavineReportsAbilities {
 			),
 			'results_count' => 1,
 			'results'       => array( $row ),
-			'provenance'    => self::buildProvenance( 'summary', 'MetricsSummaryQuery', $site_id, $start_date, $end_date, $meta ),
+			'provenance'    => self::buildProvenance( 'summary', 'MetricsSummaryQuery', $requested_site_id, $site_id, $start_date, $end_date, $meta ),
 		);
 	}
 
@@ -1053,8 +1155,8 @@ class MediavineReportsAbilities {
 	/**
 	 * Convert a Y-m-d date to an ISO 8601 instant for metricsSummary.
 	 *
-	 * The summary GraphQL query uses ISO timestamps, not MM/DD/YYYY. Start dates
-	 * map to the start of the day, end dates to the end of the day, both in UTC.
+	 * The summary GraphQL query uses ISO timestamps. Start dates map to the start
+	 * of the day, end dates to the end of the day, both in UTC.
 	 *
 	 * @param string $date     Y-m-d date.
 	 * @param bool   $end_of_day Whether this is an end date (end of day).

--- a/inc/Abilities/Analytics/MediavineReportsAbilities.php
+++ b/inc/Abilities/Analytics/MediavineReportsAbilities.php
@@ -701,9 +701,9 @@ class MediavineReportsAbilities {
 	 */
 	public static function normalizeReportMeta( array $meta ): array {
 		return array(
-			'totalCount'  => array_key_exists( 'totalCount', $meta ) ? (int) $meta['totalCount'] : null,
-			'reportStart' => array_key_exists( 'reportStart', $meta ) ? (string) $meta['reportStart'] : null,
-			'reportEnd'   => array_key_exists( 'reportEnd', $meta ) ? (string) $meta['reportEnd'] : null,
+			'totalCount'  => isset( $meta['totalCount'] ) ? (int) $meta['totalCount'] : null,
+			'reportStart' => isset( $meta['reportStart'] ) ? (string) $meta['reportStart'] : null,
+			'reportEnd'   => isset( $meta['reportEnd'] ) ? (string) $meta['reportEnd'] : null,
 		);
 	}
 

--- a/tests/Unit/Abilities/Analytics/MediavineReportsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/MediavineReportsAbilitiesTest.php
@@ -92,13 +92,14 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 	public function test_provenance_carries_requested_and_canonical_period_boundaries(): void {
 		$relay  = base64_encode( 'InternalSite:11476' );
 		$meta   = array( 'reportStart' => '2026/06/01', 'reportEnd' => '2026/06/30', 'totalCount' => 208 );
-		$prov   = MediavineReportsAbilities::buildProvenance( 'pages', 'PagesSummaryQuery', $relay, '2026-06-01', '2026-06-30', $meta );
+		$prov   = MediavineReportsAbilities::buildProvenance( 'pages', 'PagesSummaryQuery', '11476', $relay, '2026-06-01', '2026-06-30', $meta );
 
 		$this->assertSame( 'datamachine/mediavine-reports', $prov['source']['ability'] );
 		$this->assertSame( 'pages', $prov['source']['action'] );
 		$this->assertSame( 'PagesSummaryQuery', $prov['source']['operation'] );
 
-		$this->assertSame( $relay, $prov['site']['requested_id'] );
+		$this->assertSame( '11476', $prov['site']['requested_id'] );
+		$this->assertSame( $relay, $prov['site']['relay_id'] );
 		$this->assertSame( '11476', $prov['site']['internal_id'] );
 
 		$this->assertSame( '2026-06-01', $prov['period']['requested']['start'] );
@@ -109,7 +110,8 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_provenance_canonical_period_is_null_when_upstream_omits_meta(): void {
-		$prov = MediavineReportsAbilities::buildProvenance( 'backfill', 'PagesSummaryQuery', '11476', '2026-01-01', '2026-03-31', array() );
+		$relay = base64_encode( 'InternalSite:11476' );
+		$prov  = MediavineReportsAbilities::buildProvenance( 'backfill', 'PagesSummaryQuery', '11476', $relay, '2026-01-01', '2026-03-31', array() );
 
 		$this->assertNull( $prov['period']['canonical']['start'] );
 		$this->assertNull( $prov['period']['canonical']['end'] );
@@ -121,7 +123,8 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 	 * Provenance must encode that as structured "unavailable", never synthesize.
 	 */
 	public function test_provenance_reports_host_attribution_unavailable(): void {
-		$prov = MediavineReportsAbilities::buildProvenance( 'pages', 'PagesSummaryQuery', '11476', '2026-06-01', '2026-06-30', array() );
+		$relay = base64_encode( 'InternalSite:11476' );
+		$prov  = MediavineReportsAbilities::buildProvenance( 'pages', 'PagesSummaryQuery', '11476', $relay, '2026-06-01', '2026-06-30', array() );
 
 		$this->assertFalse( $prov['host_attribution']['available'] );
 		$this->assertNotEmpty( $prov['host_attribution']['reason'] );
@@ -182,12 +185,14 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 			'meta' => array( 'reportStart' => '2026/06/01', 'reportEnd' => '2026/06/30', 'totalCount' => 1 ),
 		);
 
-		$result = MediavineReportsAbilities::buildPagesResult( $relay, '2026-06-01', '2026-06-30', '2026-06', $parsed );
+		$result = MediavineReportsAbilities::buildPagesResult( '11476', $relay, '2026-06-01', '2026-06-30', '2026-06', $parsed );
 
 		$this->assertSame( 'pages', $result['action'] );
 		$this->assertSame( $relay, $result['site_id'] );
 		$this->assertSame( 1, $result['results_count'] );
 		$this->assertArrayHasKey( 'provenance', $result );
+		$this->assertSame( '11476', $result['provenance']['site']['requested_id'] );
+		$this->assertSame( $relay, $result['provenance']['site']['relay_id'] );
 		$this->assertSame( '11476', $result['provenance']['site']['internal_id'] );
 		$this->assertSame( '2026/06/01', $result['provenance']['period']['canonical']['start'] );
 		$this->assertFalse( $result['provenance']['host_attribution']['available'] );
@@ -197,12 +202,14 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 		$relay  = base64_encode( 'InternalSite:11476' );
 		$srow   = array( 'period' => '2026-06', 'earnings' => 1.0 );
 		$meta   = array( 'reportStart' => '2026/06/01', 'reportEnd' => '2026/06/30', 'totalCount' => null );
-		$result = MediavineReportsAbilities::buildSummaryResult( $relay, '2026-06-01', '2026-06-30', $srow, $meta );
+		$result = MediavineReportsAbilities::buildSummaryResult( '11476', $relay, '2026-06-01', '2026-06-30', $srow, $meta );
 
 		$this->assertSame( 'summary', $result['action'] );
 		$this->assertArrayHasKey( 'provenance', $result );
 		$this->assertSame( 'MetricsSummaryQuery', $result['provenance']['source']['operation'] );
 		$this->assertSame( '2026/06/01', $result['provenance']['period']['canonical']['start'] );
+		$this->assertStringContainsString( 'site-level aggregate', $result['provenance']['host_attribution']['reason'] );
+		$this->assertStringNotContainsString( 'PageReport', $result['provenance']['host_attribution']['reason'] );
 
 		// The summary GraphQL query must request the canonical meta block too.
 		$source = file_get_contents( dirname( __DIR__, 4 ) . '/inc/Abilities/Analytics/MediavineReportsAbilities.php' );
@@ -213,15 +220,16 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 		$relay = base64_encode( 'InternalSite:11476' );
 		$meta  = array( 'reportStart' => '2026/05/01', 'reportEnd' => '2026/05/31', 'totalCount' => 12 );
 
-		$period_one = MediavineReportsAbilities::buildBackfillPeriodSummary( $relay, '2026-05', '2026-05-01', '2026-05-31', 12, $meta );
-		$period_two = MediavineReportsAbilities::buildBackfillPeriodSummary( $relay, '2026-06', '2026-06-01', '2026-06-30', 7, $meta );
+		$period_one = MediavineReportsAbilities::buildBackfillPeriodSummary( '11476', $relay, '2026-05', '2026-05-01', '2026-05-31', 12, $meta );
+		$period_two = MediavineReportsAbilities::buildBackfillPeriodSummary( '11476', $relay, '2026-06', '2026-06-01', '2026-06-30', 7, $meta );
 
 		$this->assertArrayHasKey( 'provenance', $period_one );
 		$this->assertArrayHasKey( 'provenance', $period_two );
 		$this->assertSame( '2026-05-01', $period_one['provenance']['period']['requested']['start'] );
+		$this->assertSame( 'backfill', $period_one['provenance']['source']['action'] );
 		$this->assertFalse( $period_two['provenance']['host_attribution']['available'] );
 
-		$result = MediavineReportsAbilities::buildBackfillResult( $relay, array( $period_one, $period_two ), array_fill( 0, 19, array( 'slug' => '/x/' ) ) );
+		$result = MediavineReportsAbilities::buildBackfillResult( '11476', $relay, array( $period_one, $period_two ), array_fill( 0, 19, array( 'slug' => '/x/' ) ) );
 
 		$this->assertSame( 'backfill', $result['action'] );
 		$this->assertSame( 19, $result['results_count'] );
@@ -233,7 +241,7 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 
 	public function test_backfill_period_summary_records_error_without_losing_provenance(): void {
 		$relay   = base64_encode( 'InternalSite:11476' );
-		$summary = MediavineReportsAbilities::buildBackfillPeriodSummary( $relay, '2026-05', '2026-05-01', '2026-05-31', 0, array(), 'upstream failure' );
+		$summary = MediavineReportsAbilities::buildBackfillPeriodSummary( '11476', $relay, '2026-05', '2026-05-01', '2026-05-31', 0, array(), 'upstream failure' );
 
 		$this->assertSame( 0, $summary['rows'] );
 		$this->assertSame( 'upstream failure', $summary['error'] );
@@ -252,15 +260,74 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 			'meta' => array( 'reportStart' => '2026/06/01', 'reportEnd' => '2026/06/30', 'totalCount' => 1 ),
 		);
 
-		$blob  = wp_json_encode( MediavineReportsAbilities::buildPagesResult( $relay, '2026-06-01', '2026-06-30', '2026-06', $parsed ) );
-		$blob .= wp_json_encode( MediavineReportsAbilities::buildSummaryResult( $relay, '2026-06-01', '2026-06-30', array( 'period' => '2026-06' ), $parsed['meta'] ) );
-		$blob .= wp_json_encode( MediavineReportsAbilities::buildBackfillResult( $relay, array(), array() ) );
-		$blob .= wp_json_encode( MediavineReportsAbilities::buildProvenance( 'pages', 'PagesSummaryQuery', $relay, '2026-06-01', '2026-06-30', $parsed['meta'] ) );
+		$blob  = wp_json_encode( MediavineReportsAbilities::buildPagesResult( '11476', $relay, '2026-06-01', '2026-06-30', '2026-06', $parsed ) );
+		$blob .= wp_json_encode( MediavineReportsAbilities::buildSummaryResult( '11476', $relay, '2026-06-01', '2026-06-30', array( 'period' => '2026-06' ), $parsed['meta'] ) );
+		$blob .= wp_json_encode( MediavineReportsAbilities::buildBackfillResult( '11476', $relay, array(), array() ) );
+		$blob .= wp_json_encode( MediavineReportsAbilities::buildProvenance( 'pages', 'PagesSummaryQuery', '11476', $relay, '2026-06-01', '2026-06-30', $parsed['meta'] ) );
 
 		$this->assertStringNotContainsString( 'password', $blob );
 		$this->assertStringNotContainsString( 'Bearer ', $blob );
 		$this->assertStringNotContainsString( 'accessToken', $blob );
 		$this->assertStringNotContainsString( 'refreshToken', $blob );
+	}
+
+	public function test_registered_ability_schema_fully_describes_result_and_period_items(): void {
+		$ability = wp_get_ability( 'datamachine/mediavine-reports' );
+
+		$this->assertNotNull( $ability, 'The test must exercise the registered Mediavine ability.' );
+		$schema = $ability->get_output_schema();
+
+		$this->assertArrayHasKey( 'site_id', $schema['properties'] );
+		$this->assertArrayHasKey( 'date_range', $schema['properties'] );
+		$this->assertArrayHasKey( 'properties', $schema['properties']['results']['items'] );
+		$this->assertArrayHasKey( 'slug', $schema['properties']['results']['items']['properties'] );
+		$this->assertArrayHasKey( 'earnings', $schema['properties']['results']['items']['properties'] );
+		$this->assertArrayHasKey( 'properties', $schema['properties']['periods']['items'] );
+		$this->assertArrayHasKey( 'provenance', $schema['properties']['periods']['items']['properties'] );
+		$this->assertSame( array( 'string', 'null' ), $schema['properties']['provenance']['properties']['site']['properties']['internal_id']['type'] );
+		$this->assertSame( array( 'integer', 'null' ), $schema['properties']['provenance']['properties']['period']['properties']['row_count']['type'] );
+	}
+
+	public function test_registered_ability_schema_validates_all_action_outputs_with_omitted_metadata(): void {
+		$ability = wp_get_ability( 'datamachine/mediavine-reports' );
+
+		$this->assertNotNull( $ability, 'The test must exercise the registered Mediavine ability.' );
+		$schema = $ability->get_output_schema();
+		$relay  = base64_encode( 'InternalSite:11476' );
+		$row    = array(
+			'slug'                   => '/music/example/',
+			'views'                  => 1250,
+			'revenue'                => 18.75,
+			'rpm'                    => 15.0,
+			'cpm'                    => 2.5,
+			'viewability'            => 0.72,
+			'fillRate'               => 0.94,
+			'impressionsPerPageview' => 4.2,
+			'period'                 => '2026-06',
+		);
+		$summary_row = array(
+			'period'          => '2026-06',
+			'earnings'        => 18.75,
+			'pageviews'       => 1250,
+			'sessions'        => 900,
+			'cpm'             => 2.5,
+			'sessionRpm'      => 20.83,
+			'pageRpm'         => 15.0,
+			'paidImpressions' => 7500,
+		);
+
+		$pages  = MediavineReportsAbilities::buildPagesResult( '11476', $relay, '2026-06-01', '2026-06-30', '2026-06', array( 'rows' => array( $row ) ) );
+		$summary = MediavineReportsAbilities::buildSummaryResult( '11476', $relay, '2026-06-01', '2026-06-30', $summary_row );
+		$period  = MediavineReportsAbilities::buildBackfillPeriodSummary( '11476', $relay, '2026-06', '2026-06-01', '2026-06-30', 1 );
+		$backfill = MediavineReportsAbilities::buildBackfillResult( '11476', $relay, array( $period ), array( $row ) );
+
+		foreach ( array( 'pages' => $pages, 'summary' => $summary, 'backfill' => $backfill ) as $action => $output ) {
+			$validated = rest_validate_value_from_schema( $output, $schema, 'output' );
+			$this->assertTrue( $validated, $action . ' output failed registered schema validation: ' . ( is_wp_error( $validated ) ? $validated->get_error_message() : '' ) );
+			$this->assertNull( $output['provenance']['period']['canonical']['start'] );
+			$this->assertNull( $output['provenance']['period']['canonical']['end'] );
+			$this->assertNull( $output['provenance']['period']['row_count'] );
+		}
 	}
 
 	/**

--- a/tests/Unit/Abilities/Analytics/MediavineReportsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/MediavineReportsAbilitiesTest.php
@@ -72,4 +72,204 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'GetMetricsSummaryInput!', $source );
 		$this->assertStringNotContainsString( '$data: MetricsSummaryInput!', $source );
 	}
+
+	/**
+	 * Provenance must preserve the requested site id and a decoded numeric
+	 * internal id (relay-encoded "InternalSite:<n>" -> "<n>").
+	 */
+	public function test_decode_internal_site_id_from_relay_and_numeric(): void {
+		$this->assertSame( '11476', MediavineReportsAbilities::decodeInternalSiteId( '11476' ) );
+		$this->assertSame( '11476', MediavineReportsAbilities::decodeInternalSiteId( base64_encode( 'InternalSite:11476' ) ) );
+		$this->assertNull( MediavineReportsAbilities::decodeInternalSiteId( '' ) );
+		$this->assertNull( MediavineReportsAbilities::decodeInternalSiteId( 'legacy-slug' ) );
+	}
+
+	/**
+	 * Provenance carries the requested + canonical report period so downstream
+	 * consumers know exactly what window was asked for and what the upstream
+	 * reported (the canonical boundary comes from the upstream ReportMeta).
+	 */
+	public function test_provenance_carries_requested_and_canonical_period_boundaries(): void {
+		$relay  = base64_encode( 'InternalSite:11476' );
+		$meta   = array( 'reportStart' => '2026/06/01', 'reportEnd' => '2026/06/30', 'totalCount' => 208 );
+		$prov   = MediavineReportsAbilities::buildProvenance( 'pages', 'PagesSummaryQuery', $relay, '2026-06-01', '2026-06-30', $meta );
+
+		$this->assertSame( 'datamachine/mediavine-reports', $prov['source']['ability'] );
+		$this->assertSame( 'pages', $prov['source']['action'] );
+		$this->assertSame( 'PagesSummaryQuery', $prov['source']['operation'] );
+
+		$this->assertSame( $relay, $prov['site']['requested_id'] );
+		$this->assertSame( '11476', $prov['site']['internal_id'] );
+
+		$this->assertSame( '2026-06-01', $prov['period']['requested']['start'] );
+		$this->assertSame( '2026-06-30', $prov['period']['requested']['end'] );
+		$this->assertSame( '2026/06/01', $prov['period']['canonical']['start'] );
+		$this->assertSame( '2026/06/30', $prov['period']['canonical']['end'] );
+		$this->assertSame( 208, $prov['period']['row_count'] );
+	}
+
+	public function test_provenance_canonical_period_is_null_when_upstream_omits_meta(): void {
+		$prov = MediavineReportsAbilities::buildProvenance( 'backfill', 'PagesSummaryQuery', '11476', '2026-01-01', '2026-03-31', array() );
+
+		$this->assertNull( $prov['period']['canonical']['start'] );
+		$this->assertNull( $prov['period']['canonical']['end'] );
+		$this->assertNull( $prov['period']['row_count'] );
+	}
+
+	/**
+	 * The upstream PageReport type exposes path only — no hostname/domain.
+	 * Provenance must encode that as structured "unavailable", never synthesize.
+	 */
+	public function test_provenance_reports_host_attribution_unavailable(): void {
+		$prov = MediavineReportsAbilities::buildProvenance( 'pages', 'PagesSummaryQuery', '11476', '2026-06-01', '2026-06-30', array() );
+
+		$this->assertFalse( $prov['host_attribution']['available'] );
+		$this->assertNotEmpty( $prov['host_attribution']['reason'] );
+		// The reason must trace the limitation to the actual upstream type, not
+		// an Extra Chill assumption.
+		$this->assertStringContainsString( 'PageReport', $prov['host_attribution']['reason'] );
+		$this->assertStringNotContainsString( 'extrachill', strtolower( $prov['host_attribution']['reason'] ) );
+	}
+
+	/**
+	 * parsePagesPayload returns rows PLUS the upstream meta (canonical period),
+	 * while keeping the established row contract additive-only (no synthetic
+	 * host field is injected onto a row).
+	 */
+	public function test_parse_pages_payload_returns_rows_and_canonical_meta(): void {
+		$response = array(
+			'data' => array(
+				'pagesSummary' => array(
+					'meta'  => array( 'totalCount' => 1, 'reportStart' => '2026/06/01', 'reportEnd' => '2026/06/30' ),
+					'pages' => array(
+						array(
+							'path'                   => '/music/example/',
+							'pageviews'              => 1250.0,
+							'pageRevenue'            => 18.75,
+							'rpm'                    => 15.0,
+							'cpm'                    => 2.5,
+							'viewability'            => 0.72,
+							'fillrate'               => 0.94,
+							'impressionsPerPageView' => 4.2,
+						),
+					),
+				),
+			),
+		);
+
+		$parsed = MediavineReportsAbilities::parsePagesPayload( $response, '2026-06' );
+
+		$this->assertIsArray( $parsed );
+		$this->assertSame( '2026/06/01', $parsed['meta']['reportStart'] );
+		$this->assertSame( '2026/06/30', $parsed['meta']['reportEnd'] );
+		$this->assertSame( 1, $parsed['meta']['totalCount'] );
+
+		// Row contract unchanged.
+		$this->assertSame( '/music/example/', $parsed['rows'][0]['slug'] );
+		$this->assertSame( 1250, $parsed['rows'][0]['views'] );
+		$this->assertSame( 0.94, $parsed['rows'][0]['fillRate'] );
+		$this->assertSame( '2026-06', $parsed['rows'][0]['period'] );
+		// No synthetic host attribution is ever written onto a row.
+		$this->assertArrayNotHasKey( 'hostname', $parsed['rows'][0] );
+		$this->assertArrayNotHasKey( 'canonicalUrl', $parsed['rows'][0] );
+		$this->assertArrayNotHasKey( 'domain', $parsed['rows'][0] );
+	}
+
+	public function test_pages_result_includes_provenance_and_preserves_site_id(): void {
+		$relay  = base64_encode( 'InternalSite:11476' );
+		$parsed = array(
+			'rows' => array( array( 'slug' => '/x/', 'period' => '2026-06' ) ),
+			'meta' => array( 'reportStart' => '2026/06/01', 'reportEnd' => '2026/06/30', 'totalCount' => 1 ),
+		);
+
+		$result = MediavineReportsAbilities::buildPagesResult( $relay, '2026-06-01', '2026-06-30', '2026-06', $parsed );
+
+		$this->assertSame( 'pages', $result['action'] );
+		$this->assertSame( $relay, $result['site_id'] );
+		$this->assertSame( 1, $result['results_count'] );
+		$this->assertArrayHasKey( 'provenance', $result );
+		$this->assertSame( '11476', $result['provenance']['site']['internal_id'] );
+		$this->assertSame( '2026/06/01', $result['provenance']['period']['canonical']['start'] );
+		$this->assertFalse( $result['provenance']['host_attribution']['available'] );
+	}
+
+	public function test_summary_result_includes_provenance_and_canonical_meta_query(): void {
+		$relay  = base64_encode( 'InternalSite:11476' );
+		$srow   = array( 'period' => '2026-06', 'earnings' => 1.0 );
+		$meta   = array( 'reportStart' => '2026/06/01', 'reportEnd' => '2026/06/30', 'totalCount' => null );
+		$result = MediavineReportsAbilities::buildSummaryResult( $relay, '2026-06-01', '2026-06-30', $srow, $meta );
+
+		$this->assertSame( 'summary', $result['action'] );
+		$this->assertArrayHasKey( 'provenance', $result );
+		$this->assertSame( 'MetricsSummaryQuery', $result['provenance']['source']['operation'] );
+		$this->assertSame( '2026/06/01', $result['provenance']['period']['canonical']['start'] );
+
+		// The summary GraphQL query must request the canonical meta block too.
+		$source = file_get_contents( dirname( __DIR__, 4 ) . '/inc/Abilities/Analytics/MediavineReportsAbilities.php' );
+		$this->assertStringContainsString( 'metricsSummary(data:$data){ meta{ totalCount reportStart reportEnd }', $source );
+	}
+
+	public function test_backfill_result_and_each_period_summary_carry_provenance(): void {
+		$relay = base64_encode( 'InternalSite:11476' );
+		$meta  = array( 'reportStart' => '2026/05/01', 'reportEnd' => '2026/05/31', 'totalCount' => 12 );
+
+		$period_one = MediavineReportsAbilities::buildBackfillPeriodSummary( $relay, '2026-05', '2026-05-01', '2026-05-31', 12, $meta );
+		$period_two = MediavineReportsAbilities::buildBackfillPeriodSummary( $relay, '2026-06', '2026-06-01', '2026-06-30', 7, $meta );
+
+		$this->assertArrayHasKey( 'provenance', $period_one );
+		$this->assertArrayHasKey( 'provenance', $period_two );
+		$this->assertSame( '2026-05-01', $period_one['provenance']['period']['requested']['start'] );
+		$this->assertFalse( $period_two['provenance']['host_attribution']['available'] );
+
+		$result = MediavineReportsAbilities::buildBackfillResult( $relay, array( $period_one, $period_two ), array_fill( 0, 19, array( 'slug' => '/x/' ) ) );
+
+		$this->assertSame( 'backfill', $result['action'] );
+		$this->assertSame( 19, $result['results_count'] );
+		$this->assertArrayHasKey( 'provenance', $result );
+		// Top-level provenance spans the full requested window across periods.
+		$this->assertSame( '2026-05-01', $result['provenance']['period']['requested']['start'] );
+		$this->assertSame( '2026-06-30', $result['provenance']['period']['requested']['end'] );
+	}
+
+	public function test_backfill_period_summary_records_error_without_losing_provenance(): void {
+		$relay   = base64_encode( 'InternalSite:11476' );
+		$summary = MediavineReportsAbilities::buildBackfillPeriodSummary( $relay, '2026-05', '2026-05-01', '2026-05-31', 0, array(), 'upstream failure' );
+
+		$this->assertSame( 0, $summary['rows'] );
+		$this->assertSame( 'upstream failure', $summary['error'] );
+		// Provenance still records what was requested even on failure.
+		$this->assertArrayHasKey( 'provenance', $summary );
+		$this->assertSame( '11476', $summary['provenance']['site']['internal_id'] );
+	}
+
+	/**
+	 * No credentials/tokens ever leak into a result or provenance block.
+	 */
+	public function test_no_credentials_leak_in_outputs(): void {
+		$relay  = base64_encode( 'InternalSite:11476' );
+		$parsed = array(
+			'rows' => array( array( 'slug' => '/x/', 'period' => '2026-06' ) ),
+			'meta' => array( 'reportStart' => '2026/06/01', 'reportEnd' => '2026/06/30', 'totalCount' => 1 ),
+		);
+
+		$blob  = wp_json_encode( MediavineReportsAbilities::buildPagesResult( $relay, '2026-06-01', '2026-06-30', '2026-06', $parsed ) );
+		$blob .= wp_json_encode( MediavineReportsAbilities::buildSummaryResult( $relay, '2026-06-01', '2026-06-30', array( 'period' => '2026-06' ), $parsed['meta'] ) );
+		$blob .= wp_json_encode( MediavineReportsAbilities::buildBackfillResult( $relay, array(), array() ) );
+		$blob .= wp_json_encode( MediavineReportsAbilities::buildProvenance( 'pages', 'PagesSummaryQuery', $relay, '2026-06-01', '2026-06-30', $parsed['meta'] ) );
+
+		$this->assertStringNotContainsString( 'password', $blob );
+		$this->assertStringNotContainsString( 'Bearer ', $blob );
+		$this->assertStringNotContainsString( 'accessToken', $blob );
+		$this->assertStringNotContainsString( 'refreshToken', $blob );
+	}
+
+	/**
+	 * Layer purity: the generic ability source contains no Extra Chill
+	 * domain/route special cases.
+	 */
+	public function test_ability_source_has_no_extra_chill_special_cases(): void {
+		$source = file_get_contents( dirname( __DIR__, 4 ) . '/inc/Abilities/Analytics/MediavineReportsAbilities.php' );
+
+		$this->assertDoesNotMatchRegularExpression( '/extrachill\.com|community\.extra|events\.extra|wire\.extra|artist\.extra/i', $source );
+	}
 }

--- a/tests/Unit/Abilities/Analytics/MediavineReportsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/MediavineReportsAbilitiesTest.php
@@ -330,6 +330,38 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_registered_ability_schema_validates_explicit_null_metadata_for_all_actions(): void {
+		$ability = wp_get_ability( 'datamachine/mediavine-reports' );
+
+		$this->assertNotNull( $ability, 'The test must exercise the registered Mediavine ability.' );
+		$schema = $ability->get_output_schema();
+		$relay  = base64_encode( 'InternalSite:11476' );
+		$meta   = MediavineReportsAbilities::normalizeReportMeta(
+			array(
+				'totalCount'  => null,
+				'reportStart' => null,
+				'reportEnd'   => null,
+			)
+		);
+		$row    = array( 'slug' => '/music/example/', 'period' => '2026-06' );
+
+		$pages    = MediavineReportsAbilities::buildPagesResult( '11476', $relay, '2026-06-01', '2026-06-30', '2026-06', array( 'rows' => array( $row ), 'meta' => $meta ) );
+		$summary  = MediavineReportsAbilities::buildSummaryResult( '11476', $relay, '2026-06-01', '2026-06-30', array( 'period' => '2026-06' ), $meta );
+		$period   = MediavineReportsAbilities::buildBackfillPeriodSummary( '11476', $relay, '2026-06', '2026-06-01', '2026-06-30', 1, $meta );
+		$backfill = MediavineReportsAbilities::buildBackfillResult( '11476', $relay, array( $period ), array( $row ) );
+
+		foreach ( array( 'pages' => $pages, 'summary' => $summary, 'backfill' => $backfill ) as $action => $output ) {
+			$validated = rest_validate_value_from_schema( $output, $schema, 'output' );
+			$this->assertTrue( $validated, $action . ' output failed registered schema validation: ' . ( is_wp_error( $validated ) ? $validated->get_error_message() : '' ) );
+		}
+
+		foreach ( array( $pages['provenance'], $summary['provenance'], $backfill['periods'][0]['provenance'] ) as $provenance ) {
+			$this->assertNull( $provenance['period']['canonical']['start'] );
+			$this->assertNull( $provenance['period']['canonical']['end'] );
+			$this->assertNull( $provenance['period']['row_count'] );
+		}
+	}
+
 	/**
 	 * Layer purity: the generic ability source contains no Extra Chill
 	 * domain/route special cases.


### PR DESCRIPTION
Fixes #74

## Summary

`datamachine/mediavine-reports` now carries a structured `provenance` block on every result batch (`pages`/`summary`) and on each `backfill` period summary, so downstream consumers can attribute or explicitly quarantine per-page revenue rows without guessing from URL paths.

## Investigation: what the upstream schema actually exposes

Before implementing, I introspected the **live** Mediavine publisher GraphQL API (`api-publishers.mediavine.com`, read-only introspection + field-probe queries) to prove the exact surface. Findings:

- `pagesSummary(data: GetPagesSummaryInput!)` → returns `PagesSummaryPayload`:
  - `meta: ReportMeta { totalCount: Int, reportStart: String, reportEnd: String }` — canonical period in **YYYY/MM/DD** (e.g. `"2026/06/01"`). *Previously requested but discarded by the parser.*
  - `pages: [PageReport]`
- **`PageReport` fields (the per-row type):** `path: String` (a URL path only), `pageviews`, `pageRevenue`, `rpm`, `cpm`, `viewability`, `fillrate`, `impressionsPerPageView`, plus `siteId: Int` / `date: String` — **both of which return `null` for aggregate (date-range) queries**.
- Field probe for hostname/canonical/url/domain (HTTP 400):
  ```
  Cannot query field "hostname" on type "PageReport".
  Cannot query field "canonicalUrl" on type "PageReport".
  Cannot query field "url" on type "PageReport".
  Cannot query field "domain" on type "PageReport".
  Cannot query field "site" on type "PageReport". Did you mean "date" or "siteId"?
  ```
- `GetPagesSummaryInput` carries `siteId: ID!` (non-null) — the stable requested site/property identifier.
- `metricsSummary` likewise exposes `meta { totalCount reportStart reportEnd }`.

**Conclusion:** the upstream `PageReport` type exposes `path` only — there is **no hostname/canonical URL/domain**. Row-level host attribution is therefore encoded as structured `host_attribution.available = false`, **not** synthesized from path patterns.

## Exact provenance contract

Every result batch and each backfill period summary now carries:

```jsonc
{
  "provenance": {
    "source": { "ability": "datamachine/mediavine-reports", "action": "pages|summary|backfill", "operation": "PagesSummaryQuery|MetricsSummaryQuery", "api": "https://api-publishers.mediavine.com/graphql" },
    "site":   { "requested_id": "<relay id sent>", "internal_id": "11476" },        // numeric decoded when derivable, else null
    "period": {
      "requested":  { "start": "2026-06-01", "end": "2026-06-30" },                 // Y-m-d window the caller asked for
      "canonical":  { "start": "2026/06/01", "end": "2026/06/30" },                 // upstream ReportMeta (verbatim YYYY/MM/DD), null when upstream omits
      "row_count":  208                                                             // upstream totalCount, null when omitted
    },
    "host_attribution": { "available": false, "reason": "Mediavine PageReport exposes path only; hostname, canonical URL, and domain are not part of the upstream pagesSummary GraphQL schema." }
  }
}
```

For `backfill`, the top-level provenance spans the full requested window (min start → max end across periods); each per-period summary additionally carries its own provenance (including failed periods, which still record what was requested).

## Compatibility (additive only)

- **Row contract unchanged:** `slug, views, revenue, rpm, cpm, viewability, fillRate, impressionsPerPageview, period` — the fields `extrachill-cli RevenueCommand` / the CSV importer consume. No synthetic `hostname`/`canonicalUrl` is ever written onto a row.
- **Top-level keys preserved:** `success, action, site_id, period, date_range, results_count, results, periods, error` all unchanged; `provenance` is added.
- `parsePagesResponse()` is kept as a backward-compatible wrapper (still returns rows / `WP_Error`); new `parsePagesPayload()` additionally returns the canonical `meta`.
- New pure, HTTP-free builders (`buildProvenance`, `buildPagesResult`, `buildSummaryResult`, `buildBackfillResult`, `buildBackfillPeriodSummary`, `decodeInternalSiteId`, `normalizeReportMeta`) make the batch shape unit-testable without a network round-trip.
- `summary` now also requests `meta { totalCount reportStart reportEnd }`.

## Generic (layer purity)

No Extra Chill domains, routes, blogs, or taxonomies in the ability source (verified by test + grep). The host-attribution reason references the upstream `PageReport` type, not an Extra Chill assumption.

## Tests

Added to `MediavineReportsAbilitiesTest` (WP_UnitTestCase), all assertions verified locally against the worktree class in isolation (46/46 checks pass):
- `decodeInternalSiteId` — relay + numeric + empty + legacy-slug → null
- provenance carries requested **and** canonical period boundaries + row_count
- canonical period is null when upstream omits meta
- `host_attribution.available === false`, reason references `PageReport`, no Extra Chill domains
- `parsePagesPayload` returns rows + canonical meta; row contract additive-only (no synthetic host field)
- `buildPagesResult` / `buildSummaryResult` / `buildBackfillResult` each include provenance; backfill span = full window; each period summary carries provenance (incl. failed period)
- summary GraphQL requests the canonical `meta` block
- no credential/token leakage in any output
- layer-purity regex on the ability source

Lint: PHPCS + PHPStan pass on the changed files.

No changelog edits, no manual version bumps. Do-not-merge: PR only.