### PR TITLE
feat: expose GA page acquisition reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Actions:
 - `top_events`
 - `user_demographics`
 - `landing_pages`
+- `landing_page_acquisition`
+- `page_acquisition`
+- `page_audience`
 - `engagement`
 - `new_vs_returning`
 - `network_density`
@@ -138,6 +141,8 @@ Common options include `--start-date`, `--end-date`, `--limit`, `--page-filter`,
 
 ```bash
 wp datamachine analytics ga page_stats --hostname=example.com --compare
+wp datamachine analytics ga landing_page_acquisition --hostname=example.com
+wp datamachine analytics ga page_acquisition --page-filter=/blog/
 wp datamachine analytics ga path_sequence --format=json
 ```
 

--- a/docs/google-analytics.md
+++ b/docs/google-analytics.md
@@ -29,10 +29,21 @@ Existing GA4 installations do not need a migration step. Data Machine Business u
 - `top_events`
 - `user_demographics`
 - `landing_pages`
+- `landing_page_acquisition`
+- `page_acquisition`
+- `page_audience`
 - `engagement`
 - `new_vs_returning`
 - `network_density`
 - `path_sequence`
+
+### Bounded page breakdowns
+
+- **`landing_page_acquisition`** groups `landingPage` by `sessionSource` and `sessionMedium`. It answers how sessions were acquired for the page where each session began.
+- **`page_acquisition`** groups `pagePath` by `sessionSource` and `sessionMedium`. It answers which acquisition channels drove sessions that touched a page, whether or not that page was the session entry.
+- **`page_audience`** groups `pagePath` by `country` and `deviceCategory` for geographic and device analysis of touched pages.
+
+These are fixed report presets rather than an arbitrary GA4 report builder. All support `page_filter`, `hostname`, sorting, row limits, and comparison. Standard report responses include pagination metadata with the requested limit, returned and fetched row counts, GA4's reported row count, and a truncation flag.
 
 ### `network_density` vs `path_sequence`
 

--- a/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
+++ b/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
@@ -99,45 +99,61 @@ class GoogleAnalyticsAbilities {
 	 * @var array
 	 */
 	const ACTION_REPORTS = array(
-		'page_stats'        => array(
+		'page_stats'              => array(
 			// hostName is prepended (not replacing pagePath) so existing pagePath-keyed
 			// consumers keep working while cross-site rows become distinguishable — on a
 			// multisite GA4 property two sites otherwise both collapse to pagePath "/".
 			'dimensions' => array( 'hostName', 'pagePath', 'pageTitle' ),
 			'metrics'    => array( 'screenPageViews', 'sessions', 'bounceRate', 'averageSessionDuration', 'activeUsers' ),
 		),
-		'network_density'   => array(
+		'network_density'         => array(
 			// Cross-site journey proxy: current host x previous URL. Bucket pageReferrer's
 			// host into in-network vs external to compute "% of sessions per site whose
 			// referrer was another EC site". Approximation only — see action description.
 			'dimensions' => array( 'hostName', 'pageReferrer' ),
 			'metrics'    => array( 'sessions', 'activeUsers', 'screenPageViews' ),
 		),
-		'traffic_sources'   => array(
+		'traffic_sources'         => array(
 			'dimensions' => array( 'sessionSource', 'sessionMedium' ),
 			'metrics'    => array( 'sessions', 'activeUsers', 'screenPageViews', 'bounceRate' ),
 		),
-		'date_stats'        => array(
+		'date_stats'              => array(
 			'dimensions' => array( 'date' ),
 			'metrics'    => array( 'sessions', 'screenPageViews', 'activeUsers', 'bounceRate', 'averageSessionDuration' ),
 		),
-		'top_events'        => array(
+		'top_events'              => array(
 			'dimensions' => array( 'eventName' ),
 			'metrics'    => array( 'eventCount', 'eventCountPerUser' ),
 		),
-		'user_demographics' => array(
+		'user_demographics'       => array(
 			'dimensions' => array( 'country', 'deviceCategory' ),
 			'metrics'    => array( 'sessions', 'activeUsers', 'screenPageViews' ),
 		),
-		'landing_pages'     => array(
+		'landing_pages'           => array(
 			'dimensions' => array( 'landingPage' ),
 			'metrics'    => array( 'sessions', 'activeUsers', 'bounceRate', 'averageSessionDuration', 'engagementRate' ),
 		),
-		'engagement'        => array(
+		'landing_page_acquisition' => array(
+			// Session-entry semantics: acquisition is attributed to the page where
+			// the session began, not every page subsequently touched.
+			'dimensions' => array( 'landingPage', 'sessionSource', 'sessionMedium' ),
+			'metrics'    => array( 'sessions', 'activeUsers', 'engagedSessions', 'engagementRate' ),
+		),
+		'page_acquisition'        => array(
+			// Touched-page semantics: pagePath includes any matching page viewed
+			// during sessions attributed to the returned source and medium.
+			'dimensions' => array( 'pagePath', 'sessionSource', 'sessionMedium' ),
+			'metrics'    => array( 'screenPageViews', 'sessions', 'activeUsers', 'engagedSessions' ),
+		),
+		'page_audience'           => array(
+			'dimensions' => array( 'pagePath', 'country', 'deviceCategory' ),
+			'metrics'    => array( 'screenPageViews', 'sessions', 'activeUsers' ),
+		),
+		'engagement'              => array(
 			'dimensions' => array( 'pagePath', 'pageTitle' ),
 			'metrics'    => array( 'engagementRate', 'averageSessionDuration', 'engagedSessions', 'sessionsPerUser', 'screenPageViewsPerSession', 'userEngagementDuration' ),
 		),
-		'new_vs_returning'  => array(
+		'new_vs_returning'        => array(
 			'dimensions' => array( 'newVsReturning' ),
 			'metrics'    => array( 'sessions', 'activeUsers', 'engagementRate', 'screenPageViewsPerSession', 'averageSessionDuration' ),
 		),
@@ -156,6 +172,8 @@ class GoogleAnalyticsAbilities {
 
 	private function registerAbilities(): void {
 		$register_callback = function () {
+			$valid_actions = array_merge( array_keys( self::ACTION_REPORTS ), array( 'realtime', 'path_sequence' ) );
+
 			wp_register_ability(
 				'datamachine/google-analytics',
 				array(
@@ -168,7 +186,8 @@ class GoogleAnalyticsAbilities {
 						'properties' => array(
 							'action'      => array(
 								'type'        => 'string',
-								'description' => 'Action to perform: page_stats (per-page metrics, includes hostName for multisite), traffic_sources, date_stats, realtime, top_events, user_demographics, landing_pages, engagement, new_vs_returning, network_density (cross-site journey proxy: hostName x pageReferrer; approximation only — pageReferrer is the immediately-preceding URL, not an ordered session path, and is subject to referrer-policy stripping, sampling, and high-cardinality "(other)" bucketing), path_sequence (true ordered cross-host journeys via the v1alpha funnel report — discovers hosts then runs a 2-step closed funnel per ordered host pair, returning each host\'s entry_users, ordered next-host transitions (next_host with activeUsers), and onward_users, so a consumer can compute "% of each host\'s users reaching >=1 other site" and rank top ordered cross-site paths; in-network bucketing is the consumer\'s job. DATA SOURCE: GA4 Data API v1alpha funnel report. Caveats: v1alpha (may change), USER-scoped metric (activeUsers, not sessions), subject to sampling, returns ordered 2-hop transitions per host pair (compose deeper chains from the matrix), capped to the top hosts. The fully-accurate long-term source is a BigQuery export tap, not yet configured).',
+								'enum'        => $valid_actions,
+								'description' => 'Action to perform. Acquisition reports are bounded presets: landing_page_acquisition groups session-entry landingPage by session source/medium; page_acquisition groups touched pagePath by session source/medium; page_audience groups touched pagePath by country/device. Other actions: page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics, landing_pages, engagement, new_vs_returning, network_density (referrer proxy), path_sequence (ordered v1alpha funnel report).',
 							),
 							'property_id' => array(
 								'type'        => 'string',
@@ -184,6 +203,8 @@ class GoogleAnalyticsAbilities {
 							),
 							'limit'       => array(
 								'type'        => 'integer',
+								'minimum'     => 1,
+								'maximum'     => self::MAX_LIMIT,
 								'description' => 'Row limit (default: 25, max: 10000). For path_sequence this instead selects how many top hosts (by sessions) to pair, default 6, clamped to 12 — fan-out grows ~N*(N-1) funnel calls.',
 							),
 							'page_filter' => array(
@@ -200,6 +221,7 @@ class GoogleAnalyticsAbilities {
 							),
 							'order'       => array(
 								'type'        => 'string',
+								'enum'        => array( 'asc', 'desc' ),
 								'description' => 'Sort direction: asc or desc (default: desc).',
 							),
 							'compare'     => array(
@@ -215,6 +237,7 @@ class GoogleAnalyticsAbilities {
 							'action'        => array( 'type' => 'string' ),
 							'results_count' => array( 'type' => 'integer' ),
 							'results'       => array( 'type' => 'array' ),
+							'pagination'    => array( 'type' => 'object' ),
 							'error'         => array( 'type' => 'string' ),
 						),
 					),
@@ -310,7 +333,7 @@ class GoogleAnalyticsAbilities {
 
 		$start_date = ! empty( $input['start_date'] ) ? sanitize_text_field( $input['start_date'] ) : gmdate( 'Y-m-d', strtotime( '-28 days' ) );
 		$end_date   = ! empty( $input['end_date'] ) ? sanitize_text_field( $input['end_date'] ) : gmdate( 'Y-m-d', strtotime( '-1 day' ) );
-		$limit      = ! empty( $input['limit'] ) ? min( (int) $input['limit'], self::MAX_LIMIT ) : self::DEFAULT_LIMIT;
+		$limit      = ! empty( $input['limit'] ) ? max( 1, min( (int) $input['limit'], self::MAX_LIMIT ) ) : self::DEFAULT_LIMIT;
 		$compare    = ! empty( $input['compare'] );
 
 		$dimensions = array_map(
@@ -555,7 +578,7 @@ class GoogleAnalyticsAbilities {
 			);
 		}
 
-		$limit = ! empty( $input['limit'] ) ? min( (int) $input['limit'], self::MAX_LIMIT ) : self::DEFAULT_LIMIT;
+		$limit = ! empty( $input['limit'] ) ? max( 1, min( (int) $input['limit'], self::MAX_LIMIT ) ) : self::DEFAULT_LIMIT;
 		$rows  = $compare
 			? self::formatComparisonRows( $data, $limit )
 			: self::formatReportRows( $data);
@@ -569,6 +592,7 @@ class GoogleAnalyticsAbilities {
 			),
 			'results_count' => count( $rows ),
 			'results'       => $rows,
+			'pagination'    => self::buildPaginationMetadata( $data, $limit, count( $rows ), $compare ),
 		);
 
 		if ( $compare ) {
@@ -579,6 +603,44 @@ class GoogleAnalyticsAbilities {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Describe GA4 and display-level row limiting for a standard report.
+	 *
+	 * @param array $data           Raw GA4 API response.
+	 * @param int   $limit          Requested display limit.
+	 * @param int   $returned_rows  Number of formatted rows returned.
+	 * @param bool  $compare        Whether two date ranges were requested.
+	 * @return array Pagination metadata.
+	 */
+	private static function buildPaginationMetadata( array $data, int $limit, int $returned_rows, bool $compare ): array {
+		$fetched_rows   = count( $data['rows'] ?? array() );
+		$api_row_count  = isset( $data['rowCount'] ) ? (int) $data['rowCount'] : $fetched_rows;
+		$available_rows = $fetched_rows;
+
+		if ( $compare ) {
+			$dimension_headers = wp_list_pluck( $data['dimensionHeaders'] ?? array(), 'name' );
+			$date_range_index  = array_search( 'dateRange', $dimension_headers, true );
+			$available_rows    = 0;
+
+			foreach ( ( $data['rows'] ?? array() ) as $row ) {
+				$range = false !== $date_range_index
+					? ( $row['dimensionValues'][ $date_range_index ]['value'] ?? 'date_range_0' )
+					: 'date_range_0';
+				if ( 'date_range_0' === $range ) {
+					++$available_rows;
+				}
+			}
+		}
+
+		return array(
+			'limit'         => $limit,
+			'returned_rows' => $returned_rows,
+			'api_row_count' => $api_row_count,
+			'fetched_rows'  => $fetched_rows,
+			'truncated'     => $api_row_count > $fetched_rows || $available_rows > $returned_rows,
+		);
 	}
 
 	/**

--- a/inc/Cli/GoogleAnalyticsCommand.php
+++ b/inc/Cli/GoogleAnalyticsCommand.php
@@ -33,17 +33,20 @@ class GoogleAnalyticsCommand extends BaseCommand {
 	 */
 	public static function actions(): array {
 		return array(
-			'page_stats'        => 'Top pages by sessions, views, and engagement',
-			'traffic_sources'   => 'Sessions grouped by source and medium',
-			'date_stats'        => 'Daily session and engagement trends',
-			'realtime'          => 'Real-time active users',
-			'top_events'        => 'Top events by count',
-			'user_demographics' => 'Sessions by country and device',
-			'landing_pages'     => 'Top landing pages by entrances and engagement',
-			'engagement'        => 'Aggregate engagement metrics per page',
-			'new_vs_returning'  => 'New vs returning user split',
-			'network_density'   => 'Cross-site journey density via referrer host',
-			'path_sequence'     => 'Ordered cross-host path sequences (funnel report)',
+			'page_stats'              => 'Top pages by sessions, views, and engagement',
+			'traffic_sources'         => 'Sessions grouped by source and medium',
+			'date_stats'              => 'Daily session and engagement trends',
+			'realtime'                => 'Real-time active users',
+			'top_events'              => 'Top events by count',
+			'user_demographics'       => 'Sessions by country and device',
+			'landing_pages'           => 'Top landing pages by entrances and engagement',
+			'landing_page_acquisition' => 'Landing pages by session source and medium',
+			'page_acquisition'        => 'Touched pages by session source and medium',
+			'page_audience'           => 'Touched pages by country and device',
+			'engagement'              => 'Aggregate engagement metrics per page',
+			'new_vs_returning'        => 'New vs returning user split',
+			'network_density'         => 'Cross-site journey density via referrer host',
+			'path_sequence'           => 'Ordered cross-host path sequences (funnel report)',
 		);
 	}
 
@@ -53,7 +56,7 @@ class GoogleAnalyticsCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * <action>
-	 * : Action to perform: page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics, landing_pages, engagement, new_vs_returning, network_density, path_sequence.
+	 * : Action to perform: page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics, landing_pages, landing_page_acquisition, page_acquisition, page_audience, engagement, new_vs_returning, network_density, path_sequence.
 	 *
 	 * [--start-date=<date>]
 	 * : Start date in YYYY-MM-DD format (default: 28 days ago). Not used for realtime.
@@ -108,6 +111,15 @@ class GoogleAnalyticsCommand extends BaseCommand {
 	 *
 	 *     # Landing pages with highest engagement
 	 *     wp datamachine analytics ga landing_pages --sort-by=engagementRate --order=desc
+	 *
+	 *     # Session-entry pages broken down by acquisition source
+	 *     wp datamachine analytics ga landing_page_acquisition --hostname=example.com
+	 *
+	 *     # Any touched page broken down by acquisition source
+	 *     wp datamachine analytics ga page_acquisition --page-filter=/blog/
+	 *
+	 *     # Any touched page broken down by country and device
+	 *     wp datamachine analytics ga page_audience --page-filter=/blog/
 	 *
 	 *     # Engagement metrics for specific section
 	 *     wp datamachine analytics ga engagement --page-filter=/blog/

--- a/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
+++ b/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
@@ -66,18 +66,21 @@ class GoogleAnalytics extends BaseTool {
 	 * @return array Tool definition array.
 	 */
 	public function getToolDefinition(): array {
+		$valid_actions = array_merge( array_keys( GoogleAnalyticsAbilities::ACTION_REPORTS ), array( 'realtime', 'path_sequence' ) );
+
 		return array(
 			'class'           => __CLASS__,
 			'method'          => 'handle_tool_call',
-			'description'     => 'Fetch visitor analytics from Google Analytics (GA4). Get page performance metrics (with hostName for multisite), traffic sources, daily trends, real-time active users, top events, user demographics, landing pages, engagement metrics, new-vs-returning user breakdown, a cross-site network-density proxy, and true ordered cross-host session journeys (path_sequence). Supports sorting, hostname filtering for multisite, and period-over-period comparison.',
+			'description'     => 'Fetch visitor analytics from Google Analytics (GA4), including fixed landing-page acquisition, touched-page acquisition, and page audience breakdowns. Supports sorting, hostname and page filtering, and period-over-period comparison without arbitrary dimension selection.',
 			'requires_config' => true,
 			'parameters'      => array(
 				'type'       => 'object',
 				'properties' => array(
 					'action'      => array(
-					'type'        => 'string',
-					'description' => 'Action to perform: page_stats (per-page views, sessions, bounce rate; includes hostName so multisite pages are distinguishable), traffic_sources (where visitors come from), date_stats (daily trends over time), realtime (active users right now), top_events (most triggered events), user_demographics (visitor country and device breakdown), landing_pages (entry pages with session metrics), engagement (engagement rate, session quality, pages/session), new_vs_returning (new vs returning user comparison), network_density (cross-site journey proxy: hostName x pageReferrer, to compute % of sessions per site whose referrer was another site on the network; approximation only — pageReferrer is the immediately-preceding URL not an ordered session path, and is subject to referrer-policy stripping, sampling, and high-cardinality bucketing), path_sequence (TRUE ordered cross-host journeys via the v1alpha funnel report: discovers the hosts then runs a 2-step closed funnel per ordered host pair, returning each host\'s entry_users, ordered next-host transitions (next_host + activeUsers), and onward_users, so you can compute "% of each host\'s users reaching >=1 other site" and rank the top ordered cross-site paths — unlike network_density this is a real ordered hop, not a referrer guess. Caveats: v1alpha API, USER-scoped (activeUsers, not sessions), subject to sampling, 2-hop transitions per host pair (compose deeper chains yourself), capped to top hosts; fully-accurate source would be a BigQuery export, not yet configured).',
-				),
+						'type'        => 'string',
+						'enum'        => $valid_actions,
+						'description' => 'Choose a bounded report. landing_page_acquisition uses session-entry landingPage x session source/medium. page_acquisition uses touched pagePath x session source/medium. page_audience uses touched pagePath x country/device.',
+					),
 					'property_id' => array(
 					'type'        => 'string',
 					'description' => 'GA4 property ID (numeric). Defaults to the configured property ID.',
@@ -92,6 +95,8 @@ class GoogleAnalytics extends BaseTool {
 				),
 					'limit'       => array(
 					'type'        => 'integer',
+					'minimum'     => 1,
+					'maximum'     => GoogleAnalyticsAbilities::MAX_LIMIT,
 					'description' => 'Row limit (default: 25, max: 10000).',
 				),
 					'page_filter' => array(
@@ -108,6 +113,7 @@ class GoogleAnalytics extends BaseTool {
 				),
 					'order'       => array(
 					'type'        => 'string',
+					'enum'        => array( 'asc', 'desc' ),
 					'description' => 'Sort direction: asc or desc (default: desc).',
 				),
 					'compare'     => array(

--- a/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
@@ -15,6 +15,7 @@
 namespace DataMachine\Tests\Unit\Abilities\Analytics;
 
 use DataMachineBusiness\Abilities\Analytics\GoogleAnalyticsAbilities;
+use DataMachineBusiness\Engine\AI\Tools\Global\GoogleAnalytics;
 use WP_UnitTestCase;
 
 class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
@@ -166,6 +167,135 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 		);
 
 		$this->assertArrayNotHasKey( 'dimensionFilter', $body );
+	}
+
+	/**
+	 * The recovery-analysis additions are fixed report presets. Callers cannot
+	 * select arbitrary dimensions or metrics.
+	 *
+	 * @dataProvider bounded_page_report_configs
+	 */
+	public function test_bounded_page_report_config( string $action, array $dimensions, array $metrics ): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'start_date' => '2026-01-01',
+				'end_date'   => '2026-01-31',
+			),
+			$action
+		);
+
+		$this->assertSame( $dimensions, wp_list_pluck( $body['dimensions'], 'name' ) );
+		$this->assertSame( $metrics, wp_list_pluck( $body['metrics'], 'name' ) );
+	}
+
+	/**
+	 * landing_page_acquisition retains session-entry filtering while the two
+	 * pagePath reports retain touched-page filtering.
+	 *
+	 * @dataProvider bounded_page_filter_dimensions
+	 */
+	public function test_bounded_page_report_filter_semantics( string $action, string $field_name ): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody(
+			array(
+				'page_filter' => '/recovery/',
+				'hostname'    => 'example.com',
+				'start_date'  => '2026-01-01',
+				'end_date'    => '2026-01-31',
+			),
+			$action
+		);
+
+		$filters = $body['dimensionFilter']['andGroup']['expressions'];
+		$this->assertSame( $field_name, $filters[0]['filter']['fieldName'] );
+		$this->assertSame( 'hostName', $filters[1]['filter']['fieldName'] );
+	}
+
+	public function test_report_limit_is_clamped_to_valid_range(): void {
+		$too_small = GoogleAnalyticsAbilities::buildReportRequestBody( array( 'limit' => -5 ), 'page_acquisition' );
+		$too_large = GoogleAnalyticsAbilities::buildReportRequestBody( array( 'limit' => 20000 ), 'page_acquisition' );
+
+		$this->assertSame( 1, $too_small['limit'] );
+		$this->assertSame( GoogleAnalyticsAbilities::MAX_LIMIT, $too_large['limit'] );
+	}
+
+	public function test_ai_tool_schema_enumerates_bounded_actions(): void {
+		$reflection = new \ReflectionClass( GoogleAnalytics::class );
+		$tool       = $reflection->newInstanceWithoutConstructor();
+		$definition = $tool->getToolDefinition();
+		$parameters = $definition['parameters']['properties'];
+
+		$this->assertContains( 'landing_page_acquisition', $parameters['action']['enum'] );
+		$this->assertContains( 'page_acquisition', $parameters['action']['enum'] );
+		$this->assertContains( 'page_audience', $parameters['action']['enum'] );
+		$this->assertSame( array( 'asc', 'desc' ), $parameters['order']['enum'] );
+		$this->assertSame( 1, $parameters['limit']['minimum'] );
+		$this->assertSame( GoogleAnalyticsAbilities::MAX_LIMIT, $parameters['limit']['maximum'] );
+	}
+
+	public function test_report_rows_keep_dimensions_and_cast_numeric_metrics(): void {
+		$data = array(
+			'dimensionHeaders' => array(
+				array( 'name' => 'pagePath' ),
+				array( 'name' => 'country' ),
+				array( 'name' => 'deviceCategory' ),
+			),
+			'metricHeaders'    => array(
+				array( 'name' => 'screenPageViews' ),
+				array( 'name' => 'engagementRate' ),
+			),
+			'rows'             => array(
+				array(
+					'dimensionValues' => array(
+						array( 'value' => '/recovery/' ),
+						array( 'value' => 'United States' ),
+						array( 'value' => 'mobile' ),
+					),
+					'metricValues'    => array(
+						array( 'value' => '42' ),
+						array( 'value' => '0.625' ),
+					),
+				),
+			),
+		);
+
+		$method = new \ReflectionMethod( GoogleAnalyticsAbilities::class, 'formatReportRows' );
+		$method->setAccessible( true );
+		$rows = $method->invoke( null, $data );
+
+		$this->assertSame( '/recovery/', $rows[0]['pagePath'] );
+		$this->assertSame( 42, $rows[0]['screenPageViews'] );
+		$this->assertSame( 0.625, $rows[0]['engagementRate'] );
+	}
+
+	public function test_pagination_metadata_discloses_api_truncation(): void {
+		$data = array(
+			'rowCount' => 10,
+			'rows'     => array( array(), array(), array() ),
+		);
+
+		$pagination = $this->pagination_metadata( $data, 3, 3, false );
+
+		$this->assertSame( 10, $pagination['api_row_count'] );
+		$this->assertSame( 3, $pagination['fetched_rows'] );
+		$this->assertTrue( $pagination['truncated'] );
+	}
+
+	public function test_comparison_pagination_uses_current_period_rows_for_display_truncation(): void {
+		$data = $this->comparison_response(
+			array( 'pagePath', 'sessionSource', 'sessionMedium' ),
+			array( 'sessions' ),
+			array(
+				array( array( '/one/', 'google', 'organic' ), 'date_range_0', array( '20' ) ),
+				array( array( '/two/', 'direct', '(none)' ), 'date_range_0', array( '10' ) ),
+				array( array( '/one/', 'google', 'organic' ), 'date_range_1', array( '18' ) ),
+				array( array( '/two/', 'direct', '(none)' ), 'date_range_1', array( '8' ) ),
+			)
+		);
+		$data['rowCount'] = 4;
+
+		$pagination = $this->pagination_metadata( $data, 2, 2, true );
+
+		$this->assertFalse( $pagination['truncated'] );
 	}
 
 	/**
@@ -485,6 +615,13 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 		return $method->invoke( null, $data, $limit );
 	}
 
+	private function pagination_metadata( array $data, int $limit, int $returned_rows, bool $compare ): array {
+		$method = new \ReflectionMethod( GoogleAnalyticsAbilities::class, 'buildPaginationMetadata' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $data, $limit, $returned_rows, $compare );
+	}
+
 	private function comparison_response( array $dimensions, array $metrics, array $rows ): array {
 		return array(
 			'dimensionHeaders' => array_map(
@@ -515,21 +652,26 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 
 	public static function all_filterable_actions(): array {
 		return array(
-			'page_stats'        => array( 'page_stats' ),
-			'traffic_sources'   => array( 'traffic_sources' ),
-			'date_stats'        => array( 'date_stats' ),
-			'top_events'        => array( 'top_events' ),
-			'user_demographics' => array( 'user_demographics' ),
-			'landing_pages'     => array( 'landing_pages' ),
-			'engagement'        => array( 'engagement' ),
-			'new_vs_returning'  => array( 'new_vs_returning' ),
+			'page_stats'              => array( 'page_stats' ),
+			'traffic_sources'         => array( 'traffic_sources' ),
+			'date_stats'              => array( 'date_stats' ),
+			'top_events'              => array( 'top_events' ),
+			'user_demographics'       => array( 'user_demographics' ),
+			'landing_pages'           => array( 'landing_pages' ),
+			'landing_page_acquisition' => array( 'landing_page_acquisition' ),
+			'page_acquisition'        => array( 'page_acquisition' ),
+			'page_audience'           => array( 'page_audience' ),
+			'engagement'              => array( 'engagement' ),
+			'new_vs_returning'        => array( 'new_vs_returning' ),
 		);
 	}
 
 	public static function page_path_grouped_actions(): array {
 		return array(
-			'page_stats' => array( 'page_stats' ),
-			'engagement' => array( 'engagement' ),
+			'page_stats'       => array( 'page_stats' ),
+			'engagement'       => array( 'engagement' ),
+			'page_acquisition' => array( 'page_acquisition' ),
+			'page_audience'    => array( 'page_audience' ),
 		);
 	}
 
@@ -540,6 +682,34 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 			'top_events'        => array( 'top_events' ),
 			'user_demographics' => array( 'user_demographics' ),
 			'new_vs_returning'  => array( 'new_vs_returning' ),
+		);
+	}
+
+	public static function bounded_page_report_configs(): array {
+		return array(
+			'landing page acquisition' => array(
+				'landing_page_acquisition',
+				array( 'landingPage', 'sessionSource', 'sessionMedium' ),
+				array( 'sessions', 'activeUsers', 'engagedSessions', 'engagementRate' ),
+			),
+			'page acquisition'         => array(
+				'page_acquisition',
+				array( 'pagePath', 'sessionSource', 'sessionMedium' ),
+				array( 'screenPageViews', 'sessions', 'activeUsers', 'engagedSessions' ),
+			),
+			'page audience'            => array(
+				'page_audience',
+				array( 'pagePath', 'country', 'deviceCategory' ),
+				array( 'screenPageViews', 'sessions', 'activeUsers' ),
+			),
+		);
+	}
+
+	public static function bounded_page_filter_dimensions(): array {
+		return array(
+			'landing page acquisition' => array( 'landing_page_acquisition', 'landingPage' ),
+			'page acquisition'         => array( 'page_acquisition', 'pagePath' ),
+			'page audience'            => array( 'page_audience', 'pagePath' ),
 		);
 	}
 }


### PR DESCRIPTION
## Summary
- add bounded `landing_page_acquisition`, `page_acquisition`, and `page_audience` GA4 report presets across the ability, AI tool, and WP-CLI surfaces
- preserve session-entry `landingPage` semantics separately from touched-page `pagePath` semantics, with existing hostname/page filters and typed rows
- expose action/order/limit validation plus pagination metadata that discloses GA4 and display-level truncation

## Bounded API
These actions select fixed dimension and metric combinations. Callers cannot provide arbitrary GA4 dimensions or metrics, so the integration remains a named operational report surface rather than a generic report builder.

## Tests
- `php -l` for all changed PHP files
- `git diff --check`
- lightweight request-construction smoke covering all three report dimensions, filters, and limit clamping
- focused unit coverage added for report presets, landing-page versus touched-page filters, schemas, typed rows, and truncation metadata

`homeboy review data-machine-business --changed-only --summary` was attempted, but Homeboy refused to start before running checks because the host resource safety policy reported load average 132.2 across 8 CPUs. No local `vendor/bin/phpunit` is present in the worktree.

## Residual limitations
- GA4 reports remain subject to Data API sampling, cardinality bucketing, and the 10,000-row request ceiling; response pagination metadata now makes truncation visible.
- `page_acquisition` and `page_audience` describe sessions/users that touched a `pagePath`; they do not imply that page was the session entry. Use `landing_page_acquisition` for entry-page attribution.
- No live GA4 API request was run from the development worktree.

Closes #84