### PR TITLE
feat: complete Sendy campaign ability coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ The plugin registers the following WordPress abilities. Management-oriented abil
 | `datamachine/fetch-messages-discord` | Fetch Discord channel history with before/after pagination |
 | `datamachine/sendy-subscribe` | Subscribe an email address to a Sendy list; intentionally supports public callers |
 | `datamachine/sendy-push-campaign` | Create or update a Sendy campaign |
+| `datamachine/sendy-list-campaigns` | List Sendy campaigns with status and engagement summaries |
+| `datamachine/sendy-get-campaign` | Get one Sendy campaign |
+| `datamachine/sendy-delete-campaign` | Delete a draft Sendy campaign |
 | `datamachine/sendy-metrics` | Read subscriber, campaign, or combined funnel metrics from Sendy |
 
 ### WordPress Operations
@@ -309,7 +312,9 @@ Join Amazon Associates, create Amazon Creators API credentials, and configure th
 
 ### Sendy
 
-Sendy is config-driven: callers pass the Sendy installation URL and API key to each ability. `datamachine/sendy-metrics` can also receive an optional read-only database connection for metrics unavailable through Sendy's API. The plugin does not store Sendy credentials or consumer-specific list and brand IDs.
+Campaign abilities resolve credentials from the DMB-owned `datamachine_sendy_config` network option or `datamachine_sendy_config` filter. Configure `api_key` and `sendy_url` for campaign create/update, plus a `db` array containing `host`, `user`, `pass`, `name`, and optional `port` for list/get/delete. List and get need read access; delete also needs permission to delete draft rows. Credentials are never accepted or returned by the campaign abilities; consumers supply only campaign content, sender identity, IDs, and filters. Consumer-specific list and brand IDs remain consumer policy.
+
+The older subscribe and metrics abilities retain their config input for existing public subscription and analytics consumers. Their migration to integration-owned configuration is separate from the credential-free campaign surface.
 
 ### Mediavine
 

--- a/inc/Abilities/Sendy/SendyAbilities.php
+++ b/inc/Abilities/Sendy/SendyAbilities.php
@@ -5,15 +5,17 @@
  * Generic, config-driven abilities for the Sendy email-marketing service —
  * a sibling to the Slack, Discord, and Google integrations in this plugin.
  *
- * Every ability is keyed entirely by the configuration the caller passes in
- * (api_key, sendy_url, and optional read-only db connection details). These
- * abilities have NO knowledge of any particular consumer's list IDs, brand,
- * or content — that policy stays with the consumer. The mechanics live in
+ * Campaign abilities resolve connection configuration inside this plugin so
+ * credentials never cross the public ability boundary. Consumers continue to
+ * own campaign content and sender identity. The mechanics live in
  * {@see \DataMachineBusiness\Sendy\SendyClient}.
  *
  * Abilities:
  *  - datamachine/sendy-subscribe       Subscribe an email to a list (API).
  *  - datamachine/sendy-push-campaign   Create/update a campaign (API).
+ *  - datamachine/sendy-list-campaigns  List campaigns (read-only DB).
+ *  - datamachine/sendy-get-campaign    Get a campaign (read-only DB).
+ *  - datamachine/sendy-delete-campaign Delete a draft campaign (DB).
  *  - datamachine/sendy-metrics         Email-funnel metrics (read-only DB/API).
  *
  * @package DataMachineBusiness
@@ -32,6 +34,13 @@ defined( 'ABSPATH' ) || exit;
  * Registers the generic, config-driven Sendy abilities.
  */
 class SendyAbilities {
+
+	/**
+	 * Canonical Sendy connection configuration option.
+	 *
+	 * @var string
+	 */
+	public const CONFIG_OPTION = 'datamachine_sendy_config';
 
 	/**
 	 * Guards against double registration.
@@ -88,6 +97,54 @@ class SendyAbilities {
 	}
 
 	/**
+	 * Stable campaign summary schema.
+	 *
+	 * @return array
+	 */
+	private function campaign_summary_schema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array(
+				'id',
+				'title',
+				'status',
+				'sent',
+				'sent_date',
+				'scheduled_date',
+				'to_send',
+				'recipients',
+				'opens',
+				'clicks',
+				'open_rate',
+				'click_rate',
+				'opens_tracking',
+				'links_tracking',
+				'stopped',
+			),
+			'properties' => array(
+				'id'             => array( 'type' => 'integer' ),
+				'title'          => array( 'type' => 'string' ),
+				'status'         => array(
+					'type' => 'string',
+					'enum' => array( 'sent', 'sending', 'scheduled', 'draft' ),
+				),
+				'sent'           => array( 'type' => array( 'integer', 'null' ) ),
+				'sent_date'      => array( 'type' => array( 'string', 'null' ) ),
+				'scheduled_date' => array( 'type' => array( 'string', 'null' ) ),
+				'to_send'        => array( 'type' => 'integer' ),
+				'recipients'     => array( 'type' => 'integer' ),
+				'opens'          => array( 'type' => 'integer' ),
+				'clicks'         => array( 'type' => 'integer' ),
+				'open_rate'      => array( 'type' => 'number' ),
+				'click_rate'     => array( 'type' => 'number' ),
+				'opens_tracking' => array( 'type' => 'boolean' ),
+				'links_tracking' => array( 'type' => 'boolean' ),
+				'stopped'        => array( 'type' => 'boolean' ),
+			),
+		);
+	}
+
+	/**
 	 * Register all Sendy abilities.
 	 */
 	public function register_abilities(): void {
@@ -137,10 +194,9 @@ class SendyAbilities {
 				'description'         => __( 'Create or update a Sendy email campaign via the Sendy API. The caller owns the content and sender identity.', 'data-machine-business' ),
 				'category'            => 'datamachine-publishing',
 				'input_schema'        => array(
-					'type'       => 'object',
-					'required'   => array( 'config', 'subject' ),
-					'properties' => array(
-						'config'      => $this->config_schema(),
+					'type'                 => 'object',
+					'required'             => array( 'from_name', 'from_email', 'reply_to', 'subject', 'html_text', 'brand_id' ),
+					'properties'           => array(
 						'campaign_id' => array(
 							'type'        => array( 'string', 'null' ),
 							'description' => __( 'Existing campaign ID to update. Omit to create a new campaign.', 'data-machine-business' ),
@@ -152,16 +208,151 @@ class SendyAbilities {
 						'html_text'   => array( 'type' => 'string' ),
 						'plain_text'  => array( 'type' => 'string' ),
 						'brand_id'    => array( 'type' => 'string' ),
-						'extra'       => array(
-							'type'        => 'object',
-							'description' => __( 'Optional extra Sendy create-campaign parameters.', 'data-machine-business' ),
-						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'required'   => array( 'success', 'campaign_id', 'message', 'created' ),
+					'properties' => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'campaign_id' => array( 'type' => array( 'string', 'null' ) ),
+						'message'     => array( 'type' => 'string' ),
+						'created'     => array( 'type' => 'boolean' ),
 					),
 				),
-				'output_schema'       => array( 'type' => 'object' ),
 				'execute_callback'    => array( $this, 'execute_push_campaign' ),
 				'permission_callback' => array( $this, 'check_permission' ),
 				'meta'                => array( 'show_in_rest' => false ),
+			)
+		);
+
+		// ── Campaign Management ──
+		wp_register_ability(
+			'datamachine/sendy-list-campaigns',
+			array(
+				'label'               => __( 'Sendy: List Campaigns', 'data-machine-business' ),
+				'description'         => __( 'List Sendy campaigns from the configured database.', 'data-machine-business' ),
+				'category'            => 'datamachine-publishing',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'per_page' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => 100,
+						),
+						'offset'   => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'status'   => array(
+							'type' => 'string',
+							'enum' => array( 'sent', 'draft', 'scheduled' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'required'   => array( 'total', 'per_page', 'offset', 'campaigns' ),
+					'properties' => array(
+						'total'     => array( 'type' => 'integer' ),
+						'per_page'  => array( 'type' => 'integer' ),
+						'offset'    => array( 'type' => 'integer' ),
+						'campaigns' => array(
+							'type'  => 'array',
+							'items' => $this->campaign_summary_schema(),
+						),
+					),
+				),
+				'execute_callback'    => array( $this, 'execute_list_campaigns' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'meta'                => array(
+					'show_in_rest' => false,
+					'annotations'  => array(
+						'readonly'   => true,
+						'idempotent' => true,
+					),
+				),
+			)
+		);
+
+		$campaign_detail_schema                             = $this->campaign_summary_schema();
+		$campaign_detail_schema['properties']['from_name']  = array( 'type' => 'string' );
+		$campaign_detail_schema['properties']['from_email'] = array( 'type' => 'string' );
+		$campaign_detail_schema['properties']['reply_to']   = array( 'type' => 'string' );
+		$campaign_detail_schema['properties']['errors']     = array( 'type' => 'string' );
+		$campaign_detail_schema['required'][]               = 'from_name';
+		$campaign_detail_schema['required'][]               = 'from_email';
+		$campaign_detail_schema['required'][]               = 'reply_to';
+		$campaign_detail_schema['required'][]               = 'errors';
+
+		wp_register_ability(
+			'datamachine/sendy-get-campaign',
+			array(
+				'label'               => __( 'Sendy: Get Campaign', 'data-machine-business' ),
+				'description'         => __( 'Get one Sendy campaign from the configured database.', 'data-machine-business' ),
+				'category'            => 'datamachine-publishing',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'campaign_id' ),
+					'properties'           => array(
+						'campaign_id' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => $campaign_detail_schema,
+				'execute_callback'    => array( $this, 'execute_get_campaign' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'meta'                => array(
+					'show_in_rest' => false,
+					'annotations'  => array(
+						'readonly'   => true,
+						'idempotent' => true,
+					),
+				),
+			)
+		);
+
+		wp_register_ability(
+			'datamachine/sendy-delete-campaign',
+			array(
+				'label'               => __( 'Sendy: Delete Campaign', 'data-machine-business' ),
+				'description'         => __( 'Delete a Sendy draft campaign. Sent and sending campaigns are protected.', 'data-machine-business' ),
+				'category'            => 'datamachine-publishing',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'campaign_id' ),
+					'properties'           => array(
+						'campaign_id' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'required'   => array( 'success', 'message' ),
+					'properties' => array(
+						'success' => array( 'type' => 'boolean' ),
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => array( $this, 'execute_delete_campaign' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'meta'                => array(
+					'show_in_rest' => false,
+					'annotations'  => array(
+						'readonly'    => false,
+						'idempotent'  => false,
+						'destructive' => true,
+					),
+				),
 			)
 		);
 
@@ -255,6 +446,71 @@ class SendyAbilities {
 	}
 
 	/**
+	 * Resolve the DMB-owned Sendy configuration for campaign operations.
+	 *
+	 * Deployments may provide secrets through the filter instead of persisting
+	 * them in the network option. The filter remains owned by this integration;
+	 * consumers never pass credentials through an ability input.
+	 *
+	 * @return array
+	 */
+	public static function get_campaign_config(): array {
+		$config = get_site_option( self::CONFIG_OPTION, array() );
+		$config = is_array( $config ) ? $config : array();
+
+		/**
+		 * Filter the canonical Sendy connection configuration.
+		 *
+		 * @param array $config Keys: api_key, sendy_url, and optional db.
+		 */
+		return apply_filters( 'datamachine_sendy_config', $config );
+	}
+
+	/**
+	 * Build a campaign client from canonical configuration.
+	 *
+	 * @param string $requirement Required connection: api or db.
+	 * @return SendyClient|\WP_Error
+	 */
+	private function campaign_client( string $requirement ) {
+		$config = self::get_campaign_config();
+		if ( empty( $config ) ) {
+			return new \WP_Error(
+				'sendy_provider_unavailable',
+				__( 'The Sendy provider is not configured.', 'data-machine-business' )
+			);
+		}
+
+		if ( 'api' === $requirement ) {
+			if ( empty( $config['api_key'] ) || empty( $config['sendy_url'] ) ) {
+				return new \WP_Error(
+					'sendy_config_incomplete',
+					__( 'The Sendy API configuration requires api_key and sendy_url.', 'data-machine-business' )
+				);
+			}
+
+			if ( ! wp_http_validate_url( (string) $config['sendy_url'] ) ) {
+				return new \WP_Error(
+					'sendy_config_invalid',
+					__( 'The configured Sendy URL is invalid.', 'data-machine-business' )
+				);
+			}
+		}
+
+		if ( 'db' === $requirement ) {
+			$db = isset( $config['db'] ) && is_array( $config['db'] ) ? $config['db'] : array();
+			if ( empty( $db['host'] ) || empty( $db['user'] ) || empty( $db['name'] ) ) {
+				return new \WP_Error(
+					'sendy_db_not_configured',
+					__( 'The Sendy database configuration requires host, user, and name.', 'data-machine-business' )
+				);
+			}
+		}
+
+		return new SendyClient( $config );
+	}
+
+	/**
 	 * Execute datamachine/sendy-subscribe.
 	 *
 	 * @param array $input Ability input.
@@ -289,12 +545,38 @@ class SendyAbilities {
 	 * @return array|\WP_Error
 	 */
 	public function execute_push_campaign( array $input ) {
-		$client = $this->client_from_input( $input );
+		$client = $this->campaign_client( 'api' );
 		if ( is_wp_error( $client ) ) {
 			return $client;
 		}
 
-		return $client->push_campaign(
+		$required = array( 'from_name', 'from_email', 'reply_to', 'subject', 'html_text', 'brand_id' );
+		foreach ( $required as $field ) {
+			if ( ! isset( $input[ $field ] ) || '' === trim( (string) $input[ $field ] ) ) {
+				/* translators: %s: Sendy campaign input field name. */
+				$message = sprintf( __( '%s is required.', 'data-machine-business' ), $field );
+				return new \WP_Error(
+					'sendy_validation_error',
+					$message
+				);
+			}
+		}
+
+		if ( ! is_email( (string) $input['from_email'] ) || ! is_email( (string) $input['reply_to'] ) ) {
+			return new \WP_Error(
+				'sendy_validation_error',
+				__( 'from_email and reply_to must be valid email addresses.', 'data-machine-business' )
+			);
+		}
+
+		if ( isset( $input['campaign_id'] ) && ( ! ctype_digit( (string) $input['campaign_id'] ) || (int) $input['campaign_id'] < 1 ) ) {
+			return new \WP_Error(
+				'sendy_validation_error',
+				__( 'campaign_id must be a positive numeric identifier.', 'data-machine-business' )
+			);
+		}
+
+		$result = $client->push_campaign(
 			array(
 				'campaign_id' => isset( $input['campaign_id'] ) ? $input['campaign_id'] : null,
 				'from_name'   => isset( $input['from_name'] ) ? (string) $input['from_name'] : '',
@@ -304,9 +586,76 @@ class SendyAbilities {
 				'html_text'   => isset( $input['html_text'] ) ? (string) $input['html_text'] : '',
 				'plain_text'  => isset( $input['plain_text'] ) ? (string) $input['plain_text'] : '',
 				'brand_id'    => isset( $input['brand_id'] ) ? (string) $input['brand_id'] : '',
-				'extra'       => isset( $input['extra'] ) && is_array( $input['extra'] ) ? $input['extra'] : array(),
 			)
 		);
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		// Raw provider responses are internal diagnostics and may contain secrets.
+		unset( $result['raw'] );
+		return $result;
+	}
+
+	/**
+	 * Execute datamachine/sendy-list-campaigns.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public function execute_list_campaigns( array $input ) {
+		$client = $this->campaign_client( 'db' );
+		if ( is_wp_error( $client ) ) {
+			return $client;
+		}
+
+		$per_page = isset( $input['per_page'] ) ? (int) $input['per_page'] : 20;
+		$offset   = isset( $input['offset'] ) ? (int) $input['offset'] : 0;
+		$status   = isset( $input['status'] ) ? (string) $input['status'] : '';
+		if ( $per_page < 1 || $per_page > 100 || $offset < 0 || ( '' !== $status && ! in_array( $status, array( 'sent', 'draft', 'scheduled' ), true ) ) ) {
+			return new \WP_Error( 'sendy_validation_error', __( 'Invalid campaign list parameters.', 'data-machine-business' ) );
+		}
+
+		return $client->list_campaigns(
+			array(
+				'per_page' => $per_page,
+				'offset'   => $offset,
+				'status'   => $status,
+			)
+		);
+	}
+
+	/**
+	 * Execute datamachine/sendy-get-campaign.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public function execute_get_campaign( array $input ) {
+		$campaign_id = isset( $input['campaign_id'] ) ? (int) $input['campaign_id'] : 0;
+		if ( $campaign_id < 1 ) {
+			return new \WP_Error( 'sendy_validation_error', __( 'campaign_id must be a positive integer.', 'data-machine-business' ) );
+		}
+
+		$client = $this->campaign_client( 'db' );
+		return is_wp_error( $client ) ? $client : $client->get_campaign( $campaign_id );
+	}
+
+	/**
+	 * Execute datamachine/sendy-delete-campaign.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public function execute_delete_campaign( array $input ) {
+		$campaign_id = isset( $input['campaign_id'] ) ? (int) $input['campaign_id'] : 0;
+		if ( $campaign_id < 1 ) {
+			return new \WP_Error( 'sendy_validation_error', __( 'campaign_id must be a positive integer.', 'data-machine-business' ) );
+		}
+
+		$client = $this->campaign_client( 'db' );
+		return is_wp_error( $client ) ? $client : $client->delete_campaign( $campaign_id );
 	}
 
 	/**

--- a/inc/Sendy/SendyClient.php
+++ b/inc/Sendy/SendyClient.php
@@ -259,10 +259,11 @@ class SendyClient {
 	 * create-campaign params).
 	 *
 	 * @param array $campaign Campaign content and sender identity.
-	 * @return array Result keyed by success (bool), campaign_id (string|null),
-	 *               message (string), created (bool), raw (string).
+	 * @return array|\WP_Error Result keyed by success (bool), campaign_id
+	 *                         (string|null), message (string), created (bool),
+	 *                         raw (string); or a normalized transport error.
 	 */
-	public function push_campaign( array $campaign ): array {
+	public function push_campaign( array $campaign ) {
 		if ( ! $this->has_api_config() ) {
 			return array(
 				'success'     => false,
@@ -293,12 +294,15 @@ class SendyClient {
 			);
 
 			if ( is_wp_error( $check ) ) {
-				return array(
-					'success'     => false,
-					'campaign_id' => $campaign_id,
-					'message'     => 'Failed to check campaign status: ' . $check->get_error_message(),
-					'created'     => false,
-					'raw'         => '',
+				return $this->normalize_transport_error( $check );
+			}
+
+			$status_code = wp_remote_retrieve_response_code( $check );
+			if ( $status_code < 200 || $status_code >= 300 ) {
+				return new \WP_Error(
+					'sendy_remote_error',
+					'Sendy returned an unsuccessful response while checking campaign status.',
+					array( 'status' => $status_code )
 				);
 			}
 
@@ -342,12 +346,15 @@ class SendyClient {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return array(
-				'success'     => false,
-				'campaign_id' => $campaign_id,
-				'message'     => $response->get_error_message(),
-				'created'     => false,
-				'raw'         => '',
+			return $this->normalize_transport_error( $response );
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		if ( $status_code < 200 || $status_code >= 300 ) {
+			return new \WP_Error(
+				'sendy_remote_error',
+				'Sendy returned an unsuccessful campaign response.',
+				array( 'status' => $status_code )
 			);
 		}
 
@@ -362,11 +369,14 @@ class SendyClient {
 
 		// Sendy returns the campaign ID (numeric) on success, or an error string.
 		$success = $created || ( '/api/campaigns/update.php' === $endpoint && false === stripos( $raw, 'error' ) );
+		if ( ! $success ) {
+			return new \WP_Error( 'sendy_remote_error', 'Sendy rejected the campaign request.' );
+		}
 
 		return array(
 			'success'     => $success,
 			'campaign_id' => $campaign_id,
-			'message'     => $success ? 'Campaign pushed to Sendy successfully.' : trim( $raw ),
+			'message'     => 'Campaign pushed to Sendy successfully.',
 			'created'     => $created,
 			'raw'         => $raw,
 		);
@@ -526,7 +536,10 @@ class SendyClient {
 			);
 		}
 
-		$db->delete( 'campaigns', array( 'id' => $campaign_id ), array( '%d' ) );
+		$deleted = $db->delete( 'campaigns', array( 'id' => $campaign_id ), array( '%d' ) );
+		if ( false === $deleted ) {
+			return new \WP_Error( 'sendy_db_delete_failed', 'Failed to delete the Sendy campaign.' );
+		}
 
 		return array(
 			'success' => true,
@@ -816,7 +829,7 @@ class SendyClient {
 
 			$sum_open_rate  += $open_rate;
 			$sum_click_rate += $click_rate;
-			$analysed++;
+			++$analysed;
 
 			$campaigns[] = array(
 				'id'         => (int) $c['id'],
@@ -864,6 +877,22 @@ class SendyClient {
 	// ─── Helpers ────────────────────────────────────────────────────────────
 
 	/**
+	 * Normalize HTTP failures without returning provider or credential details.
+	 *
+	 * @param \WP_Error $error WordPress HTTP error.
+	 * @return \WP_Error
+	 */
+	private function normalize_transport_error( \WP_Error $error ): \WP_Error {
+		$code    = strtolower( (string) $error->get_error_code() );
+		$message = strtolower( $error->get_error_message() );
+		if ( false !== strpos( $code, 'timeout' ) || false !== strpos( $message, 'timed out' ) || false !== strpos( $message, 'timeout' ) || false !== strpos( $message, 'curl error 28' ) ) {
+			return new \WP_Error( 'sendy_timeout', 'The Sendy request timed out.' );
+		}
+
+		return new \WP_Error( 'sendy_remote_error', 'The Sendy request failed.' );
+	}
+
+	/**
 	 * Shape a raw campaign DB row into a normalised summary.
 	 *
 	 * @param array $c Raw campaign row.
@@ -880,7 +909,7 @@ class SendyClient {
 			'status'         => $this->campaign_status( $c ),
 			'sent'           => ! empty( $c['sent'] ) ? (int) $c['sent'] : null,
 			'sent_date'      => ! empty( $c['sent'] ) ? gmdate( 'Y-m-d H:i:s', (int) $c['sent'] ) : null,
-			'scheduled_date' => ( ! empty( $c['send_date'] ) && '0' !== (string) $c['send_date'] ) ? gmdate( 'Y-m-d H:i:s', (int) $c['send_date'] ) : null,
+			'scheduled_date' => ! empty( $c['send_date'] ) ? gmdate( 'Y-m-d H:i:s', (int) $c['send_date'] ) : null,
 			'to_send'        => isset( $c['to_send'] ) ? (int) $c['to_send'] : 0,
 			'recipients'     => $recipients,
 			'opens'          => $opens,
@@ -900,14 +929,14 @@ class SendyClient {
 	 * @return string sent|sending|scheduled|draft.
 	 */
 	private function campaign_status( array $campaign ): string {
-		if ( ! empty( $campaign['sent'] ) && '0' !== (string) $campaign['sent'] ) {
+		if ( ! empty( $campaign['sent'] ) ) {
 			if ( isset( $campaign['to_send'], $campaign['recipients'] ) && (int) $campaign['to_send'] > (int) $campaign['recipients'] ) {
 				return 'sending';
 			}
 			return 'sent';
 		}
 
-		if ( ! empty( $campaign['send_date'] ) && '0' !== (string) $campaign['send_date'] ) {
+		if ( ! empty( $campaign['send_date'] ) ) {
 			return 'scheduled';
 		}
 

--- a/tests/fixtures/sendy-campaign-http.json
+++ b/tests/fixtures/sendy-campaign-http.json
@@ -1,0 +1,18 @@
+{
+  "create": {
+    "code": 200,
+    "body": "321"
+  },
+  "exists": {
+    "code": 200,
+    "body": "Campaign exists"
+  },
+  "update": {
+    "code": 200,
+    "body": "Campaign updated"
+  },
+  "remote_error": {
+    "code": 500,
+    "body": "Remote failure containing api-secret and db-secret"
+  }
+}

--- a/tests/sendy-campaign-abilities-smoke.php
+++ b/tests/sendy-campaign-abilities-smoke.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Integration smoke coverage for the credential-free Sendy campaign surface.
+ *
+ * Run with: php tests/sendy-campaign-abilities-smoke.php
+ */
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static bool $allowed = false;
+
+		public static function can_manage(): bool {
+			return self::$allowed;
+		}
+	}
+
+	class AbilityRegistration {
+		public static function on_abilities_api_init( callable $callback ): void {
+			$callback();
+		}
+	}
+}
+
+namespace {
+	$root          = dirname( __DIR__ );
+	$failures      = array();
+	$passes        = 0;
+	$registered    = array();
+	$sendy_config  = array();
+	$http_mode     = 'create';
+	$http_fixtures = json_decode( file_get_contents( __DIR__ . '/fixtures/sendy-campaign-http.json' ), true );
+
+	define( 'ABSPATH', $root . '/' );
+	define( 'ARRAY_A', 'ARRAY_A' );
+
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private $data;
+
+		public function __construct( string $code, string $message, $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data() {
+			return $this->data;
+		}
+	}
+
+	class wpdb {
+		private array $campaigns;
+
+		public function __construct() {
+			$this->campaigns = array(
+				101 => array(
+					'id' => 101, 'title' => 'Draft campaign', 'sent' => '', 'to_send' => 0,
+					'recipients' => 0, 'opens' => 0, 'clicks' => 0, 'send_date' => '',
+					'lists' => '1', 'opens_tracking' => 1, 'links_tracking' => 1,
+					'campaign_stopped' => 0, 'from_name' => 'Extra Chill',
+					'from_email' => 'newsletter@example.com', 'reply_to' => 'reply@example.com',
+					'errors' => '',
+				),
+				102 => array(
+					'id' => 102, 'title' => 'Sent campaign', 'sent' => 1700000000, 'to_send' => 50,
+					'recipients' => 50, 'opens' => 25, 'clicks' => 5, 'send_date' => '',
+					'lists' => '1', 'opens_tracking' => 1, 'links_tracking' => 1,
+					'campaign_stopped' => 0, 'from_name' => 'Extra Chill',
+					'from_email' => 'newsletter@example.com', 'reply_to' => 'reply@example.com',
+					'errors' => '',
+				),
+			);
+		}
+
+		public function prepare( string $query, ...$args ): string {
+			return vsprintf( $query, $args );
+		}
+
+		public function get_var( string $query ) {
+			return count( $this->filtered( $query ) );
+		}
+
+		public function get_results( string $query, string $output ): array {
+			return array_values( $this->filtered( $query ) );
+		}
+
+		public function get_row( string $query, string $output ): ?array {
+			preg_match( '/id = (\d+)/', $query, $matches );
+			$id = isset( $matches[1] ) ? (int) $matches[1] : 0;
+			return $this->campaigns[ $id ] ?? null;
+		}
+
+		public function delete( string $table, array $where, array $formats ) {
+			$id = (int) $where['id'];
+			if ( ! isset( $this->campaigns[ $id ] ) ) {
+				return false;
+			}
+			unset( $this->campaigns[ $id ] );
+			return 1;
+		}
+
+		private function filtered( string $query ): array {
+			return array_filter(
+				$this->campaigns,
+				static function ( array $campaign ) use ( $query ): bool {
+					if ( false !== strpos( $query, 'sent != ""' ) ) {
+						return ! empty( $campaign['sent'] );
+					}
+					if ( false !== strpos( $query, 'send_date != ""' ) ) {
+						return ! empty( $campaign['send_date'] );
+					}
+					if ( false !== strpos( $query, 'sent = ""' ) ) {
+						return empty( $campaign['sent'] ) && empty( $campaign['send_date'] );
+					}
+					return true;
+				}
+			);
+		}
+	}
+
+	function assert_sendy( bool $condition, string $name ): void {
+		global $failures, $passes;
+		if ( $condition ) {
+			++$passes;
+			return;
+		}
+		$failures[] = $name;
+	}
+
+	function __( string $text, string $domain = '' ): string {
+		return $text;
+	}
+
+	function wp_register_ability( string $name, array $definition ): void {
+		global $registered;
+		$registered[ $name ] = $definition;
+	}
+
+	function get_site_option( string $option, $default = array() ) {
+		global $sendy_config;
+		return $sendy_config ?: $default;
+	}
+
+	function apply_filters( string $hook, $value ) {
+		return $value;
+	}
+
+	function wp_parse_args( array $args, array $defaults ): array {
+		return array_merge( $defaults, $args );
+	}
+
+	function untrailingslashit( string $value ): string {
+		return rtrim( $value, '/' );
+	}
+
+	function wp_http_validate_url( string $url ) {
+		return filter_var( $url, FILTER_VALIDATE_URL ) ? $url : false;
+	}
+
+	function is_email( string $email ) {
+		return filter_var( $email, FILTER_VALIDATE_EMAIL ) ? $email : false;
+	}
+
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+
+	function sanitize_text_field( $value ): string {
+		return trim( (string) $value );
+	}
+
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	function wp_remote_post( string $url, array $args ) {
+		global $http_mode, $http_fixtures;
+		if ( 'timeout' === $http_mode ) {
+			return new WP_Error( 'http_request_failed', 'cURL error 28: api-secret timed out' );
+		}
+		if ( false !== strpos( $url, '/status.php' ) ) {
+			return $http_fixtures['exists'];
+		}
+		if ( 'remote_error' === $http_mode ) {
+			return $http_fixtures['remote_error'];
+		}
+		return $http_fixtures[ false !== strpos( $url, '/update.php' ) ? 'update' : 'create' ];
+	}
+
+	function wp_remote_retrieve_body( array $response ): string {
+		return $response['body'];
+	}
+
+	function wp_remote_retrieve_response_code( array $response ): int {
+		return $response['code'];
+	}
+
+	require_once $root . '/inc/Sendy/SendyClient.php';
+	require_once $root . '/inc/Abilities/Sendy/SendyAbilities.php';
+
+	$abilities = new \DataMachineBusiness\Abilities\Sendy\SendyAbilities();
+	$campaign_abilities = array(
+		'datamachine/sendy-push-campaign',
+		'datamachine/sendy-list-campaigns',
+		'datamachine/sendy-get-campaign',
+		'datamachine/sendy-delete-campaign',
+	);
+	foreach ( $campaign_abilities as $ability_name ) {
+		assert_sendy( isset( $registered[ $ability_name ] ), "{$ability_name} is registered" );
+		assert_sendy( ! isset( $registered[ $ability_name ]['input_schema']['properties']['config'] ), "{$ability_name} does not accept credentials" );
+		assert_sendy( ! empty( $registered[ $ability_name ]['output_schema']['properties'] ), "{$ability_name} has an explicit output schema" );
+	}
+
+	assert_sendy( ! $abilities->check_permission(), 'campaign management rejects unauthorized callers' );
+	\DataMachine\Abilities\PermissionHelper::$allowed = true;
+	assert_sendy( $abilities->check_permission(), 'campaign management permits managers' );
+
+	$absent = $abilities->execute_list_campaigns( array() );
+	assert_sendy( is_wp_error( $absent ) && 'sendy_provider_unavailable' === $absent->get_error_code(), 'absent provider is explicit' );
+
+	$sendy_config = array( 'api_key' => 'api-secret' );
+	$invalid      = $abilities->execute_push_campaign( array() );
+	assert_sendy( is_wp_error( $invalid ) && 'sendy_config_incomplete' === $invalid->get_error_code(), 'incomplete API configuration is explicit' );
+	$db_missing = $abilities->execute_list_campaigns( array() );
+	assert_sendy( is_wp_error( $db_missing ) && 'sendy_db_not_configured' === $db_missing->get_error_code(), 'absent database configuration is explicit' );
+
+	$sendy_config = array(
+		'api_key'   => 'api-secret',
+		'sendy_url' => 'https://sendy.example.test',
+		'db'        => array( 'host' => 'db', 'user' => 'reader', 'pass' => 'db-secret', 'name' => 'sendy' ),
+	);
+	$campaign_input = array(
+		'from_name'  => 'Extra Chill',
+		'from_email' => 'newsletter@example.com',
+		'reply_to'   => 'reply@example.com',
+		'subject'    => 'Campaign subject',
+		'html_text'  => '<p>Campaign</p>',
+		'plain_text' => 'Campaign',
+		'brand_id'   => '1',
+	);
+
+	$bad_input = $abilities->execute_push_campaign( array_merge( $campaign_input, array( 'from_email' => 'invalid' ) ) );
+	assert_sendy( is_wp_error( $bad_input ) && 'sendy_validation_error' === $bad_input->get_error_code(), 'campaign input validation is explicit' );
+	$bad_list = $abilities->execute_list_campaigns( array( 'status' => 'unknown' ) );
+	assert_sendy( is_wp_error( $bad_list ) && 'sendy_validation_error' === $bad_list->get_error_code(), 'campaign list validation is explicit' );
+
+	$http_mode = 'create';
+	$created   = $abilities->execute_push_campaign( $campaign_input );
+	assert_sendy( ! is_wp_error( $created ) && '321' === $created['campaign_id'] && true === $created['created'], 'Newsletter campaign create path succeeds' );
+	assert_sendy( ! isset( $created['raw'] ), 'campaign create response omits raw provider data' );
+
+	$updated = $abilities->execute_push_campaign( array_merge( $campaign_input, array( 'campaign_id' => '321' ) ) );
+	assert_sendy( ! is_wp_error( $updated ) && false === $updated['created'], 'Newsletter campaign update path succeeds' );
+
+	$list = $abilities->execute_list_campaigns( array( 'per_page' => 20, 'offset' => 0 ) );
+	assert_sendy( ! is_wp_error( $list ) && 2 === $list['total'] && 2 === count( $list['campaigns'] ), 'Newsletter campaign list path succeeds' );
+	$get = $abilities->execute_get_campaign( array( 'campaign_id' => 101 ) );
+	assert_sendy( ! is_wp_error( $get ) && 'Draft campaign' === $get['title'], 'Newsletter campaign get path succeeds' );
+	$sent_delete = $abilities->execute_delete_campaign( array( 'campaign_id' => 102 ) );
+	assert_sendy( is_wp_error( $sent_delete ) && 'cannot_delete_sent' === $sent_delete->get_error_code(), 'sent campaigns remain protected' );
+	$deleted = $abilities->execute_delete_campaign( array( 'campaign_id' => 101 ) );
+	assert_sendy( ! is_wp_error( $deleted ) && true === $deleted['success'], 'Newsletter campaign delete path succeeds' );
+
+	$http_mode   = 'remote_error';
+	$remote_error = $abilities->execute_push_campaign( $campaign_input );
+	assert_sendy( is_wp_error( $remote_error ) && 'sendy_remote_error' === $remote_error->get_error_code(), 'remote provider errors are explicit' );
+	$http_mode = 'timeout';
+	$timeout   = $abilities->execute_push_campaign( $campaign_input );
+	assert_sendy( is_wp_error( $timeout ) && 'sendy_timeout' === $timeout->get_error_code(), 'provider timeouts are explicit' );
+
+	$public_results = array( $absent, $invalid, $db_missing, $created, $updated, $list, $get, $deleted, $remote_error, $timeout );
+	foreach ( $public_results as $result ) {
+		if ( is_wp_error( $result ) ) {
+			$result = array( $result->get_error_code(), $result->get_error_message(), $result->get_error_data() );
+		}
+		$serialized = serialize( $result );
+		assert_sendy( false === strpos( $serialized, 'api-secret' ) && false === strpos( $serialized, 'db-secret' ), 'credentials are redacted from public results' );
+	}
+
+	if ( ! empty( $failures ) ) {
+		fwrite( STDERR, implode( PHP_EOL, $failures ) . PHP_EOL );
+		exit( 1 );
+	}
+
+	echo "Sendy campaign ability smoke checks passed ({$passes} assertions).\n";
+}


### PR DESCRIPTION
## Summary
- expose create/update, list, get, and delete through stable management-gated Sendy campaign abilities
- move campaign credentials behind the DMB-owned `datamachine_sendy_config` option/filter and normalize validation, provider, remote, timeout, and delete errors without leaking raw responses
- add mocked HTTP and database integration coverage for Newsletter's complete campaign path, authorization, configuration failures, sent-campaign protection, and credential redaction

## Verification
- `php tests/sendy-campaign-abilities-smoke.php` (38 assertions)
- full PHP syntax check across tracked and new PHP files
- `homeboy review lint data-machine-business --changed-only` (PHPCS and PHPStan level 7, zero findings)
- `homeboy review audit data-machine-business --changed-since origin/main --profile architecture` (zero introduced findings)

## Follow-up
Newsletter consumer migration remains tracked in Extra-Chill/extrachill-newsletter#31. Unrelated stale smoke expectations discovered during verification are tracked in #103 and #104.

Closes #102