### PR TITLE
feat: expose Mediavine dimensional reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Data Machine Business connects WordPress automation, agents, and pipelines to an
 | Discord | Fetch channel messages and publish text or embeds | Abilities, fetch/publish handlers |
 | Amazon Associates | Search products and generate Creators API affiliate links | AI tool |
 | Sendy | Subscribe users, create or update campaigns, and read email-funnel metrics | Abilities |
-| Mediavine | Fetch page-level and aggregate publisher revenue reports | Ability |
+| Mediavine | Fetch page, aggregate, device, country, normalized-source, and ad-unit publisher revenue reports | Ability, WP-CLI |
 | Content analytics | Category-level engagement audits, editorial triage flags, and GSC opportunity ranking | Abilities |
 | Media hygiene | Detect and safely remove orphan files and unreferenced attachments | Ability, WP-CLI |
 | Agent context | Generate an `AGENTS.md` section from the registered business CLI command map | Data Machine memory composition |
@@ -50,7 +50,7 @@ The plugin registers the following WordPress abilities. Management-oriented abil
 | `datamachine/gsc-opportunity` | Rank snippet/CTR gaps, page-two demand, and SERP-captured queries using GSC data |
 | `datamachine/bing-webmaster` | Query Bing search, traffic, page, and crawl statistics |
 | `datamachine/pagespeed` | Run full, performance-focused, or opportunity-focused PageSpeed audits |
-| `datamachine/mediavine-reports` | Fetch page reports, aggregate summaries, or multi-period revenue backfills with source provenance |
+| `datamachine/mediavine-reports` | Fetch page reports, aggregate summaries, multi-period backfills, and bounded device/country/source/ad-unit reports with source provenance |
 | `datamachine/content-performance` | Rank posts within a category by GA4 engagement while accounting for traffic and sample size |
 | `datamachine/content-flags` | Produce an outcome-based editorial triage screen with confidence and query-intent caveats |
 
@@ -181,6 +181,25 @@ Actions: `query_stats`, `traffic_stats`, `page_stats`, and `crawl_stats`.
 wp datamachine analytics bing traffic_stats --days=30
 ```
 
+### Mediavine
+
+```bash
+wp datamachine analytics mediavine <action>
+```
+
+Actions: `devices`, `countries`, `sources`, and `ad_units`.
+
+Common options are `--site-id`, `--start-date`, `--end-date`, `--period`, and `--format=table|json|csv`. JSON preserves the complete typed ability response, including provenance. Table and CSV output use stable action-specific columns.
+
+```bash
+wp datamachine analytics mediavine devices
+wp datamachine analytics mediavine countries --start-date=2026-07-01 --end-date=2026-07-07
+wp datamachine analytics mediavine sources --format=json
+wp datamachine analytics mediavine ad_units --format=csv
+```
+
+See [Mediavine Reports](docs/mediavine.md) for exact report grains, fields, and attribution caveats.
+
 ### PageSpeed Insights
 
 ```bash
@@ -297,6 +316,8 @@ Sendy is config-driven: callers pass the Sendy installation URL and API key to e
 Store the publisher account email and password in the `datamachine_mediavine_config` option. Reports use the publisher GraphQL API and cache a short-lived access token. Keep fetches low-frequency, such as monthly imports and one-time backfills.
 
 Mediavine page reports expose paths but not hostnames. Results therefore include explicit provenance and report `host_attribution.available=false`; multisite consumers must resolve path ownership without guessing a host.
+
+Dimensional reports are source-native Mediavine aggregates. In particular, `sources.source` is Mediavine's normalized acquisition bucket rather than a raw referrer or GA4 source/medium, countries stop at country grain, and ad-unit output explicitly distinguishes parent rows from child rows broken down by `deviceType`. See [Mediavine Reports](docs/mediavine.md).
 
 ## Content Analytics Notes
 

--- a/docs/mediavine.md
+++ b/docs/mediavine.md
@@ -21,6 +21,7 @@ The dimensional CLI accepts `--site-id`, `--start-date`, `--end-date`, `--period
 `devices` preserves `label`, pageview/session counts and RPM, revenue, monetizable counts, and monetizable RPM.
 
 `countries` preserves `country`, pageview/session counts and percentages, net/page revenue, impressions, paid impressions, CPM, fill rate, viewability, pageview/session RPM, monetizable counts and percentages, and monetizable RPM.
+Mediavine returns country `netRevenue` in 1/10,000 dollar units; the ability normalizes it to dollars so it matches the source report's public `netRevenue` semantics.
 
 `sources` preserves `source`, revenue/net revenue, pageviews, sessions, impressions, pageview/session RPM, monetizable counts/RPM, and impression-per-pageview/session metrics. `source` is Mediavine's normalized acquisition bucket. It is not a raw referrer URL/domain and is not GA4 source/medium.
 

--- a/docs/mediavine.md
+++ b/docs/mediavine.md
@@ -1,0 +1,49 @@
+# Mediavine Reports
+
+Data Machine Business exposes bounded, read-only publisher reports through the `datamachine/mediavine-reports` ability. It calls Mediavine's source GraphQL operations directly and does not persist responses, join them to GA4, or model revenue attribution.
+
+## Report Matrix
+
+| Ability action | GraphQL operation | Input type | Public grain | WP-CLI |
+|---|---|---|---|---|
+| `pages` | `pagesSummary` | `GetPagesSummaryInput!` | URL path | Ability only |
+| `summary` | `metricsSummary` | `GetMetricsSummaryInput!` | Site total | Ability only |
+| `backfill` | `pagesSummary` | `GetPagesSummaryInput!` | URL path across requested periods | Ability only |
+| `devices` | `devicesMetricsSummary` | `GetDevicesMetricsSummaryInput!` | Device label | `wp datamachine analytics mediavine devices` |
+| `countries` | `countriesReport` | `GetCountriesReportInput!` | Country | `wp datamachine analytics mediavine countries` |
+| `sources` | `sourceReports` | `GetSourceReportsInput!` | Mediavine normalized source | `wp datamachine analytics mediavine sources` |
+| `ad_units` | `adunitsMetrics` | `GetAdunitsMetricsInput!` | Parent ad unit or child ad unit x device | `wp datamachine analytics mediavine ad_units` |
+
+The dimensional CLI accepts `--site-id`, `--start-date`, `--end-date`, `--period`, and `--format=table|json|csv`. JSON emits the complete ability envelope. Table and CSV emit stable action-specific row columns.
+
+## Dimensional Fields
+
+`devices` preserves `label`, pageview/session counts and RPM, revenue, monetizable counts, and monetizable RPM.
+
+`countries` preserves `country`, pageview/session counts and percentages, net/page revenue, impressions, paid impressions, CPM, fill rate, viewability, pageview/session RPM, monetizable counts and percentages, and monetizable RPM.
+
+`sources` preserves `source`, revenue/net revenue, pageviews, sessions, impressions, pageview/session RPM, monetizable counts/RPM, and impression-per-pageview/session metrics. `source` is Mediavine's normalized acquisition bucket. It is not a raw referrer URL/domain and is not GA4 source/medium.
+
+`ad_units` flattens the two source collections without losing their meaning:
+
+- Parent rows have `grain=parent` and `deviceType=null`.
+- Child rows have `grain=child` and preserve `deviceType`.
+- Both retain ad-unit name, revenue, paid impressions, viewability, fill rate, session/pageview RPM, monetizable session/pageview RPM, and CPM.
+
+Unknown string literals from Mediavine are preserved. An absent dimension remains JSON `null`, which is distinct from a literal `Unknown` bucket.
+
+## Provenance
+
+Every result includes:
+
+- The requested and normalized Mediavine site identifiers.
+- Requested dates and canonical upstream report dates.
+- The ability action and GraphQL operation identity.
+- The returned row count.
+- `host_attribution.available=false` with a source-specific reason.
+
+Country is the finest geography exposed here. These reports do not expose page x source/device/country/ad-unit combinations or row-level host attribution.
+
+## Security
+
+Publisher credentials remain in the server-side `datamachine_mediavine_config` option. Access tokens are cached transiently and are never part of ability output, CLI output, fixtures, or error payloads. The integration selects bounded report fields and does not log authenticated response bodies.

--- a/inc/Abilities/Analytics/MediavineReportsAbilities.php
+++ b/inc/Abilities/Analytics/MediavineReportsAbilities.php
@@ -104,6 +104,13 @@ class MediavineReportsAbilities {
 	 */
 	const SUMMARY_HOST_ATTRIBUTION_REASON = 'Mediavine metricsSummary returns site-level aggregate metrics without row-level URL or host dimensions.';
 
+	/**
+	 * Human-readable host attribution reason for dimensional reports.
+	 *
+	 * @var string
+	 */
+	const DIMENSIONAL_HOST_ATTRIBUTION_REASON = 'Mediavine dimensional reports return source-native aggregate buckets without row-level URL or host attribution.';
+
 	private static bool $registered = false;
 
 	public function __construct() {
@@ -121,7 +128,7 @@ class MediavineReportsAbilities {
 				'datamachine/mediavine-reports',
 				array(
 					'label'               => 'Mediavine Reports',
-					'description'         => 'Fetch per-period, per-URL Mediavine ad revenue directly from the Mediavine publisher GraphQL API. Actions: pages (per-period per-URL revenue rows: slug,views,revenue,rpm,cpm,viewability,fillRate,impressionsPerPageview,period), summary (site-level aggregate totals: earnings, pageviews, sessions, rpm), backfill (iterate a list of periods, returning pages rows per period for a full revenue-arc backfill). Every result batch and each backfill period summary carries a `provenance` block: the requested Mediavine site id, the requested and canonical report period, the source action/query identity, and an explicit host_attribution.available=false flag (the upstream PageReport type exposes path only, never hostname/domain). Credentials live server-side in the datamachine_mediavine_config option.',
+					'description'         => 'Fetch bounded Mediavine publisher reports directly from the source GraphQL API. Actions: pages, summary, backfill, devices, countries, sources, and ad_units. Dimensional reports preserve Mediavine source-native buckets and typed metrics; ad-unit rows identify parent versus child grain explicitly. Every result batch carries source, site, period, row-count, and host-attribution provenance. Credentials live server-side in the datamachine_mediavine_config option.',
 					'category'            => 'datamachine-analytics',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -129,7 +136,7 @@ class MediavineReportsAbilities {
 						'properties' => array(
 							'action'     => array(
 								'type'        => 'string',
-								'description' => 'Action: pages (per-period per-URL rows), summary (aggregate totals), backfill (iterate periods).',
+								'description' => 'Action: pages, summary, backfill, devices, countries, sources, or ad_units.',
 							),
 							'start_date' => array(
 								'type'        => 'string',
@@ -192,6 +199,36 @@ class MediavineReportsAbilities {
 			'sessionRpm'             => array( 'type' => 'number' ),
 			'pageRpm'                => array( 'type' => 'number' ),
 			'paidImpressions'        => array( 'type' => 'integer' ),
+			'label'                  => array( 'type' => array( 'string', 'null' ) ),
+			'country'                => array( 'type' => array( 'string', 'null' ) ),
+			'source'                 => array(
+				'type'        => array( 'string', 'null' ),
+				'description' => 'Mediavine normalized acquisition bucket; not a raw referrer or GA source/medium.',
+			),
+			'adunit'                 => array( 'type' => array( 'string', 'null' ) ),
+			'grain'                  => array( 'type' => 'string', 'enum' => array( 'parent', 'child' ) ),
+			'deviceType'             => array( 'type' => array( 'string', 'null' ) ),
+			'pageviewRpm'            => array( 'type' => 'number' ),
+			'monetizablePageviews'   => array( 'type' => 'integer' ),
+			'monetizableSessions'    => array( 'type' => 'integer' ),
+			'monetizablePageviewRpm' => array( 'type' => 'number' ),
+			'monetizableSessionRpm'  => array( 'type' => 'number' ),
+			'pageviewsPercentage'    => array( 'type' => 'number' ),
+			'sessionsPercentage'     => array( 'type' => 'number' ),
+			'netRevenue'             => array( 'type' => 'number' ),
+			'pageRevenue'            => array( 'type' => 'number' ),
+			'impressions'            => array( 'type' => 'integer' ),
+			'fillrate'               => array( 'type' => 'number' ),
+			'pageviewsRpm'           => array( 'type' => 'number' ),
+			'sessionsRpm'            => array( 'type' => 'number' ),
+			'monetizablePageviewsPercentage' => array( 'type' => 'number' ),
+			'monetizableSessionsPercentage'  => array( 'type' => 'number' ),
+			'monetizablePageviewsRpm'        => array( 'type' => 'number' ),
+			'monetizableSessionsRpm'         => array( 'type' => 'number' ),
+			'impressionsPerPageview'         => array( 'type' => 'number' ),
+			'impressionsPerSession'          => array( 'type' => 'number' ),
+			'impressionsPerMonetizablePageview' => array( 'type' => 'number' ),
+			'impressionsPerMonetizableSession'  => array( 'type' => 'number' ),
 		);
 
 		return array(
@@ -201,7 +238,7 @@ class MediavineReportsAbilities {
 				'success'       => array( 'type' => 'boolean' ),
 				'action'        => array(
 					'type' => 'string',
-					'enum' => array( 'pages', 'summary', 'backfill' ),
+					'enum' => array( 'pages', 'summary', 'backfill', 'devices', 'countries', 'sources', 'ad_units' ),
 				),
 				'site_id'       => array(
 					'type'        => 'string',
@@ -270,7 +307,7 @@ class MediavineReportsAbilities {
 						'ability'   => array( 'type' => 'string' ),
 						'action'    => array(
 							'type' => 'string',
-							'enum' => array( 'pages', 'summary', 'backfill' ),
+							'enum' => array( 'pages', 'summary', 'backfill', 'devices', 'countries', 'sources', 'ad_units' ),
 						),
 						'operation' => array( 'type' => 'string' ),
 						'api'       => array( 'type' => 'string' ),
@@ -315,7 +352,7 @@ class MediavineReportsAbilities {
 	public static function fetch( array $input ): array {
 		$action = sanitize_text_field( $input['action'] ?? '' );
 
-		$valid_actions = array( 'pages', 'summary', 'backfill' );
+		$valid_actions = array( 'pages', 'summary', 'backfill', 'devices', 'countries', 'sources', 'ad_units' );
 		if ( empty( $action ) || ! in_array( $action, $valid_actions, true ) ) {
 			return array(
 				'success' => false,
@@ -364,6 +401,10 @@ class MediavineReportsAbilities {
 
 		if ( 'backfill' === $action ) {
 			return self::fetchBackfill( $input, $access_token, $requested_site_id, $site_id );
+		}
+
+		if ( in_array( $action, array( 'devices', 'countries', 'sources', 'ad_units' ), true ) ) {
+			return self::fetchDimensionalReport( $action, $input, $access_token, $requested_site_id, $site_id );
 		}
 
 		return self::fetchPages( $input, $access_token, $requested_site_id, $site_id );
@@ -735,7 +776,13 @@ class MediavineReportsAbilities {
 	 * @return array
 	 */
 	public static function buildProvenance( string $action, string $operation, string $requested_site_id, string $relay_site_id, string $start_date, string $end_date, array $meta = array() ): array {
-		$host_reason = 'summary' === $action ? self::SUMMARY_HOST_ATTRIBUTION_REASON : self::PAGES_HOST_ATTRIBUTION_REASON;
+		if ( 'summary' === $action ) {
+			$host_reason = self::SUMMARY_HOST_ATTRIBUTION_REASON;
+		} elseif ( in_array( $action, array( 'devices', 'countries', 'sources', 'ad_units' ), true ) ) {
+			$host_reason = self::DIMENSIONAL_HOST_ATTRIBUTION_REASON;
+		} else {
+			$host_reason = self::PAGES_HOST_ATTRIBUTION_REASON;
+		}
 
 		return array(
 			'source'           => array(
@@ -886,6 +933,297 @@ class MediavineReportsAbilities {
 		}
 
 		return $rows;
+	}
+
+	/**
+	 * Fetch one bounded source-native dimensional report.
+	 *
+	 * @param string $action            Dimensional action.
+	 * @param array  $input             Ability input.
+	 * @param string $access_token      Bearer token.
+	 * @param string $requested_site_id Original site id supplied by the caller or configuration.
+	 * @param string $site_id           Normalized Relay global Mediavine site id.
+	 * @return array
+	 */
+	private static function fetchDimensionalReport( string $action, array $input, string $access_token, string $requested_site_id, string $site_id ): array {
+		$start_date = self::resolveDate( $input['start_date'] ?? '', '-28 days' );
+		$end_date   = self::resolveDate( $input['end_date'] ?? '', '-1 day' );
+		$period     = sanitize_text_field( $input['period'] ?? '' );
+		$contract   = self::dimensionalContract( $action );
+
+		$result = HttpClient::post(
+			self::API_BASE . '/graphql',
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Content-Type'  => 'application/json',
+				),
+				'body'    => wp_json_encode( self::buildDimensionalRequestBody( $action, $site_id, $start_date, $end_date ) ),
+				'context' => 'Mediavine ' . $contract['root'],
+			)
+		);
+
+		if ( empty( $result['success'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Mediavine %s report transport or authorization failure: %s', $action, $result['error'] ?? 'Unknown error' ),
+			);
+		}
+
+		$data = json_decode( (string) ( $result['data'] ?? '' ), true );
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Mediavine %s report returned invalid JSON.', $action ),
+			);
+		}
+
+		$error = self::graphqlError( $data );
+		if ( null !== $error ) {
+			return array(
+				'success' => false,
+				'error'   => sprintf( 'Mediavine %s report schema or authorization error: %s', $action, $error ),
+			);
+		}
+
+		$parsed = self::parseDimensionalPayload( $action, $data, $period );
+		if ( is_wp_error( $parsed ) ) {
+			return array(
+				'success' => false,
+				'error'   => $parsed->get_error_message(),
+			);
+		}
+
+		return self::buildDimensionalResult( $action, $requested_site_id, $site_id, $start_date, $end_date, $period, $parsed );
+	}
+
+	/**
+	 * Build one of the four confirmed dimensional GraphQL operations.
+	 *
+	 * @param string $action     Dimensional action.
+	 * @param string $site_id    Normalized Relay global Mediavine site id.
+	 * @param string $start_date Window start (Y-m-d).
+	 * @param string $end_date   Window end (Y-m-d).
+	 * @return array
+	 */
+	public static function buildDimensionalRequestBody( string $action, string $site_id, string $start_date, string $end_date ): array {
+		$contract = self::dimensionalContract( $action );
+
+		return array(
+			'query'         => $contract['query'],
+			'operationName' => $contract['operation'],
+			'variables'     => array(
+				'data' => array(
+					'siteId'    => $site_id,
+					'startDate' => self::toIso( $start_date, false ),
+					'endDate'   => self::toIso( $end_date, true ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Normalize a dimensional response into typed public rows and report meta.
+	 *
+	 * Unknown literals are preserved, while absent dimensions remain null so a
+	 * caller can distinguish an upstream null from a literal "Unknown" bucket.
+	 *
+	 * @param string $action Dimensional action.
+	 * @param array  $data   Decoded GraphQL response.
+	 * @param string $period Optional caller-provided period label.
+	 * @return array|\WP_Error Parsed payload {rows, meta} or error.
+	 */
+	public static function parseDimensionalPayload( string $action, array $data, string $period = '' ) {
+		$contract = self::dimensionalContract( $action );
+		$payload  = $data['data'][ $contract['root'] ] ?? null;
+
+		if ( ! is_array( $payload ) ) {
+			return new \WP_Error( 'mediavine_' . $action . '_contract', sprintf( 'Mediavine %s report response is missing %s.', $action, $contract['root'] ) );
+		}
+
+		$rows = array();
+		if ( 'ad_units' === $action ) {
+			foreach ( array( 'parentAdunits' => 'parent', 'childAdunits' => 'child' ) as $collection => $grain ) {
+				if ( ! isset( $payload[ $collection ] ) || ! is_array( $payload[ $collection ] ) ) {
+					return new \WP_Error( 'mediavine_ad_units_contract', 'Mediavine ad_units report response is missing parentAdunits or childAdunits.' );
+				}
+
+				foreach ( $payload[ $collection ] as $raw_row ) {
+					if ( is_array( $raw_row ) ) {
+						$rows[] = self::normalizeDimensionalRow( $action, $raw_row, $period, $grain );
+					}
+				}
+			}
+		} else {
+			$collection = $contract['collection'];
+			if ( ! isset( $payload[ $collection ] ) || ! is_array( $payload[ $collection ] ) ) {
+				return new \WP_Error( 'mediavine_' . $action . '_contract', sprintf( 'Mediavine %s report response is missing %s.%s.', $action, $contract['root'], $collection ) );
+			}
+
+			foreach ( $payload[ $collection ] as $raw_row ) {
+				if ( is_array( $raw_row ) ) {
+					$rows[] = self::normalizeDimensionalRow( $action, $raw_row, $period );
+				}
+			}
+		}
+
+		$meta               = self::normalizeReportMeta( is_array( $payload['meta'] ?? null ) ? $payload['meta'] : array() );
+		$meta['totalCount'] = count( $rows );
+
+		return array(
+			'rows' => $rows,
+			'meta' => $meta,
+		);
+	}
+
+	/**
+	 * Assemble a dimensional action response with shared provenance.
+	 *
+	 * @param string $action            Dimensional action.
+	 * @param string $requested_site_id Original site id supplied by the caller or configuration.
+	 * @param string $site_id           Normalized Relay global Mediavine site id.
+	 * @param string $start_date        Requested window start (Y-m-d).
+	 * @param string $end_date          Requested window end (Y-m-d).
+	 * @param string $period            Optional caller-provided period label.
+	 * @param array  $parsed            Parsed payload {rows, meta}.
+	 * @return array
+	 */
+	public static function buildDimensionalResult( string $action, string $requested_site_id, string $site_id, string $start_date, string $end_date, string $period, array $parsed ): array {
+		$contract = self::dimensionalContract( $action );
+		$rows     = $parsed['rows'] ?? array();
+
+		return array(
+			'success'       => true,
+			'action'        => $action,
+			'site_id'       => $site_id,
+			'period'        => $period,
+			'date_range'    => array(
+				'start_date' => $start_date,
+				'end_date'   => $end_date,
+			),
+			'results_count' => count( $rows ),
+			'results'       => $rows,
+			'provenance'    => self::buildProvenance( $action, $contract['operation'], $requested_site_id, $site_id, $start_date, $end_date, $parsed['meta'] ?? array() ),
+		);
+	}
+
+	/**
+	 * Normalize one dimensional row according to its confirmed source schema.
+	 *
+	 * @param string      $action Dimensional action.
+	 * @param array       $row    Raw source row.
+	 * @param string      $period Optional caller-provided period label.
+	 * @param string|null $grain  Ad-unit grain (parent or child).
+	 * @return array
+	 */
+	private static function normalizeDimensionalRow( string $action, array $row, string $period, ?string $grain = null ): array {
+		$field_types = self::dimensionalFieldTypes( $action );
+		$normalized  = array();
+
+		foreach ( $field_types as $field => $type ) {
+			$value = $row[ $field ] ?? null;
+			if ( 'string' === $type ) {
+				$normalized[ $field ] = null === $value ? null : (string) $value;
+			} elseif ( 'integer' === $type ) {
+				$normalized[ $field ] = (int) ( $value ?? 0 );
+			} else {
+				$normalized[ $field ] = (float) ( $value ?? 0 );
+			}
+		}
+
+		if ( 'ad_units' === $action ) {
+			$normalized['grain'] = $grain;
+			if ( 'parent' === $grain ) {
+				$normalized['deviceType'] = null;
+			}
+		}
+
+		$normalized['period'] = $period;
+		return $normalized;
+	}
+
+	/**
+	 * Return the exact selected fields and public scalar types for an action.
+	 *
+	 * @param string $action Dimensional action.
+	 * @return array<string,string>
+	 */
+	private static function dimensionalFieldTypes( string $action ): array {
+		$fields = array(
+			'devices' => array(
+				'label' => 'string', 'pageviewRpm' => 'number', 'pageviews' => 'integer', 'revenue' => 'number',
+				'sessionRpm' => 'number', 'sessions' => 'integer', 'monetizablePageviews' => 'integer',
+				'monetizableSessions' => 'integer', 'monetizablePageviewRpm' => 'number', 'monetizableSessionRpm' => 'number',
+			),
+			'countries' => array(
+				'country' => 'string', 'pageviews' => 'integer', 'pageviewsPercentage' => 'number', 'sessions' => 'integer',
+				'sessionsPercentage' => 'number', 'netRevenue' => 'number', 'pageRevenue' => 'number', 'impressions' => 'integer',
+				'paidImpressions' => 'integer', 'cpm' => 'number', 'fillrate' => 'number', 'viewability' => 'number',
+				'pageviewsRpm' => 'number', 'sessionsRpm' => 'number', 'monetizablePageviews' => 'integer',
+				'monetizablePageviewsPercentage' => 'number', 'monetizablePageviewsRpm' => 'number', 'monetizableSessions' => 'integer',
+				'monetizableSessionsPercentage' => 'number', 'monetizableSessionsRpm' => 'number',
+			),
+			'sources' => array(
+				'source' => 'string', 'revenue' => 'number', 'netRevenue' => 'number', 'pageviews' => 'integer', 'sessions' => 'integer',
+				'impressions' => 'integer', 'pageviewsRpm' => 'number', 'sessionsRpm' => 'number', 'monetizablePageviews' => 'integer',
+				'monetizablePageviewsRpm' => 'number', 'monetizableSessions' => 'integer', 'monetizableSessionsRpm' => 'number',
+				'impressionsPerPageview' => 'number', 'impressionsPerSession' => 'number',
+				'impressionsPerMonetizablePageview' => 'number', 'impressionsPerMonetizableSession' => 'number',
+			),
+			'ad_units' => array(
+				'adunit' => 'string', 'deviceType' => 'string', 'revenue' => 'number', 'paidImpressions' => 'integer',
+				'viewability' => 'number', 'fillrate' => 'number', 'sessionRpm' => 'number', 'pageviewRpm' => 'number',
+				'monetizableSessionRpm' => 'number', 'monetizablePageviewRpm' => 'number', 'cpm' => 'number',
+			),
+		);
+
+		if ( ! isset( $fields[ $action ] ) ) {
+			throw new \InvalidArgumentException( 'Unsupported Mediavine dimensional action.' );
+		}
+
+		return $fields[ $action ];
+	}
+
+	/**
+	 * Return the confirmed GraphQL contract for one bounded action.
+	 *
+	 * @param string $action Dimensional action.
+	 * @return array{operation:string,root:string,collection:string,query:string}
+	 */
+	private static function dimensionalContract( string $action ): array {
+		$contracts = array(
+			'devices' => array(
+				'operation'  => 'DevicesMetricsSummaryQuery',
+				'root'       => 'devicesMetricsSummary',
+				'collection' => 'devices',
+				'query'      => 'query DevicesMetricsSummaryQuery($data: GetDevicesMetricsSummaryInput!){ devicesMetricsSummary(data:$data){ meta{ totalCount reportStart reportEnd } devices{ label pageviewRpm pageviews revenue sessionRpm sessions monetizablePageviews monetizableSessions monetizablePageviewRpm monetizableSessionRpm } } }',
+			),
+			'countries' => array(
+				'operation'  => 'CountriesReportQuery',
+				'root'       => 'countriesReport',
+				'collection' => 'countries',
+				'query'      => 'query CountriesReportQuery($data: GetCountriesReportInput!){ countriesReport(data:$data){ meta{ totalCount reportStart reportEnd } countries{ country pageviews pageviewsPercentage sessions sessionsPercentage netRevenue pageRevenue impressions paidImpressions cpm fillrate viewability pageviewsRpm sessionsRpm monetizablePageviews monetizablePageviewsPercentage monetizablePageviewsRpm monetizableSessions monetizableSessionsPercentage monetizableSessionsRpm } } }',
+			),
+			'sources' => array(
+				'operation'  => 'SourceReportsQuery',
+				'root'       => 'sourceReports',
+				'collection' => 'reports',
+				'query'      => 'query SourceReportsQuery($data: GetSourceReportsInput!){ sourceReports(data:$data){ meta{ totalCount reportStart reportEnd } reports{ source revenue netRevenue pageviews sessions impressions pageviewsRpm sessionsRpm monetizablePageviews monetizablePageviewsRpm monetizableSessions monetizableSessionsRpm impressionsPerPageview impressionsPerSession impressionsPerMonetizablePageview impressionsPerMonetizableSession } } }',
+			),
+			'ad_units' => array(
+				'operation'  => 'AdunitsMetricsQuery',
+				'root'       => 'adunitsMetrics',
+				'collection' => '',
+				'query'      => 'query AdunitsMetricsQuery($data: GetAdunitsMetricsInput!){ adunitsMetrics(data:$data){ meta{ totalCount reportStart reportEnd } parentAdunits{ adunit revenue paidImpressions viewability fillrate sessionRpm pageviewRpm monetizableSessionRpm monetizablePageviewRpm cpm } childAdunits{ adunit deviceType revenue paidImpressions viewability fillrate sessionRpm pageviewRpm monetizableSessionRpm monetizablePageviewRpm cpm } } }',
+			),
+		);
+
+		if ( ! isset( $contracts[ $action ] ) ) {
+			throw new \InvalidArgumentException( 'Unsupported Mediavine dimensional action.' );
+		}
+
+		return $contracts[ $action ];
 	}
 
 	/**

--- a/inc/Abilities/Analytics/MediavineReportsAbilities.php
+++ b/inc/Abilities/Analytics/MediavineReportsAbilities.php
@@ -1123,6 +1123,11 @@ class MediavineReportsAbilities {
 
 		foreach ( $field_types as $field => $type ) {
 			$value = $row[ $field ] ?? null;
+			// Country netRevenue is returned in 1/10,000 dollar units, unlike the
+			// dollar-denominated source report field with the same name.
+			if ( 'countries' === $action && 'netRevenue' === $field && null !== $value ) {
+				$value = (float) $value / 10000;
+			}
 			if ( 'string' === $type ) {
 				$normalized[ $field ] = null === $value ? null : (string) $value;
 			} elseif ( 'integer' === $type ) {

--- a/inc/Cli/CommandRegistry.php
+++ b/inc/Cli/CommandRegistry.php
@@ -38,6 +38,7 @@ final class CommandRegistry {
 		return array(
 			'datamachine analytics ga'        => GoogleAnalyticsCommand::class,
 			'datamachine analytics gsc'       => GoogleSearchConsoleCommand::class,
+			'datamachine analytics mediavine' => MediavineCommand::class,
 			'datamachine analytics bing'      => Commands\BingWebmasterCommand::class,
 			'datamachine analytics pagespeed' => PageSpeedCommand::class,
 			'datamachine media'               => MediaHygieneCommand::class,

--- a/inc/Cli/MediavineCommand.php
+++ b/inc/Cli/MediavineCommand.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Mediavine dimensional reports WP-CLI command.
+ *
+ * @package DataMachineBusiness\Cli
+ */
+
+namespace DataMachineBusiness\Cli;
+
+use DataMachine\Cli\BaseCommand;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+class MediavineCommand extends BaseCommand {
+
+	/**
+	 * Available source-native dimensional actions.
+	 *
+	 * @return array<string,string> Action name => short description.
+	 */
+	public static function actions(): array {
+		return array(
+			'devices'   => 'Revenue and delivery metrics by device bucket',
+			'countries' => 'Country-level revenue and delivery metrics',
+			'sources'   => 'Revenue by Mediavine normalized acquisition source',
+			'ad_units'  => 'Parent and child ad-unit revenue by explicit grain',
+		);
+	}
+
+	/**
+	 * Query Mediavine dimensional revenue reports.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Action to perform: devices, countries, sources, or ad_units.
+	 *
+	 * [--site-id=<id>]
+	 * : Mediavine GraphQL global InternalSite ID or numeric internal site id.
+	 *
+	 * [--start-date=<date>]
+	 * : Start date in YYYY-MM-DD format (default: 28 days ago).
+	 *
+	 * [--end-date=<date>]
+	 * : End date in YYYY-MM-DD format (default: yesterday).
+	 *
+	 * [--period=<label>]
+	 * : Optional period label included in each result row.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine analytics mediavine devices
+	 *     wp datamachine analytics mediavine countries --start-date=2026-07-01 --end-date=2026-07-07
+	 *     wp datamachine analytics mediavine sources --format=json
+	 *     wp datamachine analytics mediavine ad_units --format=csv
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$input = array( 'action' => $args[0] ?? '' );
+		foreach ( array( 'site-id' => 'site_id', 'start-date' => 'start_date', 'end-date' => 'end_date', 'period' => 'period' ) as $flag => $key ) {
+			if ( isset( $assoc_args[ $flag ] ) ) {
+				$input[ $key ] = $assoc_args[ $flag ];
+			}
+		}
+
+		$ability = wp_get_ability( 'datamachine/mediavine-reports' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'Ability datamachine/mediavine-reports is not registered. Ensure Data Machine Business is active and WordPress 6.9+.' );
+			return;
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? 'Unknown error.' );
+			return;
+		}
+
+		if ( 'json' === ( $assoc_args['format'] ?? 'table' ) ) {
+			WP_CLI::line( self::jsonOutput( $result ) );
+			return;
+		}
+
+		$rows = self::tabularRows( $result );
+		if ( empty( $rows ) ) {
+			WP_CLI::success( 'Mediavine report returned no rows. Use --format=json for the complete response envelope.' );
+			return;
+		}
+
+		$this->format_items( $rows, self::tableFields( (string) $result['action'] ), $assoc_args );
+		WP_CLI::log( sprintf( '%d results', $result['results_count'] ?? count( $rows ) ) );
+	}
+
+	/**
+	 * Encode the complete typed ability envelope for JSON output.
+	 *
+	 * @param array $result Ability result.
+	 * @return string
+	 */
+	public static function jsonOutput( array $result ): string {
+		$encoded = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION );
+		return false === $encoded ? '{}' : $encoded;
+	}
+
+	/**
+	 * Return stable table/CSV field order for an action.
+	 *
+	 * @param string $action Dimensional action.
+	 * @return array<int,string>
+	 */
+	public static function tableFields( string $action ): array {
+		$fields = array(
+			'devices'   => array( 'label', 'pageviewRpm', 'pageviews', 'revenue', 'sessionRpm', 'sessions', 'monetizablePageviews', 'monetizableSessions', 'monetizablePageviewRpm', 'monetizableSessionRpm', 'period' ),
+			'countries' => array( 'country', 'pageviews', 'pageviewsPercentage', 'sessions', 'sessionsPercentage', 'netRevenue', 'pageRevenue', 'impressions', 'paidImpressions', 'cpm', 'fillrate', 'viewability', 'pageviewsRpm', 'sessionsRpm', 'monetizablePageviews', 'monetizablePageviewsPercentage', 'monetizablePageviewsRpm', 'monetizableSessions', 'monetizableSessionsPercentage', 'monetizableSessionsRpm', 'period' ),
+			'sources'   => array( 'source', 'revenue', 'netRevenue', 'pageviews', 'sessions', 'impressions', 'pageviewsRpm', 'sessionsRpm', 'monetizablePageviews', 'monetizablePageviewsRpm', 'monetizableSessions', 'monetizableSessionsRpm', 'impressionsPerPageview', 'impressionsPerSession', 'impressionsPerMonetizablePageview', 'impressionsPerMonetizableSession', 'period' ),
+			'ad_units'  => array( 'grain', 'adunit', 'deviceType', 'revenue', 'paidImpressions', 'viewability', 'fillrate', 'sessionRpm', 'pageviewRpm', 'monetizableSessionRpm', 'monetizablePageviewRpm', 'cpm', 'period' ),
+		);
+
+		return $fields[ $action ] ?? array();
+	}
+
+	/**
+	 * Normalize result rows to stable table/CSV columns.
+	 *
+	 * @param array $result Ability result.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function tabularRows( array $result ): array {
+		$fields = self::tableFields( (string) ( $result['action'] ?? '' ) );
+		$rows   = array();
+
+		foreach ( $result['results'] ?? array() as $result_row ) {
+			if ( ! is_array( $result_row ) ) {
+				continue;
+			}
+
+			$row = array();
+			foreach ( $fields as $field ) {
+				$row[ $field ] = $result_row[ $field ] ?? null;
+			}
+			$rows[] = $row;
+		}
+
+		return $rows;
+	}
+}

--- a/inc/Runtime/AgentsMdSections.php
+++ b/inc/Runtime/AgentsMdSections.php
@@ -68,7 +68,7 @@ final class AgentsMdSections {
 			array( self::class, 'render' ),
 			array(
 				'label'       => 'Data Machine Business',
-				'description' => 'Business-owned WP-CLI surface (Google Analytics, Search Console, Bing, PageSpeed, media hygiene).',
+				'description' => 'Business-owned WP-CLI surface (Google Analytics, Search Console, Mediavine, Bing, PageSpeed, media hygiene).',
 				'owner'       => 'data-machine-business',
 				'freshness'   => 'snapshot',
 				'conditions'  => 'Registered when Data Machine Business and composable memory section registration are available.',

--- a/tests/Unit/Abilities/Analytics/MediavineReportsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/MediavineReportsAbilitiesTest.php
@@ -12,6 +12,14 @@ use WP_UnitTestCase;
 
 class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 
+	private function dimensionalFixtures(): array {
+		$json = file_get_contents( dirname( __DIR__, 3 ) . '/fixtures/mediavine-dimensional-reports.json' );
+		$this->assertIsString( $json );
+		$fixtures = json_decode( $json, true );
+		$this->assertIsArray( $fixtures );
+		return $fixtures;
+	}
+
 	public function test_pages_request_uses_current_graphql_contract(): void {
 		$body = MediavineReportsAbilities::buildPagesRequestBody( 'global-id', '2026-06-01', '2026-06-30' );
 
@@ -422,5 +430,104 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 		$source = file_get_contents( dirname( __DIR__, 4 ) . '/inc/Abilities/Analytics/MediavineReportsAbilities.php' );
 
 		$this->assertDoesNotMatchRegularExpression( '/extrachill\.com|community\.extra|events\.extra|wire\.extra|artist\.extra/i', $source );
+	}
+
+	public function test_dimensional_requests_use_confirmed_operations_input_types_and_fields(): void {
+		$contracts = array(
+			'devices' => array( 'DevicesMetricsSummaryQuery', 'GetDevicesMetricsSummaryInput!', 'devicesMetricsSummary(data:$data)', array( 'label', 'monetizablePageviewRpm' ) ),
+			'countries' => array( 'CountriesReportQuery', 'GetCountriesReportInput!', 'countriesReport(data:$data)', array( 'country', 'pageviewsPercentage', 'monetizableSessionsRpm' ) ),
+			'sources' => array( 'SourceReportsQuery', 'GetSourceReportsInput!', 'sourceReports(data:$data)', array( 'source', 'netRevenue', 'impressionsPerMonetizableSession' ) ),
+			'ad_units' => array( 'AdunitsMetricsQuery', 'GetAdunitsMetricsInput!', 'adunitsMetrics(data:$data)', array( 'parentAdunits', 'childAdunits', 'deviceType' ) ),
+		);
+
+		foreach ( $contracts as $action => $expected ) {
+			$body = MediavineReportsAbilities::buildDimensionalRequestBody( $action, 'global-id', '2026-07-10', '2026-07-16' );
+			$this->assertSame( $expected[0], $body['operationName'], $action );
+			$this->assertStringContainsString( $expected[1], $body['query'], $action );
+			$this->assertStringContainsString( $expected[2], $body['query'], $action );
+			foreach ( $expected[3] as $field ) {
+				$this->assertStringContainsString( $field, $body['query'], $action . ':' . $field );
+			}
+			$this->assertSame( 'global-id', $body['variables']['data']['siteId'] );
+			$this->assertSame( '2026-07-10T00:00:00.000Z', $body['variables']['data']['startDate'] );
+			$this->assertSame( '2026-07-16T23:59:59.999Z', $body['variables']['data']['endDate'] );
+			$this->assertArrayNotHasKey( 'demandSources', $body['variables']['data'] );
+		}
+
+		$this->assertStringNotContainsString( 'demandSources', MediavineReportsAbilities::buildDimensionalRequestBody( 'sources', 'global-id', '2026-07-10', '2026-07-16' )['query'] );
+	}
+
+	public function test_dimensional_fixture_parsers_preserve_labels_and_numeric_types(): void {
+		$fixtures = $this->dimensionalFixtures();
+
+		$devices = MediavineReportsAbilities::parseDimensionalPayload( 'devices', $fixtures['devices'], '2026-07' );
+		$this->assertSame( 'Mobile', $devices['rows'][0]['label'] );
+		$this->assertSame( 1200, $devices['rows'][0]['pageviews'] );
+		$this->assertSame( 12.5, $devices['rows'][0]['pageviewRpm'] );
+		$this->assertNull( $devices['rows'][1]['label'] );
+
+		$countries = MediavineReportsAbilities::parseDimensionalPayload( 'countries', $fixtures['countries'], '2026-07' );
+		$this->assertSame( 'United States', $countries['rows'][0]['country'] );
+		$this->assertSame( 'Unknown', $countries['rows'][1]['country'] );
+		$this->assertSame( 5000, $countries['rows'][0]['impressions'] );
+		$this->assertSame( 19.0, $countries['rows'][0]['netRevenue'] );
+
+		$sources = MediavineReportsAbilities::parseDimensionalPayload( 'sources', $fixtures['sources'], '2026-07' );
+		$this->assertSame( 'Search', $sources['rows'][0]['source'] );
+		$this->assertNull( $sources['rows'][1]['source'] );
+		$this->assertSame( 6.32, $sources['rows'][0]['impressionsPerMonetizablePageview'] );
+
+		foreach ( array( $devices, $countries, $sources ) as $parsed ) {
+			$this->assertSame( 2, $parsed['meta']['totalCount'] );
+			$this->assertSame( '2026/07/10', $parsed['meta']['reportStart'] );
+			$this->assertSame( '2026-07', $parsed['rows'][0]['period'] );
+		}
+	}
+
+	public function test_ad_unit_parser_keeps_parent_and_child_device_grains_unambiguous(): void {
+		$fixtures = $this->dimensionalFixtures();
+		$parsed   = MediavineReportsAbilities::parseDimensionalPayload( 'ad_units', $fixtures['ad_units'], '2026-07' );
+
+		$this->assertSame( 2, count( $parsed['rows'] ) );
+		$this->assertSame( 'parent', $parsed['rows'][0]['grain'] );
+		$this->assertNull( $parsed['rows'][0]['deviceType'] );
+		$this->assertSame( 'child', $parsed['rows'][1]['grain'] );
+		$this->assertSame( 'Mobile', $parsed['rows'][1]['deviceType'] );
+		$this->assertSame( 7000, $parsed['rows'][1]['paidImpressions'] );
+	}
+
+	public function test_dimensional_outputs_validate_and_include_complete_provenance(): void {
+		$fixtures = $this->dimensionalFixtures();
+		$schema   = MediavineReportsAbilities::outputSchema();
+		$relay    = base64_encode( 'InternalSite:11476' );
+
+		foreach ( array( 'devices', 'countries', 'sources', 'ad_units' ) as $action ) {
+			$parsed = MediavineReportsAbilities::parseDimensionalPayload( $action, $fixtures[ $action ], '2026-07' );
+			$output = MediavineReportsAbilities::buildDimensionalResult( $action, '11476', $relay, '2026-07-10', '2026-07-16', '2026-07', $parsed );
+			$valid  = rest_validate_value_from_schema( $output, $schema, 'output' );
+
+			$this->assertTrue( $valid, $action . ': ' . ( is_wp_error( $valid ) ? $valid->get_error_message() : '' ) );
+			$this->assertSame( 2, $output['results_count'] );
+			$this->assertSame( 2, $output['provenance']['period']['row_count'] );
+			$this->assertSame( '2026/07/10', $output['provenance']['period']['canonical']['start'] );
+			$this->assertSame( $action, $output['provenance']['source']['action'] );
+			$this->assertFalse( $output['provenance']['host_attribution']['available'] );
+			$this->assertStringContainsString( 'source-native aggregate buckets', $output['provenance']['host_attribution']['reason'] );
+		}
+	}
+
+	public function test_dimensional_fixtures_and_outputs_contain_no_secret_material(): void {
+		$fixtures = $this->dimensionalFixtures();
+		$blob     = wp_json_encode( $fixtures );
+		$relay    = base64_encode( 'InternalSite:11476' );
+		foreach ( array( 'devices', 'countries', 'sources', 'ad_units' ) as $action ) {
+			$parsed = MediavineReportsAbilities::parseDimensionalPayload( $action, $fixtures[ $action ], '2026-07' );
+			$blob  .= wp_json_encode( MediavineReportsAbilities::buildDimensionalResult( $action, '11476', $relay, '2026-07-10', '2026-07-16', '2026-07', $parsed ) );
+		}
+		$forbidden = array( 'password', 'Bearer ', 'accessToken', 'refreshToken', 'userId' );
+
+		foreach ( $forbidden as $needle ) {
+			$this->assertStringNotContainsString( $needle, $blob );
+		}
 	}
 }

--- a/tests/Unit/AgentsMdActionsTest.php
+++ b/tests/Unit/AgentsMdActionsTest.php
@@ -38,6 +38,7 @@ class AgentsMdActionsTest extends \PHPUnit\Framework\TestCase {
 		return array(
 			'GSC'        => array( 'inc/Cli/GoogleSearchConsoleCommand.php' ),
 			'GA'         => array( 'inc/Cli/GoogleAnalyticsCommand.php' ),
+			'Mediavine'  => array( 'inc/Cli/MediavineCommand.php' ),
 			'PageSpeed'  => array( 'inc/Cli/PageSpeedCommand.php' ),
 			'Media'      => array( 'inc/Cli/MediaHygieneCommand.php' ),
 			'Bing'       => array( 'inc/Cli/Commands/BingWebmasterCommand.php' ),

--- a/tests/Unit/Cli/MediavineCommandTest.php
+++ b/tests/Unit/Cli/MediavineCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Mediavine CLI output contract tests.
+ *
+ * @package DataMachineBusiness\Tests\Unit\Cli
+ */
+
+namespace DataMachineBusiness\Tests\Unit\Cli;
+
+use DataMachineBusiness\Cli\MediavineCommand;
+use WP_UnitTestCase;
+
+class MediavineCommandTest extends WP_UnitTestCase {
+
+	public function test_json_output_preserves_complete_typed_ability_envelope(): void {
+		$result = array(
+			'success' => true,
+			'action' => 'devices',
+			'site_id' => 'relay-id',
+			'date_range' => array( 'start_date' => '2026-07-10', 'end_date' => '2026-07-16' ),
+			'results_count' => 1,
+			'results' => array( array( 'label' => 'Mobile', 'pageviews' => 1200, 'revenue' => 15.0, 'period' => '2026-07' ) ),
+			'provenance' => array( 'source' => array( 'operation' => 'DevicesMetricsSummaryQuery' ) ),
+		);
+
+		$this->assertSame( $result, json_decode( MediavineCommand::jsonOutput( $result ), true ) );
+		$this->assertIsInt( json_decode( MediavineCommand::jsonOutput( $result ), true )['results'][0]['pageviews'] );
+	}
+
+	public function test_table_and_csv_rows_use_stable_action_specific_columns(): void {
+		$result = array(
+			'action' => 'ad_units',
+			'results' => array(
+				array( 'adunit' => 'Content', 'grain' => 'parent', 'deviceType' => null, 'revenue' => 25.0, 'period' => '2026-07' ),
+			),
+		);
+
+		$rows = MediavineCommand::tabularRows( $result );
+		$this->assertSame( MediavineCommand::tableFields( 'ad_units' ), array_keys( $rows[0] ) );
+		$this->assertSame( 'parent', $rows[0]['grain'] );
+		$this->assertNull( $rows[0]['deviceType'] );
+		$this->assertSame( 25.0, $rows[0]['revenue'] );
+	}
+
+	public function test_cli_exposes_only_bounded_dimensional_actions(): void {
+		$this->assertSame( array( 'devices', 'countries', 'sources', 'ad_units' ), array_keys( MediavineCommand::actions() ) );
+	}
+}

--- a/tests/fixtures/mediavine-dimensional-reports.json
+++ b/tests/fixtures/mediavine-dimensional-reports.json
@@ -15,7 +15,7 @@
       "countriesReport": {
         "meta": { "totalCount": 2, "reportStart": "2026/07/10", "reportEnd": "2026/07/16" },
         "countries": [
-          { "country": "United States", "pageviews": 900, "pageviewsPercentage": 75, "sessions": 700, "sessionsPercentage": 77.78, "netRevenue": 19, "pageRevenue": 18, "impressions": 5000, "paidImpressions": 4500, "cpm": 4.22, "fillrate": 0.95, "viewability": 0.7, "pageviewsRpm": 20, "sessionsRpm": 25.71, "monetizablePageviews": 850, "monetizablePageviewsPercentage": 77.27, "monetizablePageviewsRpm": 21.18, "monetizableSessions": 650, "monetizableSessionsPercentage": 76.47, "monetizableSessionsRpm": 27.69 },
+          { "country": "United States", "pageviews": 900, "pageviewsPercentage": 75, "sessions": 700, "sessionsPercentage": 77.78, "netRevenue": 190000, "pageRevenue": 18, "impressions": 5000, "paidImpressions": 4500, "cpm": 4.22, "fillrate": 0.95, "viewability": 0.7, "pageviewsRpm": 20, "sessionsRpm": 25.71, "monetizablePageviews": 850, "monetizablePageviewsPercentage": 77.27, "monetizablePageviewsRpm": 21.18, "monetizableSessions": 650, "monetizableSessionsPercentage": 76.47, "monetizableSessionsRpm": 27.69 },
           { "country": "Unknown", "pageviews": 1, "pageviewsPercentage": 0.08, "sessions": 1, "sessionsPercentage": 0.11, "netRevenue": 0, "pageRevenue": 0, "impressions": 0, "paidImpressions": 0, "cpm": 0, "fillrate": 0, "viewability": 0, "pageviewsRpm": 0, "sessionsRpm": 0, "monetizablePageviews": 0, "monetizablePageviewsPercentage": 0, "monetizablePageviewsRpm": 0, "monetizableSessions": 0, "monetizableSessionsPercentage": 0, "monetizableSessionsRpm": 0 }
         ]
       }

--- a/tests/fixtures/mediavine-dimensional-reports.json
+++ b/tests/fixtures/mediavine-dimensional-reports.json
@@ -1,0 +1,48 @@
+{
+  "devices": {
+    "data": {
+      "devicesMetricsSummary": {
+        "meta": { "totalCount": 2, "reportStart": "2026/07/10", "reportEnd": "2026/07/16" },
+        "devices": [
+          { "label": "Mobile", "pageviewRpm": 12.5, "pageviews": 1200, "revenue": 15, "sessionRpm": 16.67, "sessions": 900, "monetizablePageviews": 1100, "monetizableSessions": 850, "monetizablePageviewRpm": 13.64, "monetizableSessionRpm": 17.65 },
+          { "label": null, "pageviewRpm": 1, "pageviews": 5, "revenue": 0.01, "sessionRpm": 2, "sessions": 4, "monetizablePageviews": 3, "monetizableSessions": 2, "monetizablePageviewRpm": 3.33, "monetizableSessionRpm": 5 }
+        ]
+      }
+    }
+  },
+  "countries": {
+    "data": {
+      "countriesReport": {
+        "meta": { "totalCount": 2, "reportStart": "2026/07/10", "reportEnd": "2026/07/16" },
+        "countries": [
+          { "country": "United States", "pageviews": 900, "pageviewsPercentage": 75, "sessions": 700, "sessionsPercentage": 77.78, "netRevenue": 19, "pageRevenue": 18, "impressions": 5000, "paidImpressions": 4500, "cpm": 4.22, "fillrate": 0.95, "viewability": 0.7, "pageviewsRpm": 20, "sessionsRpm": 25.71, "monetizablePageviews": 850, "monetizablePageviewsPercentage": 77.27, "monetizablePageviewsRpm": 21.18, "monetizableSessions": 650, "monetizableSessionsPercentage": 76.47, "monetizableSessionsRpm": 27.69 },
+          { "country": "Unknown", "pageviews": 1, "pageviewsPercentage": 0.08, "sessions": 1, "sessionsPercentage": 0.11, "netRevenue": 0, "pageRevenue": 0, "impressions": 0, "paidImpressions": 0, "cpm": 0, "fillrate": 0, "viewability": 0, "pageviewsRpm": 0, "sessionsRpm": 0, "monetizablePageviews": 0, "monetizablePageviewsPercentage": 0, "monetizablePageviewsRpm": 0, "monetizableSessions": 0, "monetizableSessionsPercentage": 0, "monetizableSessionsRpm": 0 }
+        ]
+      }
+    }
+  },
+  "sources": {
+    "data": {
+      "sourceReports": {
+        "meta": { "totalCount": 2, "reportStart": "2026/07/10", "reportEnd": "2026/07/16" },
+        "reports": [
+          { "source": "Search", "revenue": 21, "netRevenue": 20, "pageviews": 1000, "sessions": 800, "impressions": 6000, "pageviewsRpm": 21, "sessionsRpm": 26.25, "monetizablePageviews": 950, "monetizablePageviewsRpm": 22.11, "monetizableSessions": 760, "monetizableSessionsRpm": 27.63, "impressionsPerPageview": 6, "impressionsPerSession": 7.5, "impressionsPerMonetizablePageview": 6.32, "impressionsPerMonetizableSession": 7.89 },
+          { "source": null, "revenue": 0, "netRevenue": 0, "pageviews": 2, "sessions": 2, "impressions": 1, "pageviewsRpm": 0, "sessionsRpm": 0, "monetizablePageviews": 1, "monetizablePageviewsRpm": 0, "monetizableSessions": 1, "monetizableSessionsRpm": 0, "impressionsPerPageview": 0.5, "impressionsPerSession": 0.5, "impressionsPerMonetizablePageview": 1, "impressionsPerMonetizableSession": 1 }
+        ]
+      }
+    }
+  },
+  "ad_units": {
+    "data": {
+      "adunitsMetrics": {
+        "meta": { "totalCount": 2, "reportStart": "2026/07/10", "reportEnd": "2026/07/16" },
+        "parentAdunits": [
+          { "adunit": "Content", "revenue": 25, "paidImpressions": 10000, "viewability": 0.71, "fillrate": 0.96, "sessionRpm": 27.78, "pageviewRpm": 20.83, "monetizableSessionRpm": 29.41, "monetizablePageviewRpm": 22.73, "cpm": 2.5 }
+        ],
+        "childAdunits": [
+          { "adunit": "Content", "deviceType": "Mobile", "revenue": 18, "paidImpressions": 7000, "viewability": 0.74, "fillrate": 0.97, "sessionRpm": 30, "pageviewRpm": 24, "monetizableSessionRpm": 31.58, "monetizablePageviewRpm": 25.71, "cpm": 2.57 }
+        ]
+      }
+    }
+  }
+}

--- a/tests/mediavine-dimensional-smoke.php
+++ b/tests/mediavine-dimensional-smoke.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Dependency-free smoke test for Mediavine dimensional contracts.
+ *
+ * Run with: php tests/mediavine-dimensional-smoke.php
+ *
+ * @package DataMachineBusiness\Tests
+ */
+
+namespace DataMachine\Cli {
+	class BaseCommand {
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ );
+
+	class WP_Error {
+		public function __construct( private string $code, private string $message ) {
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+
+	class WP_CLI {
+	}
+
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	function wp_json_encode( $value, int $flags = 0 ) {
+		return json_encode( $value, $flags );
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Analytics/MediavineReportsAbilities.php';
+	require_once dirname( __DIR__ ) . '/inc/Cli/MediavineCommand.php';
+	require_once dirname( __DIR__ ) . '/inc/Cli/CommandRegistry.php';
+
+	use DataMachineBusiness\Abilities\Analytics\MediavineReportsAbilities;
+	use DataMachineBusiness\Cli\MediavineCommand;
+	use DataMachineBusiness\Cli\CommandRegistry;
+
+	$fixtures = json_decode( (string) file_get_contents( __DIR__ . '/fixtures/mediavine-dimensional-reports.json' ), true );
+	$failures = array();
+	$passes   = 0;
+
+	$assert = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void {
+		if ( $condition ) {
+			$passes++;
+			return;
+		}
+		$failures[] = $label;
+	};
+
+	$expected_contracts = array(
+		'devices'   => array( 'DevicesMetricsSummaryQuery', 'GetDevicesMetricsSummaryInput!', 'devicesMetricsSummary' ),
+		'countries' => array( 'CountriesReportQuery', 'GetCountriesReportInput!', 'countriesReport' ),
+		'sources'   => array( 'SourceReportsQuery', 'GetSourceReportsInput!', 'sourceReports' ),
+		'ad_units'  => array( 'AdunitsMetricsQuery', 'GetAdunitsMetricsInput!', 'adunitsMetrics' ),
+	);
+
+	foreach ( $expected_contracts as $action => $expected ) {
+		$body   = MediavineReportsAbilities::buildDimensionalRequestBody( $action, 'relay-id', '2026-07-10', '2026-07-16' );
+		$parsed = MediavineReportsAbilities::parseDimensionalPayload( $action, $fixtures[ $action ], '2026-07' );
+		$assert( $expected[0] === $body['operationName'], $action . ' operation name' );
+		$assert( str_contains( $body['query'], $expected[1] ), $action . ' input type' );
+		$assert( str_contains( $body['query'], $expected[2] ), $action . ' root operation' );
+		$assert( ! is_wp_error( $parsed ) && 2 === count( $parsed['rows'] ), $action . ' parses two fixture rows' );
+		$assert( 2 === $parsed['meta']['totalCount'], $action . ' typed row count' );
+	}
+
+	$ad_units = MediavineReportsAbilities::parseDimensionalPayload( 'ad_units', $fixtures['ad_units'], '2026-07' );
+	$assert( 'parent' === $ad_units['rows'][0]['grain'] && null === $ad_units['rows'][0]['deviceType'], 'parent ad-unit grain' );
+	$assert( 'child' === $ad_units['rows'][1]['grain'] && 'Mobile' === $ad_units['rows'][1]['deviceType'], 'child ad-unit device grain' );
+
+	$envelope = array( 'success' => true, 'action' => 'ad_units', 'results' => $ad_units['rows'], 'provenance' => array( 'source' => array( 'operation' => 'AdunitsMetricsQuery' ) ) );
+	$assert( $envelope === json_decode( MediavineCommand::jsonOutput( $envelope ), true ), 'CLI JSON preserves envelope' );
+	$assert( MediavineCommand::tableFields( 'ad_units' ) === array_keys( MediavineCommand::tabularRows( $envelope )[0] ), 'CLI table/CSV fields are stable' );
+	$assert( MediavineCommand::class === CommandRegistry::map()['datamachine analytics mediavine'], 'CLI command is registered' );
+	foreach ( array( 'password', 'Bearer ', 'accessToken', 'refreshToken', 'userId' ) as $secret_key ) {
+		$assert( ! str_contains( (string) wp_json_encode( $fixtures ), $secret_key ), 'fixtures omit ' . $secret_key );
+	}
+
+	if ( ! empty( $failures ) ) {
+		fwrite( STDERR, "Mediavine dimensional smoke failed:\n - " . implode( "\n - ", $failures ) . "\n" );
+		exit( 1 );
+	}
+
+	echo "Mediavine dimensional smoke: {$passes} assertions passed.\n";
+}

--- a/tests/verify-render.php
+++ b/tests/verify-render.php
@@ -31,6 +31,7 @@ namespace {
 
 	require_once $root . '/inc/Cli/GoogleSearchConsoleCommand.php';
 	require_once $root . '/inc/Cli/GoogleAnalyticsCommand.php';
+	require_once $root . '/inc/Cli/MediavineCommand.php';
 	require_once $root . '/inc/Cli/PageSpeedCommand.php';
 	require_once $root . '/inc/Cli/MediaHygieneCommand.php';
 	require_once $root . '/inc/Cli/Commands/BingWebmasterCommand.php';
@@ -60,6 +61,9 @@ namespace {
 	}
 	if ( false === strpos( $output, '`diagnose`' ) ) {
 		$failures[] = "Media action 'diagnose' missing from rendered output";
+	}
+	if ( false === strpos( $output, '`ad_units`' ) ) {
+		$failures[] = "Mediavine action 'ad_units' missing from rendered output";
 	}
 
 	if ( empty( $failures ) ) {


### PR DESCRIPTION
## Summary

- Add bounded `devices`, `countries`, `sources`, and `ad_units` actions to `datamachine/mediavine-reports` using the confirmed source-native GraphQL operations.
- Add `wp datamachine analytics mediavine <action>` with complete-envelope JSON and stable action-specific table/CSV output.
- Add typed parsers, provenance, explicit parent/child ad-unit grain, sanitized fixtures/tests, and precise report documentation.

Closes #88

## Supported Reports

| Action | GraphQL operation | Input type | Output grain |
|---|---|---|---|
| `devices` | `devicesMetricsSummary` | `GetDevicesMetricsSummaryInput!` | Device label |
| `countries` | `countriesReport` | `GetCountriesReportInput!` | Country only |
| `sources` | `sourceReports` | `GetSourceReportsInput!` | Mediavine normalized source bucket |
| `ad_units` | `adunitsMetrics` | `GetAdunitsMetricsInput!` | Parent ad unit or child ad unit x `deviceType` |

Existing `pages`, `summary`, and `backfill` actions remain unchanged.

## Output Semantics

- Counts are integers; revenue, RPM, CPM, percentage, fill-rate, viewability, and impression-ratio metrics are floats.
- Unknown source literals are preserved, while absent labels remain JSON `null`.
- `sources.source` is Mediavine's normalized acquisition category, not raw referrer data or GA4 source/medium.
- Country is the finest geography exposed.
- Parent ad-unit rows carry `grain=parent` and `deviceType=null`; child rows carry `grain=child` and preserve `deviceType`.
- JSON output preserves the complete ability envelope and zero-fraction floats. Table/CSV use deterministic action-specific columns.
- Provenance retains requested/canonical dates, operation identity, normalized site identifiers, returned row counts, and explicit host-attribution limits.

## Authenticated Smoke

A bounded read-only smoke for 2026-07-10 through 2026-07-16 printed only sanitized labels and metrics:

| Action | Success | Rows | Sanitized sample |
|---|---:|---:|---|
| `devices` | yes | 4 | desktop: 5,911 pageviews, $26.89 revenue, $4.55 pageview RPM |
| `countries` | yes | 104 | United States: 5,522 pageviews, $83.62 page revenue |
| `sources` | yes | 6 | bing: 681 pageviews, $13.43 revenue |
| `ad_units` | yes | 23 | Adhesion: 14,429 paid impressions, $21.08 revenue |

All four payload types also confirmed the expected `meta` field through authenticated schema introspection.

## Verification

- `php tests/mediavine-dimensional-smoke.php` (30 assertions passed)
- Worktree implementation evaluated inside WordPress: all four action outputs passed `rest_validate_value_from_schema()`
- `php tests/verify-render.php` (passed; Mediavine command/actions rendered)
- `php tests/ability-registration-lifecycle-smoke.php` (24 assertions passed)
- PHP syntax checks passed for all changed PHP files
- `git diff --check` passed
- Authenticated bounded smoke passed for all four operations

Full Homeboy/PHPUnit/PHPCS could not run safely on the controller: Homeboy refused at a load average above 129 on 8 CPUs, no eligible Lab runner was connected, no standalone PHPUnit binary is installed, and the only discovered PHPCS shim points to a missing dependency. The unrelated stale GSC registration smoke remains tracked in #77.

## Security And Privacy

- No credentials, bearer/refresh tokens, user IDs, or authenticated payloads are stored in code, fixtures, logs, errors, or PR evidence.
- Fixtures contain sanitized synthetic values only.
- Existing server-side authentication, token caching, site-ID normalization, date handling, and GraphQL error handling are reused.
- No persistence or GA4 reconstruction is added.

## Residual Limitations

- `demandSources` remains intentionally out of scope.
- No raw referrer, sub-country geography, page x dimension reports, arbitrary report builder, or modeled revenue allocation is exposed.
- Full repository review awaits a healthy controller or connected Lab runner.