### PR TITLE
fix: aggregate canonical GSC page opportunities

### DIFF
--- a/inc/Abilities/Analytics/GscOpportunityAbility.php
+++ b/inc/Abilities/Analytics/GscOpportunityAbility.php
@@ -342,7 +342,9 @@ class GscOpportunityAbility {
 				);
 			}
 
-			foreach ( (array) ( $result['results'] ?? array() ) as $row ) {
+			$rows = self::prepare_rows( $kind, (array) ( $result['results'] ?? array() ) );
+
+			foreach ( $rows as $row ) {
 				$label = self::row_label( $row );
 				if ( '' === $label ) {
 					continue;
@@ -453,8 +455,9 @@ class GscOpportunityAbility {
 				continue;
 			}
 			$position = (float) ( $row['position'] ?? 0 );
-			if ( self::is_definition_box( (string) $keys[0], $position, (float) ( $row['ctr'] ?? 0 ), self::expected_ctr( $position ), $good_position ) ) {
-				$captured[ (string) $keys[1] ] = ( $captured[ (string) $keys[1] ] ?? 0 ) + (int) ( $row['impressions'] ?? 0 );
+			$page     = self::canonical_page_url( (string) $keys[1] );
+			if ( '' !== $page && self::is_definition_box( (string) $keys[0], $position, (float) ( $row['ctr'] ?? 0 ), self::expected_ctr( $position ), $good_position ) ) {
+				$captured[ $page ] = ( $captured[ $page ] ?? 0 ) + (int) ( $row['impressions'] ?? 0 );
 			}
 		}
 		return $captured;
@@ -463,6 +466,86 @@ class GscOpportunityAbility {
 	public static function sort_and_limit( array $rows, string $field, int $limit = 0 ): array {
 		usort( $rows, static fn( array $a, array $b ): int => ( $b[ $field ] ?? 0 ) <=> ( $a[ $field ] ?? 0 ) );
 		return $limit > 0 ? array_slice( $rows, 0, $limit ) : $rows;
+	}
+
+	/**
+	 * Prepare raw GSC rows for opportunity classification.
+	 *
+	 * Query rows retain their original grain. Page rows are grouped by a stable
+	 * URL identity before thresholds and opportunity classes are evaluated.
+	 *
+	 * @param string $kind GSC dimension kind (query or page).
+	 * @param array  $rows Raw GSC result rows.
+	 * @return array Rows at the dimension's classification grain.
+	 */
+	public static function prepare_rows( string $kind, array $rows ): array {
+		if ( 'page' !== $kind ) {
+			return $rows;
+		}
+
+		$aggregated = array();
+		foreach ( $rows as $row ) {
+			$keys = (array) ( $row['keys'] ?? array() );
+			if ( empty( $keys ) ) {
+				continue;
+			}
+
+			$url = self::canonical_page_url( (string) $keys[0] );
+			if ( '' === $url ) {
+				continue;
+			}
+
+			$impressions = (int) ( $row['impressions'] ?? 0 );
+			if ( ! isset( $aggregated[ $url ] ) ) {
+				$aggregated[ $url ] = $row + array(
+					'clicks'      => 0,
+					'impressions' => 0,
+					'ctr'         => 0.0,
+					'position'    => 0.0,
+				);
+
+				$aggregated[ $url ]['keys']               = array( $url );
+				$aggregated[ $url ]['clicks']             = 0;
+				$aggregated[ $url ]['impressions']        = 0;
+				$aggregated[ $url ]['_position_weighted'] = 0.0;
+			}
+
+			$aggregated[ $url ]['clicks']             += (int) ( $row['clicks'] ?? 0 );
+			$aggregated[ $url ]['impressions']        += $impressions;
+			$aggregated[ $url ]['_position_weighted'] += (float) ( $row['position'] ?? 0.0 ) * $impressions;
+		}
+
+		foreach ( $aggregated as &$row ) {
+			$impressions     = (int) $row['impressions'];
+			$row['ctr']      = $impressions > 0 ? (int) $row['clicks'] / $impressions : 0.0;
+			$row['position'] = $impressions > 0 ? $row['_position_weighted'] / $impressions : 0.0;
+			unset( $row['_position_weighted'] );
+		}
+		unset( $row );
+
+		return array_values( $aggregated );
+	}
+
+	/**
+	 * Normalize a page URL for report identity.
+	 *
+	 * @param string $url Raw GSC page URL.
+	 * @return string Canonical report URL, or an empty string when invalid.
+	 */
+	private static function canonical_page_url( string $url ): string {
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) || empty( $parts['host'] ) ) {
+			return '';
+		}
+
+		$scheme = strtolower( (string) ( $parts['scheme'] ?? 'https' ) );
+		$host   = strtolower( (string) $parts['host'] );
+		$port   = isset( $parts['port'] ) ? ':' . (int) $parts['port'] : '';
+		$path   = (string) ( $parts['path'] ?? '/' );
+		$path   = '' === $path ? '/' : $path;
+		$path   = '/' === $path ? '/' : rtrim( $path, '/' );
+
+		return $scheme . '://' . $host . $port . $path;
 	}
 
 	private static function gsc_input( string $action, string $start_date, string $end_date, array $input ): array {

--- a/tests/Unit/Abilities/Analytics/GscOpportunityAbilityTest.php
+++ b/tests/Unit/Abilities/Analytics/GscOpportunityAbilityTest.php
@@ -59,6 +59,7 @@ class GscOpportunityAbilityTest extends WP_UnitTestCase {
 
 	public function test_captured_query_impressions_qualify_page_aggregate(): void {
 		$page = 'https://extrachill.com/the-meaning-of-blackstreets-no-diggity/';
+		$canonical_page = 'https://extrachill.com/the-meaning-of-blackstreets-no-diggity';
 		$map  = GscOpportunityAbility::captured_impressions_by_page(
 			array(
 				array(
@@ -76,13 +77,14 @@ class GscOpportunityAbilityTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( 340000, $map[ $page ] );
-		$this->assertSame( 14588, 354588 - $map[ $page ] );
-		$this->assertLessThan( 5000, (int) round( ( 354588 - $map[ $page ] ) * ( 0.10 - 0.0004 ) ) );
+		$this->assertSame( 340000, $map[ $canonical_page ] );
+		$this->assertSame( 14588, 354588 - $map[ $canonical_page ] );
+		$this->assertLessThan( 5000, (int) round( ( 354588 - $map[ $canonical_page ] ) * ( 0.10 - 0.0004 ) ) );
 	}
 
 	public function test_normal_page_has_no_captured_adjustment(): void {
 		$page = 'https://extrachill.com/normal-article/';
+		$canonical_page = 'https://extrachill.com/normal-article';
 		$map  = GscOpportunityAbility::captured_impressions_by_page(
 			array(
 				array(
@@ -94,7 +96,51 @@ class GscOpportunityAbilityTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertArrayNotHasKey( $page, $map );
+		$this->assertArrayNotHasKey( $canonical_page, $map );
 		$this->assertSame( 900, (int) round( 10000 * ( 0.10 - 0.01 ) ) );
+	}
+
+	public function test_page_rows_are_aggregated_by_canonical_url_before_classification(): void {
+		$rows = GscOpportunityAbility::prepare_rows(
+			'page',
+			array(
+				array(
+					'keys'        => array( 'https://EXTRACHILL.com/led-zeppelin-icarus-meaning/?utm_source=test' ),
+					'clicks'      => 10,
+					'impressions' => 100,
+					'ctr'         => 0.10,
+					'position'    => 2.0,
+				),
+				array(
+					'keys'        => array( 'https://extrachill.com/led-zeppelin-icarus-meaning' ),
+					'clicks'      => 5,
+					'impressions' => 300,
+					'ctr'         => 0.0167,
+					'position'    => 6.0,
+				),
+			)
+		);
+
+		$this->assertCount( 1, $rows );
+		$this->assertSame( array( 'https://extrachill.com/led-zeppelin-icarus-meaning' ), $rows[0]['keys'] );
+		$this->assertSame( 15, $rows[0]['clicks'] );
+		$this->assertSame( 400, $rows[0]['impressions'] );
+		$this->assertEqualsWithDelta( 0.0375, $rows[0]['ctr'], 0.000001 );
+		$this->assertEqualsWithDelta( 5.0, $rows[0]['position'], 0.000001 );
+	}
+
+	public function test_query_rows_remain_distinct(): void {
+		$rows = array(
+			array(
+				'keys'        => array( 'led zeppelin icarus meaning' ),
+				'impressions' => 100,
+			),
+			array(
+				'keys'        => array( 'icarus meaning led zeppelin' ),
+				'impressions' => 200,
+			),
+		);
+
+		$this->assertSame( $rows, GscOpportunityAbility::prepare_rows( 'query', $rows ) );
 	}
 }


### PR DESCRIPTION
## Summary
- aggregate page-dimension GSC rows before opportunity thresholds and classification
- canonicalize page identity by lowercasing scheme/host, dropping query strings/fragments, and normalizing trailing slashes
- preserve query-dimension rows at their original distinct query grain

## Root cause
`GscOpportunityAbility::audit()` classified every raw `page_stats` row independently. Search Console can return trailing-slash, non-trailing-slash, host-case, and query-string variants for the same page, so each variant received separate totals, CTR, position, and recoverable-click estimates.

The issue was originally filed as `Extra-Chill/extrachill-analytics#172`, but the CLI command is a thin consumer of the `datamachine/gsc-opportunity` ability owned here. The issue was transferred to this repository as #82 so the fix remains in the owning layer.

## Aggregation semantics
- group page rows by normalized URL identity before minimum-impression checks or opportunity classification
- sum clicks and impressions exactly
- recompute CTR as aggregate clicks divided by aggregate impressions
- recompute position as an impression-weighted average
- canonicalize the supporting query-page captured-impression map with the same URL identity
- return query rows unchanged so different queries remain distinct

## Tests
Added regression coverage proving:
- slash/non-slash, host-case, and query-string variants collapse to one page
- clicks and impressions reconcile to source totals
- CTR is recomputed from aggregate totals
- position is impression-weighted
- query rows remain distinct

Commands and results:
- `homeboy --placement local review data-machine-business test --path /var/lib/datamachine/workspace/data-machine-business@issue-82-canonical-gsc-opportunities -- --filter=GscOpportunityAbilityTest` - passed: 6 tests, 18 assertions
- `homeboy --placement local review data-machine-business lint --path /var/lib/datamachine/workspace/data-machine-business@issue-82-canonical-gsc-opportunities --changed-only` - passed: PHPCS clean; PHPStan unavailable because the installed Homeboy extension binary is corrupted
- `php -l` on both changed PHP files - passed
- `git diff --check` - passed
- full `homeboy ... test` - 73/74 passed; the sole failure is the unchanged `GoogleSearchConsoleBusinessTest::test_business_registers_google_search_console_tool_api_and_cli`, which expects `datamachine analytics gsc` in `data-machine-business.php`

Closes #82
Closes Extra-Chill/extrachill-analytics#172