### PR TITLE
fix: disclose GA landing attribution gaps

### DIFF
--- a/docs/google-analytics.md
+++ b/docs/google-analytics.md
@@ -45,6 +45,16 @@ Existing GA4 installations do not need a migration step. Data Machine Business u
 
 These are fixed report presets rather than an arbitrary GA4 report builder. All support `page_filter`, `hostname`, sorting, row limits, and comparison. Standard report responses include pagination metadata with the requested limit, returned and fetched row counts, GA4's reported row count, and a truncation flag.
 
+#### Unknown landing-page coverage
+
+`landing_page_acquisition` preserves GA4's `(not set)` rows and adds `unknown_dimension_coverage` metadata. Google defines `landingPage` as the page path associated with the first `page_view` in a session and documents `(not set)` for this dimension when a session has no `page_view`. This identifies an attribution/collection gap, but the Data API response cannot prove whether an individual gap came from Measurement Protocol, consent or tag sequencing, automated traffic, or another collection path. Separately, `(not set)` session source/medium can indicate a missing `session_start` event.
+
+The metadata reports observed unknown sessions, sessions represented by fetched rows, total sessions from GA4's `TOTAL` metric aggregation, unknown-cohort engagement, and a 5% materiality status. `share` and exact unknown/engagement counts are populated only when all dimensional rows were fetched. If GA4's row count exceeds the fetched rows, `status` is `partial`, exact fields are `null`, and `observed_share_lower_bound` makes the top-N limitation explicit. A partial cohort is still `material` when that lower bound is at least 5%; otherwise materiality is `unknown`.
+
+Table and CSV CLI output warn when the exact share or observed lower bound is material. JSON retains the complete metadata. For page-level acquisition conclusions, operators should preserve the cohort in source data but exclude or segment it from ranked landing-page analysis, disclose the omitted share, and investigate tagging/collection separately. Do not relabel it as bot or Measurement Protocol traffic without independent evidence.
+
+References: [Google's `(not set)` guidance](https://support.google.com/analytics/answer/13504892) and the [GA4 Data API schema](https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema).
+
 ### `network_density` vs `path_sequence`
 
 Both measure cross-site behavior on a multisite GA4 property, but they are not the same thing:

--- a/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
+++ b/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
@@ -92,6 +92,13 @@ class GoogleAnalyticsAbilities {
 	const MAX_LIMIT = 10000;
 
 	/**
+	 * Share at which unknown landing-page coverage is material to analysis.
+	 *
+	 * @var float
+	 */
+	const UNKNOWN_LANDING_PAGE_MATERIAL_SHARE = 0.05;
+
+	/**
 	 * Action-to-report configuration mapping.
 	 *
 	 * Each action defines the dimensions and metrics for its GA4 report request.
@@ -99,37 +106,37 @@ class GoogleAnalyticsAbilities {
 	 * @var array
 	 */
 	const ACTION_REPORTS = array(
-		'page_stats'              => array(
+		'page_stats'               => array(
 			// hostName is prepended (not replacing pagePath) so existing pagePath-keyed
 			// consumers keep working while cross-site rows become distinguishable — on a
 			// multisite GA4 property two sites otherwise both collapse to pagePath "/".
 			'dimensions' => array( 'hostName', 'pagePath', 'pageTitle' ),
 			'metrics'    => array( 'screenPageViews', 'sessions', 'bounceRate', 'averageSessionDuration', 'activeUsers' ),
 		),
-		'network_density'         => array(
+		'network_density'          => array(
 			// Cross-site journey proxy: current host x previous URL. Bucket pageReferrer's
 			// host into in-network vs external to compute "% of sessions per site whose
 			// referrer was another EC site". Approximation only — see action description.
 			'dimensions' => array( 'hostName', 'pageReferrer' ),
 			'metrics'    => array( 'sessions', 'activeUsers', 'screenPageViews' ),
 		),
-		'traffic_sources'         => array(
+		'traffic_sources'          => array(
 			'dimensions' => array( 'sessionSource', 'sessionMedium' ),
 			'metrics'    => array( 'sessions', 'activeUsers', 'screenPageViews', 'bounceRate' ),
 		),
-		'date_stats'              => array(
+		'date_stats'               => array(
 			'dimensions' => array( 'date' ),
 			'metrics'    => array( 'sessions', 'screenPageViews', 'activeUsers', 'bounceRate', 'averageSessionDuration' ),
 		),
-		'top_events'              => array(
+		'top_events'               => array(
 			'dimensions' => array( 'eventName' ),
 			'metrics'    => array( 'eventCount', 'eventCountPerUser' ),
 		),
-		'user_demographics'       => array(
+		'user_demographics'        => array(
 			'dimensions' => array( 'country', 'deviceCategory' ),
 			'metrics'    => array( 'sessions', 'activeUsers', 'screenPageViews' ),
 		),
-		'landing_pages'           => array(
+		'landing_pages'            => array(
 			'dimensions' => array( 'landingPage' ),
 			'metrics'    => array( 'sessions', 'activeUsers', 'bounceRate', 'averageSessionDuration', 'engagementRate' ),
 		),
@@ -139,21 +146,21 @@ class GoogleAnalyticsAbilities {
 			'dimensions' => array( 'landingPage', 'sessionSource', 'sessionMedium' ),
 			'metrics'    => array( 'sessions', 'activeUsers', 'engagedSessions', 'engagementRate' ),
 		),
-		'page_acquisition'        => array(
+		'page_acquisition'         => array(
 			// Touched-page semantics: pagePath includes any matching page viewed
 			// during sessions attributed to the returned source and medium.
 			'dimensions' => array( 'pagePath', 'sessionSource', 'sessionMedium' ),
 			'metrics'    => array( 'screenPageViews', 'sessions', 'activeUsers', 'engagedSessions' ),
 		),
-		'page_audience'           => array(
+		'page_audience'            => array(
 			'dimensions' => array( 'pagePath', 'country', 'deviceCategory' ),
 			'metrics'    => array( 'screenPageViews', 'sessions', 'activeUsers' ),
 		),
-		'engagement'              => array(
+		'engagement'               => array(
 			'dimensions' => array( 'pagePath', 'pageTitle' ),
 			'metrics'    => array( 'engagementRate', 'averageSessionDuration', 'engagedSessions', 'sessionsPerUser', 'screenPageViewsPerSession', 'userEngagementDuration' ),
 		),
-		'new_vs_returning'        => array(
+		'new_vs_returning'         => array(
 			'dimensions' => array( 'newVsReturning' ),
 			'metrics'    => array( 'sessions', 'activeUsers', 'engagementRate', 'screenPageViewsPerSession', 'averageSessionDuration' ),
 		),
@@ -230,17 +237,7 @@ class GoogleAnalyticsAbilities {
 							),
 						),
 					),
-					'output_schema'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'success'       => array( 'type' => 'boolean' ),
-							'action'        => array( 'type' => 'string' ),
-							'results_count' => array( 'type' => 'integer' ),
-							'results'       => array( 'type' => 'array' ),
-							'pagination'    => array( 'type' => 'object' ),
-							'error'         => array( 'type' => 'string' ),
-						),
-					),
+					'output_schema'       => self::outputSchema(),
 					'execute_callback'    => array( self::class, 'fetchStats' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage(),
 					'meta'                => array( 'show_in_rest' => false ),
@@ -249,6 +246,61 @@ class GoogleAnalyticsAbilities {
 		};
 
 		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
+	}
+
+	/**
+	 * Ability output schema.
+	 *
+	 * @return array
+	 */
+	public static function outputSchema(): array {
+		$coverage_period = array(
+			'type'       => 'object',
+			'properties' => array(
+				'status'                     => array(
+					'type' => 'string',
+					'enum' => array( 'complete', 'partial' ),
+				),
+				'unknown_sessions'           => array( 'type' => array( 'integer', 'null' ) ),
+				'observed_unknown_sessions'  => array( 'type' => 'integer' ),
+				'observed_fetched_sessions'  => array( 'type' => 'integer' ),
+				'total_sessions'             => array( 'type' => array( 'integer', 'null' ) ),
+				'share'                      => array( 'type' => array( 'number', 'null' ) ),
+				'observed_share_lower_bound' => array( 'type' => array( 'number', 'null' ) ),
+				'engaged_sessions'           => array( 'type' => array( 'integer', 'null' ) ),
+				'engagement_rate'            => array( 'type' => array( 'number', 'null' ) ),
+				'materiality'                => array(
+					'type' => 'string',
+					'enum' => array( 'absent', 'small', 'material', 'unknown' ),
+				),
+			),
+		);
+
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'                    => array( 'type' => 'boolean' ),
+				'action'                     => array( 'type' => 'string' ),
+				'results_count'              => array( 'type' => 'integer' ),
+				'results'                    => array( 'type' => 'array' ),
+				'pagination'                 => array( 'type' => 'object' ),
+				'unknown_dimension_coverage' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'dimension'                => array( 'type' => 'string' ),
+						'unknown_value'            => array( 'type' => 'string' ),
+						'interpretation'           => array( 'type' => 'string' ),
+						'material_share_threshold' => array( 'type' => 'number' ),
+						'current_period'           => $coverage_period,
+						'comparison_period'        => array(
+							'type'       => array( 'object', 'null' ),
+							'properties' => $coverage_period['properties'],
+						),
+					),
+				),
+				'error'                      => array( 'type' => 'string' ),
+			),
+		);
 	}
 
 	/**
@@ -377,6 +429,10 @@ class GoogleAnalyticsAbilities {
 			// not incorrectly classified as new.
 			'limit'      => $compare ? self::MAX_LIMIT : $limit,
 		);
+
+		if ( 'landing_page_acquisition' === $action ) {
+			$request_body['metricAggregations'] = array( 'TOTAL' );
+		}
 
 		// Build dimension filters.
 		$filters = array();
@@ -581,7 +637,7 @@ class GoogleAnalyticsAbilities {
 		$limit = ! empty( $input['limit'] ) ? max( 1, min( (int) $input['limit'], self::MAX_LIMIT ) ) : self::DEFAULT_LIMIT;
 		$rows  = $compare
 			? self::formatComparisonRows( $data, $limit )
-			: self::formatReportRows( $data);
+			: self::formatReportRows( $data );
 
 		$response = array(
 			'success'       => true,
@@ -595,6 +651,10 @@ class GoogleAnalyticsAbilities {
 			'pagination'    => self::buildPaginationMetadata( $data, $limit, count( $rows ), $compare ),
 		);
 
+		if ( 'landing_page_acquisition' === $action ) {
+			$response['unknown_dimension_coverage'] = self::buildUnknownDimensionCoverage( $data, $compare );
+		}
+
 		if ( $compare ) {
 			$response['compare_date_range'] = array(
 				'start_date' => $date_ranges[1]['startDate'],
@@ -603,6 +663,130 @@ class GoogleAnalyticsAbilities {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Quantify GA4's unknown landing-page cohort without altering report rows.
+	 *
+	 * GA documents landingPage as the first page_view in a session and `(not set)`
+	 * as a session with no page_view. The report cannot identify the collection
+	 * path that caused an individual gap, so the interpretation stays bounded.
+	 *
+	 * @param array $data    Raw GA4 API response.
+	 * @param bool  $compare Whether two date ranges were requested.
+	 * @return array
+	 */
+	public static function buildUnknownDimensionCoverage( array $data, bool $compare ): array {
+		$fetched_rows = count( $data['rows'] ?? array() );
+		$complete     = isset( $data['rowCount'] ) && (int) $data['rowCount'] <= $fetched_rows;
+
+		return array(
+			'dimension'                => 'landingPage',
+			'unknown_value'            => '(not set)',
+			'interpretation'           => 'GA4 did not associate a first page_view with these sessions. This report cannot identify the collection cause.',
+			'material_share_threshold' => self::UNKNOWN_LANDING_PAGE_MATERIAL_SHARE,
+			'current_period'           => self::buildUnknownCoveragePeriod( $data, 'date_range_0', $complete ),
+			'comparison_period'        => $compare ? self::buildUnknownCoveragePeriod( $data, 'date_range_1', $complete ) : null,
+		);
+	}
+
+	/**
+	 * Build one date range's unknown landing-page coverage.
+	 *
+	 * @param array  $data       Raw GA4 API response.
+	 * @param string $date_range GA4 synthetic date range value.
+	 * @param bool   $complete   Whether all dimensional rows were fetched.
+	 * @return array
+	 */
+	private static function buildUnknownCoveragePeriod( array $data, string $date_range, bool $complete ): array {
+		$dimension_headers = wp_list_pluck( $data['dimensionHeaders'] ?? array(), 'name' );
+		$metric_headers    = wp_list_pluck( $data['metricHeaders'] ?? array(), 'name' );
+		$landing_index     = array_search( 'landingPage', $dimension_headers, true );
+		$date_range_index  = array_search( 'dateRange', $dimension_headers, true );
+		$sessions_index    = array_search( 'sessions', $metric_headers, true );
+		$engaged_index     = array_search( 'engagedSessions', $metric_headers, true );
+		$unknown_sessions  = 0;
+		$engaged_sessions  = 0;
+		$fetched_sessions  = 0;
+
+		foreach ( ( $data['rows'] ?? array() ) as $row ) {
+			$dimensions = wp_list_pluck( $row['dimensionValues'] ?? array(), 'value' );
+			$row_range  = false !== $date_range_index ? ( $dimensions[ $date_range_index ] ?? 'date_range_0' ) : 'date_range_0';
+			if ( $date_range !== $row_range ) {
+				continue;
+			}
+
+			$metrics           = wp_list_pluck( $row['metricValues'] ?? array(), 'value' );
+			$fetched_sessions += false !== $sessions_index ? (int) ( $metrics[ $sessions_index ] ?? 0 ) : 0;
+			if ( false === $landing_index || '(not set)' !== ( $dimensions[ $landing_index ] ?? '' ) ) {
+				continue;
+			}
+
+			$unknown_sessions += false !== $sessions_index ? (int) ( $metrics[ $sessions_index ] ?? 0 ) : 0;
+			$engaged_sessions += false !== $engaged_index ? (int) ( $metrics[ $engaged_index ] ?? 0 ) : 0;
+		}
+
+		$total_sessions = self::extractTotalSessions( $data, $date_range );
+		if ( null === $total_sessions && $complete && false !== $sessions_index ) {
+			$total_sessions = $fetched_sessions;
+		}
+
+		$observed_share = null !== $total_sessions && $total_sessions > 0 ? $unknown_sessions / $total_sessions : null;
+		$share          = $complete ? $observed_share : null;
+		$materiality    = 'unknown';
+		if ( $complete ) {
+			if ( 0 === $unknown_sessions ) {
+				$materiality = 'absent';
+			} elseif ( null !== $share ) {
+				$materiality = $share >= self::UNKNOWN_LANDING_PAGE_MATERIAL_SHARE ? 'material' : 'small';
+			}
+		} elseif ( null !== $observed_share && $observed_share >= self::UNKNOWN_LANDING_PAGE_MATERIAL_SHARE ) {
+			$materiality = 'material';
+		}
+
+		return array(
+			'status'                     => $complete ? 'complete' : 'partial',
+			'unknown_sessions'           => $complete ? $unknown_sessions : null,
+			'observed_unknown_sessions'  => $unknown_sessions,
+			'observed_fetched_sessions'  => $fetched_sessions,
+			'total_sessions'             => $total_sessions,
+			'share'                      => $share,
+			'observed_share_lower_bound' => $complete ? null : $observed_share,
+			'engaged_sessions'           => $complete ? $engaged_sessions : null,
+			'engagement_rate'            => $complete && $unknown_sessions > 0 ? $engaged_sessions / $unknown_sessions : null,
+			'materiality'                => $materiality,
+		);
+	}
+
+	/**
+	 * Read GA4's requested TOTAL sessions aggregation for one date range.
+	 *
+	 * @param array  $data       Raw GA4 API response.
+	 * @param string $date_range GA4 synthetic date range value.
+	 * @return int|null
+	 */
+	private static function extractTotalSessions( array $data, string $date_range ): ?int {
+		$dimension_headers = wp_list_pluck( $data['dimensionHeaders'] ?? array(), 'name' );
+		$metric_headers    = wp_list_pluck( $data['metricHeaders'] ?? array(), 'name' );
+		$date_range_index  = array_search( 'dateRange', $dimension_headers, true );
+		$sessions_index    = array_search( 'sessions', $metric_headers, true );
+
+		if ( false === $sessions_index ) {
+			return null;
+		}
+
+		foreach ( ( $data['totals'] ?? array() ) as $index => $row ) {
+			$dimensions = wp_list_pluck( $row['dimensionValues'] ?? array(), 'value' );
+			$row_range  = false !== $date_range_index ? ( $dimensions[ $date_range_index ] ?? '' ) : ( 0 === $index ? 'date_range_0' : 'date_range_1' );
+			if ( $date_range !== $row_range ) {
+				continue;
+			}
+
+			$metrics = wp_list_pluck( $row['metricValues'] ?? array(), 'value' );
+			return (int) ( $metrics[ $sessions_index ] ?? 0 );
+		}
+
+		return null;
 	}
 
 	/**
@@ -1143,7 +1327,7 @@ class GoogleAnalyticsAbilities {
 	 * @param array $report_config Report configuration with dimension/metric names.
 	 * @return array Formatted rows.
 	 */
-	private static function formatReportRows( array $data): array {
+	private static function formatReportRows( array $data ): array {
 		$dimension_headers = wp_list_pluck( $data['dimensionHeaders'] ?? array(), 'name' );
 		$metric_headers    = wp_list_pluck( $data['metricHeaders'] ?? array(), 'name' );
 
@@ -1274,18 +1458,26 @@ class GoogleAnalyticsAbilities {
 			return $cached;
 		}
 
-		$header = self::base64url_encode( wp_json_encode( array(
-			'alg' => 'RS256',
-			'typ' => 'JWT',
-		) ) );
+		$header = self::base64url_encode(
+			wp_json_encode(
+				array(
+					'alg' => 'RS256',
+					'typ' => 'JWT',
+				)
+			)
+		);
 		$now    = time();
-		$claims = self::base64url_encode( wp_json_encode( array(
-			'iss'   => $service_account['client_email'],
-			'scope' => 'https://www.googleapis.com/auth/analytics.readonly',
-			'aud'   => 'https://oauth2.googleapis.com/token',
-			'iat'   => $now,
-			'exp'   => $now + 3600,
-		) ) );
+		$claims = self::base64url_encode(
+			wp_json_encode(
+				array(
+					'iss'   => $service_account['client_email'],
+					'scope' => 'https://www.googleapis.com/auth/analytics.readonly',
+					'aud'   => 'https://oauth2.googleapis.com/token',
+					'iat'   => $now,
+					'exp'   => $now + 3600,
+				)
+			)
+		);
 
 		$unsigned = $header . '.' . $claims;
 

--- a/inc/Cli/GoogleAnalyticsCommand.php
+++ b/inc/Cli/GoogleAnalyticsCommand.php
@@ -33,20 +33,20 @@ class GoogleAnalyticsCommand extends BaseCommand {
 	 */
 	public static function actions(): array {
 		return array(
-			'page_stats'              => 'Top pages by sessions, views, and engagement',
-			'traffic_sources'         => 'Sessions grouped by source and medium',
-			'date_stats'              => 'Daily session and engagement trends',
-			'realtime'                => 'Real-time active users',
-			'top_events'              => 'Top events by count',
-			'user_demographics'       => 'Sessions by country and device',
-			'landing_pages'           => 'Top landing pages by entrances and engagement',
+			'page_stats'               => 'Top pages by sessions, views, and engagement',
+			'traffic_sources'          => 'Sessions grouped by source and medium',
+			'date_stats'               => 'Daily session and engagement trends',
+			'realtime'                 => 'Real-time active users',
+			'top_events'               => 'Top events by count',
+			'user_demographics'        => 'Sessions by country and device',
+			'landing_pages'            => 'Top landing pages by entrances and engagement',
 			'landing_page_acquisition' => 'Landing pages by session source and medium',
-			'page_acquisition'        => 'Touched pages by session source and medium',
-			'page_audience'           => 'Touched pages by country and device',
-			'engagement'              => 'Aggregate engagement metrics per page',
-			'new_vs_returning'        => 'New vs returning user split',
-			'network_density'         => 'Cross-site journey density via referrer host',
-			'path_sequence'           => 'Ordered cross-host path sequences (funnel report)',
+			'page_acquisition'         => 'Touched pages by session source and medium',
+			'page_audience'            => 'Touched pages by country and device',
+			'engagement'               => 'Aggregate engagement metrics per page',
+			'new_vs_returning'         => 'New vs returning user split',
+			'network_density'          => 'Cross-site journey density via referrer host',
+			'path_sequence'            => 'Ordered cross-host path sequences (funnel report)',
 		);
 	}
 
@@ -144,15 +144,19 @@ class GoogleAnalyticsCommand extends BaseCommand {
 			'action' => $args[0] ?? '',
 		);
 
-		$this->map_optional( $input, $assoc_args, array(
-			'start-date'  => 'start_date',
-			'end-date'    => 'end_date',
-			'limit'       => 'limit',
-			'page-filter' => 'page_filter',
-			'hostname'    => 'hostname',
-			'sort-by'     => 'sort_by',
-			'order'       => 'order',
-		) );
+		$this->map_optional(
+			$input,
+			$assoc_args,
+			array(
+				'start-date'  => 'start_date',
+				'end-date'    => 'end_date',
+				'limit'       => 'limit',
+				'page-filter' => 'page_filter',
+				'hostname'    => 'hostname',
+				'sort-by'     => 'sort_by',
+				'order'       => 'order',
+			)
+		);
 
 		// --compare is a boolean flag (no value).
 		if ( isset( $assoc_args['compare'] ) ) {
@@ -202,6 +206,11 @@ class GoogleAnalyticsCommand extends BaseCommand {
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Unknown error.' );
 			return;
+		}
+
+		$coverage_warning = self::coverageWarning( $result );
+		if ( null !== $coverage_warning ) {
+			WP_CLI::warning( $coverage_warning );
 		}
 
 		$format = $assoc_args['format'] ?? 'table';
@@ -262,15 +271,43 @@ class GoogleAnalyticsCommand extends BaseCommand {
 			WP_CLI::log( sprintf( '%d results (%s to %s)', $count, $start, $end ) );
 
 			if ( null !== $days_ago && $days_ago > 30 ) {
-				WP_CLI::warning( sprintf(
-					'Data is %d days stale (latest: %s). Check API key and site verification.',
-					$days_ago,
-					$end
-				) );
+				WP_CLI::warning(
+					sprintf(
+						'Data is %d days stale (latest: %s). Check API key and site verification.',
+						$days_ago,
+						$end
+					)
+				);
 			}
 		} else {
 			WP_CLI::log( sprintf( '%d results', $count ) );
 		}
+	}
+
+	/**
+	 * Build the human warning for material unknown landing-page coverage.
+	 *
+	 * @param array $result Ability result.
+	 * @return string|null
+	 */
+	public static function coverageWarning( array $result ): ?string {
+		$coverage = $result['unknown_dimension_coverage']['current_period'] ?? null;
+		if ( ! is_array( $coverage ) || 'material' !== ( $coverage['materiality'] ?? '' ) ) {
+			return null;
+		}
+
+		$partial = 'partial' === ( $coverage['status'] ?? '' );
+		$share   = $partial ? ( $coverage['observed_share_lower_bound'] ?? null ) : ( $coverage['share'] ?? null );
+		$count   = $partial ? ( $coverage['observed_unknown_sessions'] ?? 0 ) : ( $coverage['unknown_sessions'] ?? 0 );
+		$label   = $partial ? 'at least ' : '';
+
+		return sprintf(
+			'GA4 landing-page attribution gap: %s%d sessions (%s%.1f%%) have landingPage `(not set)`. Preserve these rows, but exclude or segment them for page-level acquisition conclusions.',
+			$label,
+			(int) $count,
+			$label,
+			(float) $share * 100
+		);
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
+++ b/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
@@ -71,7 +71,7 @@ class GoogleAnalytics extends BaseTool {
 		return array(
 			'class'           => __CLASS__,
 			'method'          => 'handle_tool_call',
-			'description'     => 'Fetch visitor analytics from Google Analytics (GA4), including fixed landing-page acquisition, touched-page acquisition, and page audience breakdowns. Supports sorting, hostname and page filtering, and period-over-period comparison without arbitrary dimension selection.',
+			'description'     => 'Fetch visitor analytics from Google Analytics (GA4), including fixed landing-page acquisition, touched-page acquisition, and page audience breakdowns. Landing-page acquisition preserves `(not set)` rows and reports unknown-dimension coverage metadata. Supports sorting, hostname and page filtering, and period-over-period comparison without arbitrary dimension selection.',
 			'requires_config' => true,
 			'parameters'      => array(
 				'type'       => 'object',
@@ -79,7 +79,7 @@ class GoogleAnalytics extends BaseTool {
 					'action'      => array(
 						'type'        => 'string',
 						'enum'        => $valid_actions,
-						'description' => 'Choose a bounded report. landing_page_acquisition uses session-entry landingPage x session source/medium. page_acquisition uses touched pagePath x session source/medium. page_audience uses touched pagePath x country/device.',
+						'description' => 'Choose a bounded report. landing_page_acquisition uses session-entry landingPage x session source/medium and discloses material `(not set)` coverage without filtering it. page_acquisition uses touched pagePath x session source/medium. page_audience uses touched pagePath x country/device.',
 					),
 					'property_id' => array(
 					'type'        => 'string',

--- a/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
@@ -15,6 +15,7 @@
 namespace DataMachine\Tests\Unit\Abilities\Analytics;
 
 use DataMachineBusiness\Abilities\Analytics\GoogleAnalyticsAbilities;
+use DataMachineBusiness\Cli\GoogleAnalyticsCommand;
 use DataMachineBusiness\Engine\AI\Tools\Global\GoogleAnalytics;
 use WP_UnitTestCase;
 
@@ -218,6 +219,13 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( GoogleAnalyticsAbilities::MAX_LIMIT, $too_large['limit'] );
 	}
 
+	public function test_landing_acquisition_requests_total_session_aggregation(): void {
+		$body = GoogleAnalyticsAbilities::buildReportRequestBody( array( 'limit' => 25 ), 'landing_page_acquisition' );
+
+		$this->assertSame( array( 'TOTAL' ), $body['metricAggregations'] );
+		$this->assertArrayNotHasKey( 'metricAggregations', GoogleAnalyticsAbilities::buildReportRequestBody( array(), 'page_acquisition' ) );
+	}
+
 	public function test_ai_tool_schema_enumerates_bounded_actions(): void {
 		$reflection = new \ReflectionClass( GoogleAnalytics::class );
 		$tool       = $reflection->newInstanceWithoutConstructor();
@@ -296,6 +304,166 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 		$pagination = $this->pagination_metadata( $data, 2, 2, true );
 
 		$this->assertFalse( $pagination['truncated'] );
+	}
+
+	public function test_unknown_landing_coverage_reports_absent_cohort(): void {
+		$data     = $this->landing_acquisition_response(
+			array( array( '/known/', 'google', 'organic', 100, 60 ) ),
+			100
+		);
+		$coverage = GoogleAnalyticsAbilities::buildUnknownDimensionCoverage( $data, false );
+		$current  = $coverage['current_period'];
+
+		$this->assertSame( 'complete', $current['status'] );
+		$this->assertSame( 0, $current['unknown_sessions'] );
+		$this->assertSame( 100, $current['observed_fetched_sessions'] );
+		$this->assertSame( 0, $current['share'] );
+		$this->assertSame( 'absent', $current['materiality'] );
+		$this->assertNull( GoogleAnalyticsCommand::coverageWarning( array( 'unknown_dimension_coverage' => $coverage ) ) );
+	}
+
+	public function test_unknown_landing_coverage_reports_small_cohort(): void {
+		$data     = $this->landing_acquisition_response(
+			array(
+				array( '(not set)', 'google', 'organic', 4, 1 ),
+				array( '/known/', 'google', 'organic', 96, 58 ),
+			),
+			100
+		);
+		$current = GoogleAnalyticsAbilities::buildUnknownDimensionCoverage( $data, false )['current_period'];
+
+		$this->assertSame( 4, $current['unknown_sessions'] );
+		$this->assertSame( 0.04, $current['share'] );
+		$this->assertSame( 0.25, $current['engagement_rate'] );
+		$this->assertSame( 'small', $current['materiality'] );
+	}
+
+	public function test_unknown_landing_coverage_reports_material_cohort_and_cli_warning(): void {
+		$data     = $this->landing_acquisition_response(
+			array(
+				array( '(not set)', 'google', 'organic', 12, 2 ),
+				array( '(not set)', 'bing', 'organic', 8, 0 ),
+				array( '/known/', 'google', 'organic', 80, 48 ),
+			),
+			100
+		);
+		$coverage = GoogleAnalyticsAbilities::buildUnknownDimensionCoverage( $data, false );
+		$current  = $coverage['current_period'];
+
+		$this->assertSame( 20, $current['unknown_sessions'] );
+		$this->assertSame( 100, $current['total_sessions'] );
+		$this->assertSame( 0.2, $current['share'] );
+		$this->assertSame( 2, $current['engaged_sessions'] );
+		$this->assertSame( 0.1, $current['engagement_rate'] );
+		$this->assertSame( 'material', $current['materiality'] );
+		$this->assertStringContainsString( '20 sessions (20.0%)', GoogleAnalyticsCommand::coverageWarning( array( 'unknown_dimension_coverage' => $coverage ) ) );
+	}
+
+	public function test_truncated_unknown_landing_coverage_is_an_explicit_lower_bound(): void {
+		$data             = $this->landing_acquisition_response(
+			array(
+				array( '(not set)', 'google', 'organic', 20, 2 ),
+				array( '/known/', 'google', 'organic', 30, 18 ),
+			),
+			100
+		);
+		$data['rowCount'] = 12;
+		$coverage         = GoogleAnalyticsAbilities::buildUnknownDimensionCoverage( $data, false );
+		$current          = $coverage['current_period'];
+
+		$this->assertSame( 'partial', $current['status'] );
+		$this->assertNull( $current['unknown_sessions'] );
+		$this->assertSame( 20, $current['observed_unknown_sessions'] );
+		$this->assertSame( 50, $current['observed_fetched_sessions'] );
+		$this->assertNull( $current['share'] );
+		$this->assertSame( 0.2, $current['observed_share_lower_bound'] );
+		$this->assertNull( $current['engaged_sessions'] );
+		$this->assertNull( $current['engagement_rate'] );
+		$this->assertSame( 'material', $current['materiality'] );
+		$this->assertStringContainsString( 'at least 20 sessions (at least 20.0%)', GoogleAnalyticsCommand::coverageWarning( array( 'unknown_dimension_coverage' => $coverage ) ) );
+	}
+
+	public function test_truncated_small_observation_has_unknown_materiality(): void {
+		$data             = $this->landing_acquisition_response(
+			array( array( '(not set)', 'google', 'organic', 2, 0 ) ),
+			100
+		);
+		$data['rowCount'] = 50;
+		$current          = GoogleAnalyticsAbilities::buildUnknownDimensionCoverage( $data, false )['current_period'];
+
+		$this->assertSame( 'partial', $current['status'] );
+		$this->assertSame( 'unknown', $current['materiality'] );
+	}
+
+	public function test_missing_api_row_count_never_claims_complete_coverage(): void {
+		$data = $this->landing_acquisition_response(
+			array( array( '(not set)', 'google', 'organic', 20, 2 ) ),
+			100
+		);
+		unset( $data['rowCount'] );
+
+		$current = GoogleAnalyticsAbilities::buildUnknownDimensionCoverage( $data, false )['current_period'];
+
+		$this->assertSame( 'partial', $current['status'] );
+		$this->assertNull( $current['unknown_sessions'] );
+		$this->assertSame( 0.2, $current['observed_share_lower_bound'] );
+	}
+
+	public function test_comparison_reports_each_period_unknown_coverage(): void {
+		$data     = $this->landing_acquisition_response(
+			array(
+				array( '(not set)', 'google', 'organic', 20, 2 ),
+				array( '/known/', 'google', 'organic', 80, 48 ),
+			),
+			100,
+			array(
+				array( '(not set)', 'google', 'organic', 4, 1 ),
+				array( '/known/', 'google', 'organic', 76, 45 ),
+			),
+			80
+		);
+		$coverage = GoogleAnalyticsAbilities::buildUnknownDimensionCoverage( $data, true );
+
+		$this->assertSame( 0.2, $coverage['current_period']['share'] );
+		$this->assertSame( 'material', $coverage['current_period']['materiality'] );
+		$this->assertSame( 0.05, $coverage['comparison_period']['share'] );
+		$this->assertSame( 'material', $coverage['comparison_period']['materiality'] );
+	}
+
+	public function test_unknown_coverage_does_not_filter_or_mutate_report_rows(): void {
+		$data = $this->landing_acquisition_response(
+			array(
+				array( '(not set)', 'google', 'organic', 20, 2 ),
+				array( '/known/', 'google', 'organic', 80, 48 ),
+			),
+			100
+		);
+		$before = $data;
+
+		GoogleAnalyticsAbilities::buildUnknownDimensionCoverage( $data, false );
+		$rows = $this->format_report_rows( $data );
+
+		$this->assertSame( $before, $data );
+		$this->assertCount( 2, $rows );
+		$this->assertSame( '(not set)', $rows[0]['landingPage'] );
+	}
+
+	public function test_unknown_coverage_validates_against_ability_output_schema(): void {
+		$data     = $this->landing_acquisition_response(
+			array( array( '(not set)', 'google', 'organic', 20, 2 ) ),
+			20
+		);
+		$response = array(
+			'success'                    => true,
+			'action'                     => 'landing_page_acquisition',
+			'results_count'              => 1,
+			'results'                    => $this->format_report_rows( $data ),
+			'pagination'                 => array( 'truncated' => false ),
+			'unknown_dimension_coverage' => GoogleAnalyticsAbilities::buildUnknownDimensionCoverage( $data, false ),
+		);
+
+		$validated = rest_validate_value_from_schema( $response, GoogleAnalyticsAbilities::outputSchema(), 'output' );
+		$this->assertTrue( $validated, is_wp_error( $validated ) ? $validated->get_error_message() : '' );
 	}
 
 	/**
@@ -615,6 +783,13 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 		return $method->invoke( null, $data, $limit );
 	}
 
+	private function format_report_rows( array $data ): array {
+		$method = new \ReflectionMethod( GoogleAnalyticsAbilities::class, 'formatReportRows' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $data );
+	}
+
 	private function pagination_metadata( array $data, int $limit, int $returned_rows, bool $compare ): array {
 		$method = new \ReflectionMethod( GoogleAnalyticsAbilities::class, 'buildPaginationMetadata' );
 		$method->setAccessible( true );
@@ -647,6 +822,69 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 				},
 				$rows
 			),
+		);
+	}
+
+	private function landing_acquisition_response( array $current_rows, int $current_total, array $comparison_rows = array(), ?int $comparison_total = null ): array {
+		$compare    = null !== $comparison_total;
+		$dimensions = array( 'landingPage', 'sessionSource', 'sessionMedium' );
+		if ( $compare ) {
+			$dimensions[] = 'dateRange';
+		}
+
+		$build_row = static function ( array $row, string $date_range, bool $include_range ): array {
+			$dimension_values = array_slice( $row, 0, 3 );
+			if ( $include_range ) {
+				$dimension_values[] = $date_range;
+			}
+
+			return array(
+				'dimensionValues' => array_map( static fn( string $value ): array => array( 'value' => $value ), $dimension_values ),
+				'metricValues'    => array(
+					array( 'value' => (string) $row[3] ),
+					array( 'value' => (string) $row[3] ),
+					array( 'value' => (string) $row[4] ),
+					array( 'value' => (string) ( $row[3] > 0 ? $row[4] / $row[3] : 0 ) ),
+				),
+			);
+		};
+
+		$rows = array_map( static fn( array $row ): array => $build_row( $row, 'date_range_0', $compare ), $current_rows );
+		if ( $compare ) {
+			$rows = array_merge( $rows, array_map( static fn( array $row ): array => $build_row( $row, 'date_range_1', true ), $comparison_rows ) );
+		}
+
+		$build_total = static function ( int $sessions, string $date_range, bool $include_range ): array {
+			$dimension_values = array( 'RESERVED_TOTAL', 'RESERVED_TOTAL', 'RESERVED_TOTAL' );
+			if ( $include_range ) {
+				$dimension_values[] = $date_range;
+			}
+
+			return array(
+				'dimensionValues' => array_map( static fn( string $value ): array => array( 'value' => $value ), $dimension_values ),
+				'metricValues'    => array(
+					array( 'value' => (string) $sessions ),
+					array( 'value' => '0' ),
+					array( 'value' => '0' ),
+					array( 'value' => '0' ),
+				),
+			);
+		};
+
+		$totals = array( $build_total( $current_total, 'date_range_0', $compare ) );
+		if ( $compare ) {
+			$totals[] = $build_total( (int) $comparison_total, 'date_range_1', true );
+		}
+
+		return array(
+			'dimensionHeaders' => array_map( static fn( string $name ): array => array( 'name' => $name ), $dimensions ),
+			'metricHeaders'    => array_map(
+				static fn( string $name ): array => array( 'name' => $name ),
+				array( 'sessions', 'activeUsers', 'engagedSessions', 'engagementRate' )
+			),
+			'rows'             => $rows,
+			'totals'           => $totals,
+			'rowCount'         => count( $rows ),
 		);
 	}
 


### PR DESCRIPTION
## Summary
- preserve every GA4 `landing_page_acquisition` row while exposing typed `(not set)` coverage metadata for current and comparison periods
- report observed unknown/fetched sessions, GA total sessions, exact or lower-bound share, engagement, completeness, and 5% materiality
- warn CLI users when exact coverage or the observed lower bound is material, and document operator interpretation

## Root-cause confidence
Google documents `landingPage` as the first `page_view` in a session and `(not set)` for this dimension when a session has no `page_view`. Confidence is high that these rows represent a landing-page attribution/collection gap. The Data API cannot prove whether an individual gap came from Measurement Protocol, consent or tag sequencing, automated traffic, or another collection path, so the response and docs do not assign a more specific cause. `(not set)` session source/medium is separately documented as potentially indicating a missing `session_start`.

## Metadata semantics
`unknown_dimension_coverage` includes the dimension/value and interpretation plus current/comparison period objects. Each period reports:
- `observed_unknown_sessions` and `observed_fetched_sessions` from unchanged fetched rows
- `total_sessions` from GA4's requested `TOTAL` metric aggregation when available
- exact `unknown_sessions`, `share`, `engaged_sessions`, and `engagement_rate` only for complete rowsets
- `status` and `materiality` using a documented 5% threshold

## Truncation behavior
Coverage is `complete` only when GA4 returns `rowCount` and every dimensional row was fetched. Otherwise exact fields remain `null`, `status` is `partial`, and `observed_share_lower_bound` is reported when the GA total denominator is available. A partial cohort is marked material only when its observed lower bound already reaches 5%; otherwise materiality remains unknown. Display limiting never filters or mutates upstream rows.

## Tests
- focused GA suite: 56 tests, 170 assertions passed
- GA plus CLI action registration smoke: 63 tests, 191 assertions passed
- changed-file PHPCS: passed with no findings
- PHP syntax, output schema validation, `git diff --check`, and PR audit: passed
- full suite: 113/114 passed; the unrelated stale GSC source-literal assertion is tracked in #77

## Limitations
- no production live smoke was run because this is a PR-only worktree change and production files were not modified
- GA totals and row-count completeness remain subject to GA4 Data API reporting semantics
- this diagnoses coverage, not the underlying collection path; operators still need independent tagging/collection evidence

Closes #91