### PR TITLE
fix: surface Mediavine integrity warnings

### DIFF
--- a/docs/mediavine.md
+++ b/docs/mediavine.md
@@ -33,6 +33,19 @@ Mediavine returns country `netRevenue` in 1/10,000 dollar units; the ability nor
 
 Unknown string literals from Mediavine are preserved. An absent dimension remains JSON `null`, which is distinct from a literal `Unknown` bucket.
 
+## Integrity Diagnostics
+
+Dimensional results include an additive `diagnostics` block with `status`, `warning_count`, and machine-readable `warnings`. For device, country, and source rows, the ability checks only the source fields with established subset semantics:
+
+- `monetizablePageviews <= pageviews`
+- `monetizableSessions <= sessions`
+
+Each warning identifies the zero-based row index and source dimension, the violated invariant, both observed field/value pairs, and `source_semantics=unknown_upstream`. The normalized source row remains unchanged. Zero counts, null dimensions, and literal unknown buckets are not warnings unless the counts themselves violate one of these relationships.
+
+Mediavine's GraphQL schema exposes these ordinary and monetizable counts as separate scalar fields but does not document alternate semantics for unclassified buckets. A live `devicesMetricsSummary` report has returned an `other` bucket that violates both relationships while named device rows remain coherent. The dashboard/API evidence does not establish whether this is special unclassified-bucket behavior or an upstream defect, so anomalous rows must not support causal or economic conclusions until Mediavine explains them.
+
+Table and CSV commands print visible warnings before their rows. JSON remains machine-readable and preserves the complete diagnostics envelope.
+
 ## Provenance
 
 Every result includes:

--- a/inc/Abilities/Analytics/MediavineReportsAbilities.php
+++ b/inc/Abilities/Analytics/MediavineReportsAbilities.php
@@ -276,6 +276,48 @@ class MediavineReportsAbilities {
 						),
 					),
 				),
+				'diagnostics'   => array(
+					'type'        => 'object',
+					'description' => 'Integrity diagnostics for source-native dimensional rows. Raw result rows are never changed by these checks.',
+					'required'    => array( 'status', 'warning_count', 'warnings' ),
+					'properties'  => array(
+						'status'        => array( 'type' => 'string', 'enum' => array( 'ok', 'warning' ) ),
+						'warning_count' => array( 'type' => 'integer' ),
+						'warnings'      => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'required'   => array( 'code', 'severity', 'row', 'invariant', 'observed', 'source_semantics', 'message' ),
+								'properties' => array(
+									'code'             => array( 'type' => 'string' ),
+									'severity'         => array( 'type' => 'string', 'enum' => array( 'warning' ) ),
+									'row'              => array(
+										'type'       => 'object',
+										'required'   => array( 'index', 'dimension', 'value' ),
+										'properties' => array(
+											'index'     => array( 'type' => 'integer' ),
+											'dimension' => array( 'type' => 'string' ),
+											'value'     => array( 'type' => array( 'string', 'null' ) ),
+										),
+									),
+									'invariant'         => array( 'type' => 'string' ),
+									'observed'          => array(
+										'type'       => 'object',
+										'required'   => array( 'subset_field', 'subset_value', 'total_field', 'total_value' ),
+										'properties' => array(
+											'subset_field' => array( 'type' => 'string' ),
+											'subset_value' => array( 'type' => 'integer' ),
+											'total_field'  => array( 'type' => 'string' ),
+											'total_value'  => array( 'type' => 'integer' ),
+										),
+									),
+									'source_semantics' => array( 'type' => 'string', 'enum' => array( 'unknown_upstream' ) ),
+									'message'           => array( 'type' => 'string' ),
+								),
+							),
+						),
+					),
+				),
 				'provenance'    => self::provenanceSchema(),
 				'error'         => array( 'type' => 'string' ),
 			),
@@ -1104,7 +1146,83 @@ class MediavineReportsAbilities {
 			),
 			'results_count' => count( $rows ),
 			'results'       => $rows,
+			'diagnostics'   => self::diagnoseDimensionalIntegrity( $action, $rows ),
 			'provenance'    => self::buildProvenance( $action, $contract['operation'], $requested_site_id, $site_id, $start_date, $end_date, $parsed['meta'] ?? array() ),
+		);
+	}
+
+	/**
+	 * Detect proven subset-count violations without changing source rows.
+	 *
+	 * Device, country, and source reports expose ordinary totals alongside their
+	 * monetizable subsets. An upstream bucket that violates either relationship
+	 * is retained verbatim and marked as unknown upstream semantics.
+	 *
+	 * @param string $action Dimensional action.
+	 * @param array  $rows   Normalized source rows.
+	 * @return array
+	 */
+	public static function diagnoseDimensionalIntegrity( string $action, array $rows ): array {
+		$warnings = array();
+		if ( ! in_array( $action, array( 'devices', 'countries', 'sources' ), true ) ) {
+			return array(
+				'status'        => 'ok',
+				'warning_count' => 0,
+				'warnings'      => array(),
+			);
+		}
+
+		$dimension = array(
+			'devices'   => 'label',
+			'countries' => 'country',
+			'sources'   => 'source',
+		)[ $action ];
+		$invariants = array(
+			array( 'monetizablePageviews', 'pageviews', 'monetizable_pageviews_exceed_pageviews' ),
+			array( 'monetizableSessions', 'sessions', 'monetizable_sessions_exceed_sessions' ),
+		);
+
+		foreach ( $rows as $index => $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			foreach ( $invariants as $invariant ) {
+				list( $subset_field, $total_field, $code ) = $invariant;
+				if ( ! array_key_exists( $subset_field, $row ) || ! array_key_exists( $total_field, $row ) ) {
+					continue;
+				}
+
+				$subset_value = (int) $row[ $subset_field ];
+				$total_value  = (int) $row[ $total_field ];
+				if ( $subset_value <= $total_value ) {
+					continue;
+				}
+
+				$warnings[] = array(
+					'code'             => $code,
+					'severity'         => 'warning',
+					'row'              => array(
+						'index'     => (int) $index,
+						'dimension' => $dimension,
+						'value'     => null === ( $row[ $dimension ] ?? null ) ? null : (string) $row[ $dimension ],
+					),
+					'invariant'         => $subset_field . ' <= ' . $total_field,
+					'observed'          => array(
+						'subset_field' => $subset_field,
+						'subset_value' => $subset_value,
+						'total_field'  => $total_field,
+						'total_value'  => $total_value,
+					),
+					'source_semantics' => 'unknown_upstream',
+					'message'           => 'The source row violates documented subset-count semantics. Upstream bucket semantics are unknown; raw values are preserved unchanged and should not support causal conclusions.',
+				);
+			}
+		}
+
+		return array(
+			'status'        => empty( $warnings ) ? 'ok' : 'warning',
+			'warning_count' => count( $warnings ),
+			'warnings'      => $warnings,
 		);
 	}
 

--- a/inc/Cli/MediavineCommand.php
+++ b/inc/Cli/MediavineCommand.php
@@ -95,6 +95,10 @@ class MediavineCommand extends BaseCommand {
 			return;
 		}
 
+		foreach ( self::integrityWarningMessages( $result ) as $warning ) {
+			WP_CLI::warning( $warning );
+		}
+
 		$rows = self::tabularRows( $result );
 		if ( empty( $rows ) ) {
 			WP_CLI::success( 'Mediavine report returned no rows. Use --format=json for the complete response envelope.' );
@@ -114,6 +118,38 @@ class MediavineCommand extends BaseCommand {
 	public static function jsonOutput( array $result ): string {
 		$encoded = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION );
 		return false === $encoded ? '{}' : $encoded;
+	}
+
+	/**
+	 * Render concise human warnings from machine-readable diagnostics.
+	 *
+	 * @param array $result Ability result.
+	 * @return array<int,string>
+	 */
+	public static function integrityWarningMessages( array $result ): array {
+		$messages = array();
+		foreach ( $result['diagnostics']['warnings'] ?? array() as $warning ) {
+			if ( ! is_array( $warning ) || ! is_array( $warning['row'] ?? null ) || ! is_array( $warning['observed'] ?? null ) ) {
+				continue;
+			}
+
+			$row      = $warning['row'];
+			$observed = $warning['observed'];
+			$value    = null === ( $row['value'] ?? null ) ? 'null' : (string) $row['value'];
+
+			$messages[] = sprintf(
+				'Mediavine integrity warning at row %d (%s=%s): %s=%d exceeds %s=%d. Upstream bucket semantics are unknown; raw values were preserved.',
+				(int) ( $row['index'] ?? 0 ),
+				(string) ( $row['dimension'] ?? 'dimension' ),
+				$value,
+				(string) ( $observed['subset_field'] ?? 'subset' ),
+				(int) ( $observed['subset_value'] ?? 0 ),
+				(string) ( $observed['total_field'] ?? 'total' ),
+				(int) ( $observed['total_value'] ?? 0 )
+			);
+		}
+
+		return $messages;
 	}
 
 	/**

--- a/tests/Unit/Abilities/Analytics/MediavineReportsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/MediavineReportsAbilitiesTest.php
@@ -484,6 +484,40 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_coherent_and_unknown_dimensional_rows_have_no_integrity_warnings(): void {
+		$fixtures = $this->dimensionalFixtures();
+
+		foreach ( array( 'devices', 'countries', 'sources' ) as $action ) {
+			$parsed      = MediavineReportsAbilities::parseDimensionalPayload( $action, $fixtures[ $action ], '2026-07' );
+			$diagnostics = MediavineReportsAbilities::diagnoseDimensionalIntegrity( $action, $parsed['rows'] );
+
+			$this->assertSame( 'ok', $diagnostics['status'], $action );
+			$this->assertSame( 0, $diagnostics['warning_count'], $action );
+			$this->assertSame( array(), $diagnostics['warnings'], $action );
+		}
+	}
+
+	public function test_impossible_device_counts_are_diagnosed_without_changing_rows(): void {
+		$fixtures = $this->dimensionalFixtures();
+		$parsed   = MediavineReportsAbilities::parseDimensionalPayload( 'devices', $fixtures['devices_impossible'], '2026-07' );
+		$rows     = $parsed['rows'];
+		$output   = MediavineReportsAbilities::buildDimensionalResult( 'devices', 'site', 'relay-id', '2026-04-17', '2026-07-16', '2026-07', $parsed );
+
+		$this->assertSame( $rows, $output['results'] );
+		$this->assertSame( 6, $output['results'][1]['pageviews'] );
+		$this->assertSame( 18211, $output['results'][1]['monetizablePageviews'] );
+		$this->assertSame( 'warning', $output['diagnostics']['status'] );
+		$this->assertSame( 2, $output['diagnostics']['warning_count'] );
+		$this->assertSame( 'monetizable_pageviews_exceed_pageviews', $output['diagnostics']['warnings'][0]['code'] );
+		$this->assertSame( array( 'index' => 1, 'dimension' => 'label', 'value' => 'other' ), $output['diagnostics']['warnings'][0]['row'] );
+		$this->assertSame( 'monetizablePageviews <= pageviews', $output['diagnostics']['warnings'][0]['invariant'] );
+		$this->assertSame( 18211, $output['diagnostics']['warnings'][0]['observed']['subset_value'] );
+		$this->assertSame( 6, $output['diagnostics']['warnings'][0]['observed']['total_value'] );
+		$this->assertSame( 'unknown_upstream', $output['diagnostics']['warnings'][0]['source_semantics'] );
+		$this->assertStringContainsString( 'raw values are preserved unchanged', $output['diagnostics']['warnings'][0]['message'] );
+		$this->assertSame( 'DevicesMetricsSummaryQuery', $output['provenance']['source']['operation'] );
+	}
+
 	public function test_ad_unit_parser_keeps_parent_and_child_device_grains_unambiguous(): void {
 		$fixtures = $this->dimensionalFixtures();
 		$parsed   = MediavineReportsAbilities::parseDimensionalPayload( 'ad_units', $fixtures['ad_units'], '2026-07' );
@@ -511,9 +545,21 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 			$this->assertSame( 2, $output['provenance']['period']['row_count'] );
 			$this->assertSame( '2026/07/10', $output['provenance']['period']['canonical']['start'] );
 			$this->assertSame( $action, $output['provenance']['source']['action'] );
+			$this->assertSame( 'ok', $output['diagnostics']['status'] );
+			$this->assertSame( 0, $output['diagnostics']['warning_count'] );
 			$this->assertFalse( $output['provenance']['host_attribution']['available'] );
 			$this->assertStringContainsString( 'source-native aggregate buckets', $output['provenance']['host_attribution']['reason'] );
 		}
+	}
+
+	public function test_impossible_device_diagnostics_validate_against_output_schema(): void {
+		$fixtures = $this->dimensionalFixtures();
+		$parsed   = MediavineReportsAbilities::parseDimensionalPayload( 'devices', $fixtures['devices_impossible'], '2026-07' );
+		$output   = MediavineReportsAbilities::buildDimensionalResult( 'devices', 'site', 'relay-id', '2026-04-17', '2026-07-16', '2026-07', $parsed );
+		$valid    = rest_validate_value_from_schema( $output, MediavineReportsAbilities::outputSchema(), 'output' );
+
+		$this->assertTrue( $valid, is_wp_error( $valid ) ? $valid->get_error_message() : '' );
+		$this->assertArrayHasKey( 'diagnostics', MediavineReportsAbilities::outputSchema()['properties'] );
 	}
 
 	public function test_dimensional_fixtures_and_outputs_contain_no_secret_material(): void {
@@ -524,6 +570,8 @@ class MediavineReportsAbilitiesTest extends WP_UnitTestCase {
 			$parsed = MediavineReportsAbilities::parseDimensionalPayload( $action, $fixtures[ $action ], '2026-07' );
 			$blob  .= wp_json_encode( MediavineReportsAbilities::buildDimensionalResult( $action, '11476', $relay, '2026-07-10', '2026-07-16', '2026-07', $parsed ) );
 		}
+		$impossible = MediavineReportsAbilities::parseDimensionalPayload( 'devices', $fixtures['devices_impossible'], '2026-07' );
+		$blob      .= wp_json_encode( MediavineReportsAbilities::buildDimensionalResult( 'devices', '11476', $relay, '2026-04-17', '2026-07-16', '2026-07', $impossible ) );
 		$forbidden = array( 'password', 'Bearer ', 'accessToken', 'refreshToken', 'userId' );
 
 		foreach ( $forbidden as $needle ) {

--- a/tests/Unit/Cli/MediavineCommandTest.php
+++ b/tests/Unit/Cli/MediavineCommandTest.php
@@ -20,11 +20,42 @@ class MediavineCommandTest extends WP_UnitTestCase {
 			'date_range' => array( 'start_date' => '2026-07-10', 'end_date' => '2026-07-16' ),
 			'results_count' => 1,
 			'results' => array( array( 'label' => 'Mobile', 'pageviews' => 1200, 'revenue' => 15.0, 'period' => '2026-07' ) ),
+			'diagnostics' => array(
+				'status' => 'warning',
+				'warning_count' => 1,
+				'warnings' => array( array( 'code' => 'monetizable_pageviews_exceed_pageviews' ) ),
+			),
 			'provenance' => array( 'source' => array( 'operation' => 'DevicesMetricsSummaryQuery' ) ),
 		);
 
 		$this->assertSame( $result, json_decode( MediavineCommand::jsonOutput( $result ), true ) );
 		$this->assertIsInt( json_decode( MediavineCommand::jsonOutput( $result ), true )['results'][0]['pageviews'] );
+	}
+
+	public function test_integrity_warning_messages_surface_row_and_observed_values(): void {
+		$result = array(
+			'diagnostics' => array(
+				'warnings' => array(
+					array(
+						'row' => array( 'index' => 3, 'dimension' => 'label', 'value' => 'other' ),
+						'observed' => array(
+							'subset_field' => 'monetizablePageviews',
+							'subset_value' => 18211,
+							'total_field' => 'pageviews',
+							'total_value' => 6,
+						),
+					),
+				),
+			),
+		);
+
+		$messages = MediavineCommand::integrityWarningMessages( $result );
+
+		$this->assertCount( 1, $messages );
+		$this->assertStringContainsString( 'row 3 (label=other)', $messages[0] );
+		$this->assertStringContainsString( 'monetizablePageviews=18211 exceeds pageviews=6', $messages[0] );
+		$this->assertStringContainsString( 'Upstream bucket semantics are unknown', $messages[0] );
+		$this->assertSame( array(), MediavineCommand::integrityWarningMessages( array() ) );
 	}
 
 	public function test_table_and_csv_rows_use_stable_action_specific_columns(): void {

--- a/tests/fixtures/mediavine-dimensional-reports.json
+++ b/tests/fixtures/mediavine-dimensional-reports.json
@@ -10,6 +10,17 @@
       }
     }
   },
+  "devices_impossible": {
+    "data": {
+      "devicesMetricsSummary": {
+        "meta": { "totalCount": 2, "reportStart": "2026/04/17", "reportEnd": "2026/07/16" },
+        "devices": [
+          { "label": "desktop", "pageviewRpm": 4.72, "pageviews": 105677, "revenue": 498.72, "sessionRpm": 5.22, "sessions": 95476, "monetizablePageviews": 23314, "monetizableSessions": 20912, "monetizablePageviewRpm": 21.41, "monetizableSessionRpm": 23.85 },
+          { "label": "other", "pageviewRpm": 435.38, "pageviews": 6, "revenue": 2.61, "sessionRpm": 435.38, "sessions": 6, "monetizablePageviews": 18211, "monetizableSessions": 15976, "monetizablePageviewRpm": 0.14, "monetizableSessionRpm": 0.16 }
+        ]
+      }
+    }
+  },
   "countries": {
     "data": {
       "countriesReport": {

--- a/tests/mediavine-dimensional-smoke.php
+++ b/tests/mediavine-dimensional-smoke.php
@@ -79,10 +79,19 @@ namespace {
 	$ad_units = MediavineReportsAbilities::parseDimensionalPayload( 'ad_units', $fixtures['ad_units'], '2026-07' );
 	$assert( 'parent' === $ad_units['rows'][0]['grain'] && null === $ad_units['rows'][0]['deviceType'], 'parent ad-unit grain' );
 	$assert( 'child' === $ad_units['rows'][1]['grain'] && 'Mobile' === $ad_units['rows'][1]['deviceType'], 'child ad-unit device grain' );
+	$impossible = MediavineReportsAbilities::parseDimensionalPayload( 'devices', $fixtures['devices_impossible'], '2026-07' );
+	$diagnosed  = MediavineReportsAbilities::buildDimensionalResult( 'devices', 'site', 'relay-id', '2026-04-17', '2026-07-16', '2026-07', $impossible );
+	$assert( $impossible['rows'] === $diagnosed['results'], 'integrity diagnostics preserve raw normalized rows' );
+	$assert( 'warning' === $diagnosed['diagnostics']['status'] && 2 === $diagnosed['diagnostics']['warning_count'], 'impossible device counts produce two warnings' );
+	$assert( 'other' === $diagnosed['diagnostics']['warnings'][0]['row']['value'], 'warning identifies anomalous device bucket' );
+	$assert( 'unknown_upstream' === $diagnosed['diagnostics']['warnings'][0]['source_semantics'], 'warning marks upstream semantics unknown' );
+	$assert( 0 === MediavineReportsAbilities::diagnoseDimensionalIntegrity( 'countries', array( array( 'country' => 'Unknown', 'pageviews' => 0, 'sessions' => 0, 'monetizablePageviews' => 0, 'monetizableSessions' => 0 ) ) )['warning_count'], 'valid zero and unknown bucket is not warned' );
+	$warning_messages = MediavineCommand::integrityWarningMessages( $diagnosed );
+	$assert( 2 === count( $warning_messages ) && str_contains( $warning_messages[0], 'label=other' ), 'CLI renders visible integrity warnings' );
 
-	$envelope = array( 'success' => true, 'action' => 'ad_units', 'results' => $ad_units['rows'], 'provenance' => array( 'source' => array( 'operation' => 'AdunitsMetricsQuery' ) ) );
+	$envelope = array( 'success' => true, 'action' => 'devices', 'results' => $diagnosed['results'], 'diagnostics' => $diagnosed['diagnostics'], 'provenance' => array( 'source' => array( 'operation' => 'DevicesMetricsSummaryQuery' ) ) );
 	$assert( $envelope === json_decode( MediavineCommand::jsonOutput( $envelope ), true ), 'CLI JSON preserves envelope' );
-	$assert( MediavineCommand::tableFields( 'ad_units' ) === array_keys( MediavineCommand::tabularRows( $envelope )[0] ), 'CLI table/CSV fields are stable' );
+	$assert( MediavineCommand::tableFields( 'devices' ) === array_keys( MediavineCommand::tabularRows( $envelope )[0] ), 'CLI table/CSV fields are stable' );
 	$assert( MediavineCommand::class === CommandRegistry::map()['datamachine analytics mediavine'], 'CLI command is registered' );
 	foreach ( array( 'password', 'Bearer ', 'accessToken', 'refreshToken', 'userId' ) as $secret_key ) {
 		$assert( ! str_contains( (string) wp_json_encode( $fixtures ), $secret_key ), 'fixtures omit ' . $secret_key );


### PR DESCRIPTION
## Summary
- add additive machine-readable integrity diagnostics for Mediavine dimensional subset-count violations without changing normalized source rows
- warn visibly in human CLI output while preserving the complete diagnostics envelope in JSON
- document unknown upstream bucket semantics and cover coherent, zero/unknown, impossible, schema, provenance, CLI, and secret non-disclosure cases

Closes #90

## Evidence
A bounded 2026-04-17 through 2026-07-16 live `devicesMetricsSummary` smoke reproduced the source-native `other` row with 6 pageviews, 6 sessions, 18,211 monetizable pageviews, and 15,976 monetizable sessions. Desktop, mobile, and tablet rows remained internally coherent. The selected GraphQL schema exposes ordinary and monetizable counts as separate scalar fields but does not document an alternate interpretation for unclassified buckets, so the implementation does not guess whether this is special dashboard behavior or an upstream defect.

## Invariant Semantics
Diagnostics are limited to reports that expose both ordinary totals and monetizable subsets (`devices`, `countries`, and `sources`):

- `monetizablePageviews <= pageviews`
- `monetizableSessions <= sessions`

Only strict violations warn. Valid zeros, null dimensions, and literal unknown buckets remain valid. Each warning includes a stable code, severity, zero-based row identity, invariant, observed field/value pairs, `source_semantics=unknown_upstream`, and an explicit caution against causal conclusions.

## Compatibility
- Existing `results` rows and values are preserved byte-for-value after normalization; no row is dropped, rewritten, or fabricated.
- The top-level `diagnostics` object is additive on dimensional success responses.
- Table and CSV output emit human warnings before rendering rows.
- JSON remains machine-readable and preserves the complete ability envelope, including diagnostics and provenance.
- No Extra Chill-specific filtering or generic rules engine was added.

## Verification
- `php tests/mediavine-dimensional-smoke.php` (36 assertions)
- `php tests/verify-render.php`
- `php tests/ability-registration-lifecycle-smoke.php` (24 assertions)
- PHP syntax checks for all changed PHP files
- sanitized bounded live dimensional smoke
- fixture JSON validation and secret-marker scan
- `git diff --check`

## Limits
- Mediavine does not publish semantics explaining the anomalous `other` bucket, so diagnostics deliberately report unknown upstream behavior rather than infer corrected values.
- Full Homeboy lint/test/audit were resource-gated: the host reported load 117.2 on 8 CPUs and no eligible Lab runner, so the safety gate was respected rather than overridden. CI remains the full unit/schema/PHPCS gate.