### PR TITLE
feat: expose GSC audience segmentation

### DIFF
--- a/docs/ai-tools/google-search-console.md
+++ b/docs/ai-tools/google-search-console.md
@@ -103,6 +103,19 @@ URL & Sitemap actions:
 **query_filter** (string)
 - Filter results to queries containing this string
 
+**search_type** (string)
+- Select the Search Analytics search type: `web` (default), `image`, `video`, `news`, `discover`, or `googleNews`
+
+**country** (string)
+- Filter by an ISO 3166-1 alpha-3 country code, such as `USA` or `GBR`
+
+**device** (string)
+- Filter by `DESKTOP`, `MOBILE`, or `TABLET`
+
+**search_appearance** (string)
+- Filter by a Search Console appearance value, such as `AMP_BLUE_LINK`
+- Appearance values are supplied by Search Console and can vary by property
+
 **url** (string)
 - Required for `inspect_url` action — the full URL to inspect
 
@@ -126,6 +139,8 @@ URL & Sitemap actions:
 
 All search analytics responses include: `clicks`, `impressions`, `ctr`, `position` per row, plus dimension keys.
 
+`country`, `device`, and `search_appearance` are filters, not returned dimensions. The selected named report continues to control the returned dimensions. Response `metadata` records those dimensions, the selected search type, and the exact filters sent to Google.
+
 ### URL Inspection API
 
 **Endpoint**: `POST https://searchconsole.googleapis.com/v1/urlInspection/index:inspect`
@@ -146,6 +161,11 @@ Returns indexing status, mobile usability, and rich results information for a sp
     'success'       => true,
     'action'        => 'query_stats',
     'results_count' => 25,
+    'metadata'      => [
+        'dimensions'  => ['query'],
+        'search_type' => 'web',
+        'filters'     => [],
+    ],
     'results'       => [
         [
             'keys'        => ['wordpress analytics'],
@@ -204,7 +224,7 @@ wp datamachine analytics gsc list_sitemaps --allow-root
 wp datamachine analytics gsc submit_sitemap --sitemap-url=https://chubes.net/sitemap.xml --allow-root
 ```
 
-**Flags**: `--start-date`, `--end-date`, `--limit`, `--url-filter`, `--query-filter`, `--url`, `--sitemap-url`, `--format` (table|json|csv)
+**Flags**: `--start-date`, `--end-date`, `--limit`, `--url-filter`, `--query-filter`, `--search-type`, `--country`, `--device`, `--search-appearance`, `--url`, `--sitemap-url`, `--format` (table|json|csv)
 
 ## REST API
 

--- a/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php
+++ b/inc/Abilities/Analytics/GoogleSearchConsoleAbilities.php
@@ -45,6 +45,20 @@ class GoogleSearchConsoleAbilities {
 	);
 
 	/**
+	 * Search types accepted by the Search Analytics API.
+	 *
+	 * @var string[]
+	 */
+	const SEARCH_TYPES = array( 'web', 'image', 'video', 'news', 'discover', 'googleNews' );
+
+	/**
+	 * Device filter values accepted by the Search Analytics API.
+	 *
+	 * @var string[]
+	 */
+	const DEVICES = array( 'DESKTOP', 'MOBILE', 'TABLET' );
+
+	/**
 	 * Default result limit.
 	 *
 	 * @var int
@@ -117,6 +131,26 @@ class GoogleSearchConsoleAbilities {
 								'type'        => 'string',
 								'description' => 'Filter results to queries containing this string.',
 							),
+							'search_type'  => array(
+								'type'        => 'string',
+								'enum'        => self::SEARCH_TYPES,
+								'description' => 'Search result type: web, image, video, news, discover, or googleNews. Defaults to web.',
+							),
+							'country'      => array(
+								'type'        => 'string',
+								'pattern'     => '^[A-Za-z]{3}$',
+								'description' => 'Filter by ISO 3166-1 alpha-3 country code, such as USA or GBR.',
+							),
+							'device'       => array(
+								'type'        => 'string',
+								'enum'        => self::DEVICES,
+								'description' => 'Filter by device: DESKTOP, MOBILE, or TABLET.',
+							),
+							'search_appearance' => array(
+								'type'        => 'string',
+								'pattern'     => '^[A-Za-z][A-Za-z0-9_]*$',
+								'description' => 'Filter by a Search Console search appearance value, such as AMP_BLUE_LINK.',
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -126,6 +160,7 @@ class GoogleSearchConsoleAbilities {
 							'action'        => array( 'type' => 'string' ),
 							'results_count' => array( 'type' => 'integer' ),
 							'results'       => array( 'type' => 'array' ),
+							'metadata'      => array( 'type' => 'object' ),
 							'error'         => array( 'type' => 'string' ),
 						),
 					),
@@ -231,39 +266,12 @@ class GoogleSearchConsoleAbilities {
 			);
 		}
 
-		$request_body = array(
-			'startDate'  => $start_date,
-			'endDate'    => $end_date,
-			'dimensions' => $dimensions,
-			'rowLimit'   => $limit,
-			'dataState'  => 'final',
-		);
+		$request_body = self::buildSearchAnalyticsRequest( $input, $start_date, $end_date, $dimensions, $limit );
 
-		// Build dimension filter groups if filters provided.
-		$filters = array();
-
-		if ( ! empty( $input['url_filter'] ) ) {
-			$filters[] = array(
-				'dimension'  => 'page',
-				'operator'   => 'contains',
-				'expression' => sanitize_text_field( $input['url_filter'] ),
-			);
-		}
-
-		if ( ! empty( $input['query_filter'] ) ) {
-			$filters[] = array(
-				'dimension'  => 'query',
-				'operator'   => 'contains',
-				'expression' => sanitize_text_field( $input['query_filter'] ),
-			);
-		}
-
-		if ( ! empty( $filters ) ) {
-			$request_body['dimensionFilterGroups'] = array(
-				array(
-					'groupType' => 'and',
-					'filters'   => $filters,
-				),
+		if ( is_wp_error( $request_body ) ) {
+			return array(
+				'success' => false,
+				'error'   => $request_body->get_error_message(),
 			);
 		}
 
@@ -314,7 +322,105 @@ class GoogleSearchConsoleAbilities {
 			'action'        => $action,
 			'results_count' => count( $rows ),
 			'results'       => $rows,
+			'metadata'      => array(
+				'dimensions'  => $dimensions,
+				'search_type' => $request_body['type'],
+				'filters'     => $request_body['dimensionFilterGroups'][0]['filters'] ?? array(),
+			),
 		);
+	}
+
+	/**
+	 * Build and validate a bounded Search Analytics request body.
+	 *
+	 * Audience inputs are filters only; they never alter the dimensions returned
+	 * by the named report action.
+	 *
+	 * @param array    $input      Ability input.
+	 * @param string   $start_date Start date.
+	 * @param string   $end_date   End date.
+	 * @param string[] $dimensions Report dimensions.
+	 * @param int      $limit      Row limit.
+	 * @return array|\WP_Error
+	 */
+	private static function buildSearchAnalyticsRequest( array $input, string $start_date, string $end_date, array $dimensions, int $limit ) {
+		$search_type = ! empty( $input['search_type'] ) ? sanitize_text_field( $input['search_type'] ) : 'web';
+		if ( ! in_array( $search_type, self::SEARCH_TYPES, true ) ) {
+			return new \WP_Error( 'invalid_gsc_search_type', 'Invalid search_type. Must be one of: ' . implode( ', ', self::SEARCH_TYPES ) );
+		}
+
+		$request_body = array(
+			'startDate'  => $start_date,
+			'endDate'    => $end_date,
+			'dimensions' => $dimensions,
+			'rowLimit'   => $limit,
+			'dataState'  => 'final',
+			'type'       => $search_type,
+		);
+		$filters = array();
+
+		if ( ! empty( $input['url_filter'] ) ) {
+			$filters[] = array(
+				'dimension'  => 'page',
+				'operator'   => 'contains',
+				'expression' => sanitize_text_field( $input['url_filter'] ),
+			);
+		}
+
+		if ( ! empty( $input['query_filter'] ) ) {
+			$filters[] = array(
+				'dimension'  => 'query',
+				'operator'   => 'contains',
+				'expression' => sanitize_text_field( $input['query_filter'] ),
+			);
+		}
+
+		if ( ! empty( $input['country'] ) ) {
+			$country = strtolower( sanitize_text_field( $input['country'] ) );
+			if ( 1 !== preg_match( '/^[a-z]{3}$/', $country ) ) {
+				return new \WP_Error( 'invalid_gsc_country', 'Invalid country. Use an ISO 3166-1 alpha-3 country code such as USA or GBR.' );
+			}
+			$filters[] = array(
+				'dimension'  => 'country',
+				'operator'   => 'equals',
+				'expression' => $country,
+			);
+		}
+
+		if ( ! empty( $input['device'] ) ) {
+			$device = strtoupper( sanitize_text_field( $input['device'] ) );
+			if ( ! in_array( $device, self::DEVICES, true ) ) {
+				return new \WP_Error( 'invalid_gsc_device', 'Invalid device. Must be one of: ' . implode( ', ', self::DEVICES ) );
+			}
+			$filters[] = array(
+				'dimension'  => 'device',
+				'operator'   => 'equals',
+				'expression' => $device,
+			);
+		}
+
+		if ( ! empty( $input['search_appearance'] ) ) {
+			$search_appearance = strtoupper( sanitize_text_field( $input['search_appearance'] ) );
+			if ( 1 !== preg_match( '/^[A-Z][A-Z0-9_]*$/', $search_appearance ) ) {
+				return new \WP_Error( 'invalid_gsc_search_appearance', 'Invalid search_appearance. Use a Search Console appearance value such as AMP_BLUE_LINK.' );
+			}
+			$filters[] = array(
+				'dimension'  => 'searchAppearance',
+				'operator'   => 'equals',
+				'expression' => $search_appearance,
+			);
+		}
+
+		if ( ! empty( $filters ) ) {
+			$request_body['dimensionFilterGroups'] = array(
+				array(
+					'groupType' => 'and',
+					'filters'   => $filters,
+				),
+			);
+		}
+
+		return $request_body;
 	}
 
 	/**

--- a/inc/Cli/GoogleSearchConsoleCommand.php
+++ b/inc/Cli/GoogleSearchConsoleCommand.php
@@ -65,6 +65,18 @@ class GoogleSearchConsoleCommand extends BaseCommand {
 	 * [--query-filter=<string>]
 	 * : Filter results to queries containing this string.
 	 *
+	 * [--search-type=<type>]
+	 * : Search result type: web, image, video, news, discover, or googleNews (default: web).
+	 *
+	 * [--country=<code>]
+	 * : Filter by ISO 3166-1 alpha-3 country code, such as USA or GBR.
+	 *
+	 * [--device=<device>]
+	 * : Filter by device: DESKTOP, MOBILE, or TABLET.
+	 *
+	 * [--search-appearance=<appearance>]
+	 * : Filter by a Search Console appearance value, such as AMP_BLUE_LINK.
+	 *
 	 * [--inspect-url=<url>]
 	 * : URL for inspect_url action (named --inspect-url to avoid WP-CLI's global --url).
 	 *
@@ -98,6 +110,10 @@ class GoogleSearchConsoleCommand extends BaseCommand {
 			'limit'        => 'limit',
 			'url-filter'   => 'url_filter',
 			'query-filter' => 'query_filter',
+			'search-type'  => 'search_type',
+			'country'      => 'country',
+			'device'       => 'device',
+			'search-appearance' => 'search_appearance',
 			'inspect-url'  => 'url',
 			'sitemap-url'  => 'sitemap_url',
 		) );

--- a/inc/Tools/GoogleSearchConsole.php
+++ b/inc/Tools/GoogleSearchConsole.php
@@ -109,6 +109,24 @@ class GoogleSearchConsole extends BaseTool {
 					'type'        => 'string',
 					'description' => 'Filter results to queries containing this string.',
 				),
+					'search_type'  => array(
+					'type'        => 'string',
+					'enum'        => GoogleSearchConsoleAbilities::SEARCH_TYPES,
+					'description' => 'Search result type. Defaults to web.',
+				),
+					'country'      => array(
+					'type'        => 'string',
+					'description' => 'ISO 3166-1 alpha-3 country filter, such as USA or GBR.',
+				),
+					'device'       => array(
+					'type'        => 'string',
+					'enum'        => GoogleSearchConsoleAbilities::DEVICES,
+					'description' => 'Device filter: DESKTOP, MOBILE, or TABLET.',
+				),
+					'search_appearance' => array(
+					'type'        => 'string',
+					'description' => 'Search appearance filter, such as AMP_BLUE_LINK.',
+				),
 				),
 				'required'   => array( 'action' ),
 			),

--- a/tests/Unit/Abilities/Analytics/GoogleSearchConsoleAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/GoogleSearchConsoleAbilitiesTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unit tests for GoogleSearchConsoleAbilities subsite auto-scoping.
+ * Unit tests for GoogleSearchConsoleAbilities request construction and scoping.
  *
  * Covers the enhancement where the datamachine/google-search-console ability
  * always queried the configured sc-domain: property and returned the whole
@@ -20,6 +20,96 @@ use DataMachineBusiness\Abilities\Analytics\GoogleSearchConsoleAbilities;
 use WP_UnitTestCase;
 
 class GoogleSearchConsoleAbilitiesTest extends WP_UnitTestCase {
+
+	public function test_builds_default_search_analytics_request_body(): void {
+		$this->assertSame(
+			array(
+				'startDate'  => '2026-06-01',
+				'endDate'    => '2026-06-30',
+				'dimensions' => array( 'query' ),
+				'rowLimit'   => 25,
+				'dataState'  => 'final',
+				'type'       => 'web',
+			),
+			$this->build_request( array() )
+		);
+	}
+
+	public function test_builds_exact_segmented_search_analytics_request_body(): void {
+		$this->assertSame(
+			array(
+				'startDate'            => '2026-06-01',
+				'endDate'              => '2026-06-30',
+				'dimensions'           => array( 'query', 'page' ),
+				'rowLimit'             => 100,
+				'dataState'            => 'final',
+				'type'                 => 'googleNews',
+				'dimensionFilterGroups' => array(
+					array(
+						'groupType' => 'and',
+						'filters'   => array(
+							array(
+								'dimension'  => 'page',
+								'operator'   => 'contains',
+								'expression' => '/music/',
+							),
+							array(
+								'dimension'  => 'query',
+								'operator'   => 'contains',
+								'expression' => 'festival',
+							),
+							array(
+								'dimension'  => 'country',
+								'operator'   => 'equals',
+								'expression' => 'usa',
+							),
+							array(
+								'dimension'  => 'device',
+								'operator'   => 'equals',
+								'expression' => 'MOBILE',
+							),
+							array(
+								'dimension'  => 'searchAppearance',
+								'operator'   => 'equals',
+								'expression' => 'AMP_BLUE_LINK',
+							),
+						),
+					),
+				),
+			),
+			$this->build_request(
+				array(
+					'search_type'       => 'googleNews',
+					'url_filter'        => '/music/',
+					'query_filter'      => 'festival',
+					'country'           => 'USA',
+					'device'            => 'mobile',
+					'search_appearance' => 'amp_blue_link',
+				),
+				array( 'query', 'page' ),
+				100
+			)
+		);
+	}
+
+	/**
+	 * @dataProvider invalid_segmentation_provider
+	 */
+	public function test_rejects_invalid_segmentation_input( array $input, string $error_code ): void {
+		$result = $this->build_request( $input );
+
+		$this->assertWPError( $result );
+		$this->assertSame( $error_code, $result->get_error_code() );
+	}
+
+	public static function invalid_segmentation_provider(): array {
+		return array(
+			'invalid search type'       => array( array( 'search_type' => 'all' ), 'invalid_gsc_search_type' ),
+			'invalid country'           => array( array( 'country' => 'US' ), 'invalid_gsc_country' ),
+			'invalid device'            => array( array( 'device' => 'TV' ), 'invalid_gsc_device' ),
+			'invalid search appearance' => array( array( 'search_appearance' => 'AMP BLUE LINK' ), 'invalid_gsc_search_appearance' ),
+		);
+	}
 
 	/**
 	 * A genuine subdomain of the configured sc-domain: property gets scoped to
@@ -142,5 +232,17 @@ class GoogleSearchConsoleAbilitiesTest extends WP_UnitTestCase {
 				'https://a.b.extrachill.com'
 			)
 		);
+	}
+
+	/**
+	 * Invoke the private request builder to verify the exact Google API payload.
+	 *
+	 * @return array|\WP_Error
+	 */
+	private function build_request( array $input, array $dimensions = array( 'query' ), int $limit = 25 ) {
+		$method = new \ReflectionMethod( GoogleSearchConsoleAbilities::class, 'buildSearchAnalyticsRequest' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $input, '2026-06-01', '2026-06-30', $dimensions, $limit );
 	}
 }


### PR DESCRIPTION
## Summary
- expose bounded `search_type`, `country`, `device`, and `search_appearance` inputs through the GSC ability, AI tool, and WP-CLI
- preserve named report dimensions and canonical page filtering while sending audience selections as Search Analytics filters
- return request metadata and add exact request-body and validation coverage

## Supported Surface
- Search types: `web`, `image`, `video`, `news`, `discover`, `googleNews`
- Country filter: ISO 3166-1 alpha-3 code, normalized to the lowercase value expected by GSC
- Device filter: `DESKTOP`, `MOBILE`, or `TABLET`
- Search appearance filter: Search Console appearance token such as `AMP_BLUE_LINK`

`country`, `device`, and `search_appearance` are filter-only inputs. They do not become returned dimensions; `query_stats`, `page_stats`, `query_page_stats`, and `date_stats` continue to determine the response keys. Search appearance values are property-dependent, so this validates token shape but cannot enumerate availability for a property.

## Tests
- PHP syntax checks for all modified PHP files
- `git diff --check`
- isolated exact request-body and invalid-input assertions: passed
- focused WordPress PHPUnit coverage added in `GoogleSearchConsoleAbilitiesTest`

## Verification Limitations
- `homeboy review data-machine-business --changed-only --summary` was refused by resource policy because host load was about 132 on 8 CPUs; it was not forced
- `php tests/gsc-business-registration-smoke.php` has a pre-existing unrelated failure in its unchanged CLI registration string assertion
- the production WordPress bootstrap does not provide `WP_UnitTestCase`, so the focused PHPUnit file could not be executed there directly
- no live GSC request was made; property-specific search appearance availability remains an API-side constraint

Closes #85