### PR TITLE
fix: reconcile GA comparison rows by dimensions

### DIFF
--- a/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
+++ b/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
@@ -349,7 +349,10 @@ class GoogleAnalyticsAbilities {
 			'dateRanges' => $date_ranges,
 			'dimensions' => $dimensions,
 			'metrics'    => $metrics,
-			'limit'      => $limit,
+			// Comparison rows are reconciled after the API response. Fetch the full
+			// supported key set so a prior row outside the final display limit is
+			// not incorrectly classified as new.
+			'limit'      => $compare ? self::MAX_LIMIT : $limit,
 		);
 
 		// Build dimension filters.
@@ -552,8 +555,9 @@ class GoogleAnalyticsAbilities {
 			);
 		}
 
-		$rows = $compare
-			? self::formatComparisonRows( $data)
+		$limit = ! empty( $input['limit'] ) ? min( (int) $input['limit'], self::MAX_LIMIT ) : self::DEFAULT_LIMIT;
+		$rows  = $compare
+			? self::formatComparisonRows( $data, $limit )
 			: self::formatReportRows( $data);
 
 		$response = array(
@@ -1110,61 +1114,86 @@ class GoogleAnalyticsAbilities {
 	/**
 	 * Format GA4 comparison rows with delta columns.
 	 *
-	 * When two date ranges are used, the API returns rows with metricValues
-	 * containing values for each date range. This interleaves current and
-	 * previous values, then computes percentage deltas.
+	 * GA returns a separate row for each date range and adds a synthetic
+	 * dateRange dimension. Reconcile those rows by the complete report dimension
+	 * tuple, preserving current-period order and omitting prior-only rows.
 	 *
-	 * @param array $data          Raw GA4 API response.
-	 * @param array $report_config Report configuration.
+	 * @param array $data  Raw GA4 API response.
+	 * @param int   $limit Final reconciled row limit.
 	 * @return array Formatted rows with delta columns.
 	 */
-	private static function formatComparisonRows( array $data): array {
+	private static function formatComparisonRows( array $data, int $limit ): array {
 		$dimension_headers = wp_list_pluck( $data['dimensionHeaders'] ?? array(), 'name' );
 		$metric_headers    = wp_list_pluck( $data['metricHeaders'] ?? array(), 'name' );
-		$metric_count      = count( $metric_headers );
-
-		$rows = array();
+		$date_range_index  = array_search( 'dateRange', $dimension_headers, true );
+		$current_rows      = array();
+		$previous_rows     = array();
 
 		foreach ( ( $data['rows'] ?? array() ) as $row ) {
 			$dim_values    = wp_list_pluck( $row['dimensionValues'] ?? array(), 'value' );
 			$metric_values = wp_list_pluck( $row['metricValues'] ?? array(), 'value' );
-
-			$formatted = array();
+			$dimensions    = array();
 			foreach ( $dimension_headers as $i => $name ) {
-				// Skip the dateRange dimension GA4 adds for multi-range requests.
 				if ( 'dateRange' === $name ) {
 					continue;
 				}
-				$formatted[ $name ] = $dim_values[ $i ] ?? '';
+				$dimensions[ $name ] = $dim_values[ $i ] ?? '';
 			}
 
-			// GA4 returns metric values as [current_m1, current_m2, ..., previous_m1, previous_m2, ...].
-			for ( $i = 0; $i < $metric_count; $i++ ) {
-				$name     = $metric_headers[ $i ];
-				$current  = $metric_values[ $i ] ?? '0';
-				$previous = $metric_values[ $i + $metric_count ] ?? '0';
+			$key         = wp_json_encode( array_values( $dimensions ) );
+			$range       = false !== $date_range_index ? ( $dim_values[ $date_range_index ] ?? 'date_range_0' ) : 'date_range_0';
+			$formatted   = $dimensions;
+			$raw_metrics = array();
+			foreach ( $metric_headers as $i => $name ) {
+				$value                = $metric_values[ $i ] ?? '0';
+				$raw_metrics[ $name ] = $value;
+				$formatted[ $name ]   = is_numeric( $value )
+					? ( strpos( $value, '.' ) !== false ? (float) $value : (int) $value )
+					: $value;
+			}
 
+			$entry = array(
+				'formatted' => $formatted,
+				'metrics'   => $raw_metrics,
+			);
+
+			if ( 'date_range_1' === $range ) {
+				$previous_rows[ $key ] = $entry;
+			} else {
+				$current_rows[ $key ] = $entry;
+			}
+		}
+
+		$rows = array();
+		foreach ( $current_rows as $key => $current_row ) {
+			$formatted    = $current_row['formatted'];
+			$has_previous = isset( $previous_rows[ $key ] );
+
+			foreach ( $metric_headers as $name ) {
+				$current      = $current_row['metrics'][ $name ] ?? '0';
 				$current_num  = is_numeric( $current ) ? (float) $current : 0;
-				$previous_num = is_numeric( $previous ) ? (float) $previous : 0;
+				$delta_column = "\xCE\x94 " . $name;
 
-				// Format current value.
-				if ( is_numeric( $current ) ) {
-					$formatted[ $name ] = strpos( $current, '.' ) !== false ? (float) $current : (int) $current;
-				} else {
-					$formatted[ $name ] = $current;
+				if ( ! $has_previous ) {
+					$formatted[ $delta_column ] = 'new';
+					continue;
 				}
 
-				// Compute delta percentage.
+				$previous     = $previous_rows[ $key ]['metrics'][ $name ] ?? '0';
+				$previous_num = is_numeric( $previous ) ? (float) $previous : 0;
 				if ( 0.0 !== $previous_num ) {
-					$delta                            = ( ( $current_num - $previous_num ) / $previous_num ) * 100;
-					$sign                             = $delta >= 0 ? '+' : '';
-					$formatted[ "\xCE\x94 " . $name ] = $sign . round( $delta, 1 ) . '%';
+					$delta                      = ( ( $current_num - $previous_num ) / $previous_num ) * 100;
+					$sign                       = $delta >= 0 ? '+' : '';
+					$formatted[ $delta_column ] = $sign . round( $delta, 1 ) . '%';
 				} else {
-					$formatted[ "\xCE\x94 " . $name ] = $current_num > 0 ? 'new' : '-';
+					$formatted[ $delta_column ] = '-';
 				}
 			}
 
 			$rows[] = $formatted;
+			if ( count( $rows ) >= $limit ) {
+				break;
+			}
 		}
 
 		return $rows;

--- a/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
@@ -388,6 +388,131 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'dimensionFilter', $body );
 	}
 
+	/**
+	 * Comparison rows are joined by landing page before the final limit is
+	 * applied. Prior-only rows are not emitted and absent prior keys are new.
+	 */
+	public function test_landing_page_comparison_reconciles_rows_and_applies_final_limit(): void {
+		$data = $this->comparison_response(
+			array( 'landingPage' ),
+			array( 'sessions' ),
+			array(
+				array( array( '/shared' ), 'date_range_0', array( '120' ) ),
+				array( array( '/new' ), 'date_range_0', array( '30' ) ),
+				array( array( '/shared' ), 'date_range_1', array( '100' ) ),
+				array( array( '/removed' ), 'date_range_1', array( '40' ) ),
+			)
+		);
+
+		$rows = $this->format_comparison_rows( $data, 2 );
+
+		$this->assertCount( 2, $rows );
+		$this->assertSame( '/shared', $rows[0]['landingPage'] );
+		$this->assertSame( 120, $rows[0]['sessions'] );
+		$this->assertSame( '+20%', $rows[0]["\xCE\x94 sessions"] );
+		$this->assertSame( 'new', $rows[1]["\xCE\x94 sessions"] );
+		$this->assertNotContains( '/removed', wp_list_pluck( $rows, 'landingPage' ) );
+
+		$limited = $this->format_comparison_rows( $data, 1 );
+		$this->assertCount( 1, $limited );
+		$this->assertSame( '/shared', $limited[0]['landingPage'] );
+	}
+
+	/**
+	 * A present zero-valued prior row is not a new key, even though a percentage
+	 * delta cannot be calculated from zero.
+	 */
+	public function test_comparison_marks_only_absent_prior_keys_as_new(): void {
+		$data = $this->comparison_response(
+			array( 'landingPage' ),
+			array( 'sessions' ),
+			array(
+				array( array( '(not set)' ), 'date_range_0', array( '10' ) ),
+				array( array( '(not set)' ), 'date_range_1', array( '0' ) ),
+			)
+		);
+
+		$rows = $this->format_comparison_rows( $data, 10 );
+
+		$this->assertSame( '-', $rows[0]["\xCE\x94 sessions"] );
+	}
+
+	/**
+	 * Multi-dimension actions use the complete tuple as their stable key, so two
+	 * rows sharing a source but using different media remain independent.
+	 */
+	public function test_comparison_uses_complete_multi_dimension_key(): void {
+		$data = $this->comparison_response(
+			array( 'sessionSource', 'sessionMedium' ),
+			array( 'sessions' ),
+			array(
+				array( array( 'search', 'organic' ), 'date_range_0', array( '90' ) ),
+				array( array( 'search', 'referral' ), 'date_range_0', array( '25' ) ),
+				array( array( 'search', 'organic' ), 'date_range_1', array( '60' ) ),
+				array( array( 'search', 'referral' ), 'date_range_1', array( '20' ) ),
+			)
+		);
+
+		$rows = $this->format_comparison_rows( $data, 10 );
+
+		$this->assertCount( 2, $rows );
+		$this->assertSame( '+50%', $rows[0]["\xCE\x94 sessions"] );
+		$this->assertSame( '+25%', $rows[1]["\xCE\x94 sessions"] );
+	}
+
+	/**
+	 * Compare requests fetch the supported key set; the requested limit is
+	 * enforced after current/prior reconciliation instead of by GA per range.
+	 */
+	public function test_compare_request_defers_limit_until_after_reconciliation(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'compare'    => true,
+				'limit'      => 30,
+				'start_date' => '2026-04-01',
+				'end_date'   => '2026-07-13',
+			),
+			'landing_pages'
+		);
+
+		$this->assertSame( GoogleAnalyticsAbilities::MAX_LIMIT, $body['limit'] );
+	}
+
+	private function format_comparison_rows( array $data, int $limit ): array {
+		$method = new \ReflectionMethod( GoogleAnalyticsAbilities::class, 'formatComparisonRows' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $data, $limit );
+	}
+
+	private function comparison_response( array $dimensions, array $metrics, array $rows ): array {
+		return array(
+			'dimensionHeaders' => array_map(
+				static fn( string $name ): array => array( 'name' => $name ),
+				array_merge( $dimensions, array( 'dateRange' ) )
+			),
+			'metricHeaders'    => array_map(
+				static fn( string $name ): array => array( 'name' => $name ),
+				$metrics
+			),
+			'rows'             => array_map(
+				static function ( array $row ): array {
+					return array(
+						'dimensionValues' => array_map(
+							static fn( string $value ): array => array( 'value' => $value ),
+							array_merge( $row[0], array( $row[1] ) )
+						),
+						'metricValues'    => array_map(
+							static fn( string $value ): array => array( 'value' => $value ),
+							$row[2]
+						),
+					);
+				},
+				$rows
+			),
+		);
+	}
+
 	public static function all_filterable_actions(): array {
 		return array(
 			'page_stats'        => array( 'page_stats' ),


### PR DESCRIPTION
## Summary
- reconcile GA multi-date-range rows by each action's complete dimension tuple instead of treating each date-range row independently
- preserve current-period rows and schemas, calculate percentage deltas against matching prior rows, and reserve `new` for keys absent from the prior period
- fetch the supported comparison key set before applying the caller's final result limit, preventing per-range limits from doubling output or misclassifying prior keys

## Root Cause
GA4 adds a synthetic `dateRange` dimension and returns current and prior periods as separate rows. The formatter instead assumed each row contained both periods' metrics, so it compared current metrics against missing values, emitted every row separately, and marked every delta as `new`.

## Comparison Key Strategy
The formatter excludes only GA's synthetic `dateRange` dimension and JSON-encodes the ordered values of every remaining dimension. This supports single-dimension reports such as `landing_pages`, composite reports such as `traffic_sources`, and ordinary values such as `(not set)` without action-specific logic. Prior-only keys remain omitted because the established response contract emits current rows.

## Limit Semantics
Compare requests fetch up to the existing `MAX_LIMIT` so prior-key presence can be determined outside the display window. Reconciled current rows retain GA ordering and are then capped to the caller's requested limit, so `--limit=30` returns at most 30 rows rather than 30 per date range.

## Compatibility
- non-comparison report formatting and CLI argument mapping are unchanged
- current metric and delta column schemas are preserved
- a present prior row with a zero metric produces `-` because percentage change from zero is undefined; it is not incorrectly labeled `new`

## Tests
- `homeboy review test data-machine-business --path /var/lib/datamachine/workspace/data-machine-business@issue-80-ga-compare --placement local -- --filter=GoogleAnalyticsAbilitiesTest` (`30 passed`, `87 assertions`)
- `homeboy review lint data-machine-business --path /var/lib/datamachine/workspace/data-machine-business@issue-80-ga-compare --changed-only --placement local` (passed, no PHPCS findings)
- full component suite: `70 passed`, `1 unrelated existing failure` at `tests/GoogleSearchConsoleBusinessTest.php:47`; the stale local `data-machine` dependency is 12 commits behind `origin/main` and its CLI registration text does not contain the assertion's expected `datamachine analytics gsc` string
- `php -l` passed for both changed PHP files
- `git diff --check` passed

Closes #80