### PR TITLE
refactor: isolate optional provider bootstrap failures

### DIFF
--- a/data-machine-business.php
+++ b/data-machine-business.php
@@ -63,79 +63,14 @@ function datamachine_business_load_handlers() {
 			</div>
 			<?php
 		} );
-		return;
 	}
 
-	// Load Abilities (they self-register)
-	new \DataMachineBusiness\Abilities\Analytics\GoogleAnalyticsAbilities();
-	new \DataMachineBusiness\Abilities\Analytics\MediavineReportsAbilities();
-	new \DataMachineBusiness\Abilities\Analytics\ContentPerformanceAbility();
-	new \DataMachineBusiness\Abilities\Analytics\ContentFlagsAbility();
-
-	// Global AI tools.
-	new \DataMachineBusiness\Engine\AI\Tools\Global\GoogleAnalytics();
-
-	// Google Sheets
-	new \DataMachineBusiness\Abilities\GoogleSheets\FetchGoogleSheetsAbility();
-	new \DataMachineBusiness\Abilities\GoogleSheets\PublishGoogleSheetsAbility();
-	new \DataMachineBusiness\Abilities\Analytics\GoogleSearchConsoleAbilities();
-	new \DataMachineBusiness\Abilities\Analytics\GscOpportunityAbility();
-
-	// Google Sheets Handlers
-	new \DataMachineBusiness\Handlers\GoogleSheets\GoogleSheetsFetch();
-	new \DataMachineBusiness\Handlers\GoogleSheets\GoogleSheetsPublish();
-
-	// Google Drive (shares the unified GoogleAuth credential — see scope union below)
-	new \DataMachineBusiness\Abilities\GoogleDrive\FetchGoogleDriveAbility();
-	new \DataMachineBusiness\Abilities\GoogleDrive\ListGoogleDriveFilesAbility();
-	new \DataMachineBusiness\Abilities\GoogleDrive\ReadGoogleDriveDocAbility();
-	new \DataMachineBusiness\Abilities\GoogleDrive\DownloadGoogleDriveAbility();
-	new \DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveFetch();
-
-	// PageSpeed Insights
-	new \DataMachineBusiness\Abilities\PageSpeed\PageSpeedAbility();
-	new \DataMachineBusiness\Tools\PageSpeedTool();
-	\DataMachineBusiness\Api\PageSpeedAnalytics::register();
-
-	// Google Custom Search API tool.
-	new \DataMachineBusiness\Tools\GoogleSearch();
-
-	// Google Search Console global tool. Uses the legacy core option key so
-	// existing service-account configuration is adopted without migration.
-	new \DataMachineBusiness\Tools\GoogleSearchConsole();
-	\DataMachineBusiness\Api\GoogleSearchConsoleAnalytics::register();
-
-	// Slack
-	new \DataMachineBusiness\Abilities\Slack\PostMessageSlackAbility();
-	new \DataMachineBusiness\Abilities\Slack\FetchMessagesSlackAbility();
-
-	// Slack Handlers
-	new \DataMachineBusiness\Handlers\Slack\SlackPublish();
-	new \DataMachineBusiness\Handlers\Slack\SlackFetch();
-
-	// Discord
-	new \DataMachineBusiness\Abilities\Discord\PostMessageDiscordAbility();
-	new \DataMachineBusiness\Abilities\Discord\FetchMessagesDiscordAbility();
-
-	// Bing Webmaster Tools.
-	new \DataMachineBusiness\Abilities\Analytics\BingWebmasterAbilities();
-	new \DataMachineBusiness\Tools\BingWebmaster();
-
-	// Discord Handlers
-	new \DataMachineBusiness\Handlers\Discord\DiscordPublish();
-	new \DataMachineBusiness\Handlers\Discord\DiscordFetch();
-
-	// Business AI tools
-	new \DataMachineBusiness\Tools\AmazonAffiliateLink();
-
-	// Media Hygiene — orphan files + unused attachments.
-	new \DataMachineBusiness\Abilities\MediaHygiene\MediaHygieneAbility();
-
-	// Sendy — generic email-marketing integration (subscribe, campaigns, metrics).
-	new \DataMachineBusiness\Abilities\Sendy\SendyAbilities();
+	\DataMachineBusiness\Bootstrap\ProviderBootstrap::boot( \DataMachineBusiness\Bootstrap\ProviderModules::all() );
 }
 
-// Hook into plugins_loaded to ensure Data Machine core is loaded first
+\DataMachineBusiness\Bootstrap\ProviderBootstrap::register_discovery();
+
+// Hook into plugins_loaded to ensure Data Machine core is loaded first.
 add_action( 'plugins_loaded', 'datamachine_business_load_handlers', 20 );
 
 /**
@@ -164,6 +99,7 @@ add_filter( 'datamachine_analytics_ability_map', function ( array $ability_map )
  * the single source of truth for command registration.
  */
 add_action( 'plugins_loaded', function (): void {
+	// @phpstan-ignore-next-line WP_CLI can be false outside the analysis bootstrap.
 	if ( ! defined( 'WP_CLI' ) || ! WP_CLI || ! class_exists( 'DataMachine\\Cli\\BaseCommand' ) ) {
 		return;
 	}

--- a/inc/Bootstrap/ProviderBootstrap.php
+++ b/inc/Bootstrap/ProviderBootstrap.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Failure-isolated bootstrap for Data Machine Business providers.
+ *
+ * @package DataMachineBusiness
+ */
+
+namespace DataMachineBusiness\Bootstrap;
+
+defined( 'ABSPATH' ) || exit;
+
+final class ProviderBootstrap {
+
+	/** @var array<int,mixed> */
+	private array $modules;
+
+	/** @var array<string,array<string,mixed>> */
+	private array $availability = array();
+
+	private bool $registered = false;
+
+	private static ?self $current = null;
+
+	private static bool $discovery_registered = false;
+
+	/** @param array<int,mixed> $modules Provider modules in deterministic registration order. */
+	public function __construct( array $modules ) {
+		$this->modules = $modules;
+	}
+
+	/** @param ProviderModule[] $modules Provider modules in deterministic registration order. */
+	public static function boot( array $modules ): self {
+		if ( null === self::$current ) {
+			self::$current = new self( $modules );
+		}
+
+		self::$current->register();
+		return self::$current;
+	}
+
+	public static function register_discovery(): void {
+		if ( self::$discovery_registered ) {
+			return;
+		}
+
+		add_filter( 'datamachine_business_provider_availability', array( self::class, 'filter_provider_availability' ) );
+		add_filter( 'datamachine_business_capability_availability', array( self::class, 'filter_capability_availability' ) );
+		self::$discovery_registered = true;
+	}
+
+	/** @param array<string,array<string,mixed>> $availability Existing provider availability. */
+	public static function filter_provider_availability( array $availability ): array {
+		return array_merge( $availability, self::$current ? self::$current->availability() : array() );
+	}
+
+	/** @param array<string,array<string,mixed>> $availability Existing capability availability. */
+	public static function filter_capability_availability( array $availability ): array {
+		if ( null === self::$current ) {
+			return $availability;
+		}
+
+		foreach ( self::$current->availability() as $provider => $status ) {
+			foreach ( $status['capabilities'] as $capability ) {
+				$availability[ $capability ] = array(
+					'provider'  => $provider,
+					'available' => $status['available'],
+					'reason'    => $status['reason'],
+				);
+			}
+		}
+
+		return $availability;
+	}
+
+	public function register(): void {
+		if ( $this->registered ) {
+			return;
+		}
+
+		$this->registered = true;
+		foreach ( $this->modules as $index => $module ) {
+			if ( ! $module instanceof ProviderModule ) {
+				$this->availability[ 'invalid-module-' . $index ] = array(
+					'available'             => false,
+					'reason'                => 'invalid_module',
+					'missing_prerequisites' => array(),
+					'capabilities'          => array(),
+				);
+				continue;
+			}
+
+			$id = $module->id();
+			if ( isset( $this->availability[ $id ] ) ) {
+				continue;
+			}
+
+			try {
+				$missing = $module->missing_prerequisites();
+				if ( ! empty( $missing ) ) {
+					$this->availability[ $id ] = $this->status( $module, false, 'missing_prerequisites', $missing );
+					continue;
+				}
+
+				$module->register();
+				$this->availability[ $id ] = $this->status( $module, true, 'available' );
+			} catch ( \Throwable ) {
+				$this->availability[ $id ] = $this->status( $module, false, 'initialization_failed' );
+			}
+		}
+	}
+
+	/** @return array<string,array<string,mixed>> */
+	public function availability(): array {
+		return $this->availability;
+	}
+
+	/**
+	 * @param string[] $missing Missing prerequisite names.
+	 * @return array<string,mixed>
+	 */
+	private function status( ProviderModule $module, bool $available, string $reason, array $missing = array() ): array {
+		return array(
+			'available'             => $available,
+			'reason'                => $reason,
+			'missing_prerequisites' => $missing,
+			'capabilities'          => $module->capabilities(),
+		);
+	}
+}

--- a/inc/Bootstrap/ProviderModule.php
+++ b/inc/Bootstrap/ProviderModule.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * One isolated Data Machine Business provider module.
+ *
+ * @package DataMachineBusiness
+ */
+
+namespace DataMachineBusiness\Bootstrap;
+
+defined( 'ABSPATH' ) || exit;
+
+final class ProviderModule {
+
+	private string $id;
+
+	/** @var array<string,callable> */
+	private array $prerequisites;
+
+	/** @var string[] */
+	private array $capabilities;
+
+	/** @var callable */
+	private $initializer;
+
+	/**
+	 * @param array<string,callable> $prerequisites Named prerequisite checks.
+	 * @param string[]               $capabilities  Public surfaces supplied by the module.
+	 */
+	public function __construct( string $id, array $prerequisites, array $capabilities, callable $initializer ) {
+		if ( ! preg_match( '/^[a-z0-9][a-z0-9-]*$/', $id ) ) {
+			throw new \InvalidArgumentException( 'Provider module IDs must be non-empty slugs.' );
+		}
+
+		foreach ( $prerequisites as $name => $check ) {
+			if ( '' === $name ) {
+				throw new \InvalidArgumentException( 'Provider module prerequisites must be named callables.' );
+			}
+		}
+
+		foreach ( $capabilities as $capability ) {
+			if ( '' === $capability ) {
+				throw new \InvalidArgumentException( 'Provider module capabilities must be non-empty strings.' );
+			}
+		}
+
+		$this->id            = $id;
+		$this->prerequisites = $prerequisites;
+		$this->capabilities  = array_values( array_unique( $capabilities ) );
+		$this->initializer   = $initializer;
+	}
+
+	public function id(): string {
+		return $this->id;
+	}
+
+	/** @return string[] */
+	public function capabilities(): array {
+		return $this->capabilities;
+	}
+
+	/** @return string[] */
+	public function missing_prerequisites(): array {
+		$missing = array();
+
+		foreach ( $this->prerequisites as $name => $check ) {
+			if ( ! $check() ) {
+				$missing[] = $name;
+			}
+		}
+
+		return $missing;
+	}
+
+	public function register(): void {
+		( $this->initializer )();
+	}
+}

--- a/inc/Bootstrap/ProviderModules.php
+++ b/inc/Bootstrap/ProviderModules.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Data Machine Business provider module declarations.
+ *
+ * @package DataMachineBusiness
+ */
+
+namespace DataMachineBusiness\Bootstrap;
+
+defined( 'ABSPATH' ) || exit;
+
+final class ProviderModules {
+
+	/** @return ProviderModule[] */
+	public static function all(): array {
+		$abilities        = array(
+			'DataMachine\\Abilities\\AbilityRegistration' => static fn(): bool => class_exists( 'DataMachine\\Abilities\\AbilityRegistration' ),
+		);
+		$tools            = array(
+			'DataMachine\\Engine\\AI\\Tools\\BaseTool' => static fn(): bool => class_exists( 'DataMachine\\Engine\\AI\\Tools\\BaseTool' ),
+		);
+		$fetch_handlers   = array(
+			'DataMachine\\Core\\Steps\\Fetch\\Handlers\\FetchHandler' => static fn(): bool => class_exists( 'DataMachine\\Core\\Steps\\Fetch\\Handlers\\FetchHandler' ),
+		);
+		$publish_handlers = array(
+			'DataMachine\\Core\\Steps\\Publish\\Handlers\\PublishHandler' => static fn(): bool => class_exists( 'DataMachine\\Core\\Steps\\Publish\\Handlers\\PublishHandler' ),
+		);
+
+		return array(
+			new ProviderModule(
+				'google-analytics',
+				array_merge( $abilities, $tools ),
+				array( 'datamachine/google-analytics', 'tool:google_analytics' ),
+				static function (): void {
+					new \DataMachineBusiness\Abilities\Analytics\GoogleAnalyticsAbilities();
+					new \DataMachineBusiness\Engine\AI\Tools\Global\GoogleAnalytics();
+				}
+			),
+			new ProviderModule(
+				'mediavine',
+				$abilities,
+				array( 'datamachine/mediavine-reports' ),
+				static fn() => new \DataMachineBusiness\Abilities\Analytics\MediavineReportsAbilities()
+			),
+			new ProviderModule(
+				'content-insights',
+				$abilities,
+				array( 'datamachine/content-performance', 'datamachine/content-flags' ),
+				static function (): void {
+					new \DataMachineBusiness\Abilities\Analytics\ContentPerformanceAbility();
+					new \DataMachineBusiness\Abilities\Analytics\ContentFlagsAbility();
+				}
+			),
+			new ProviderModule(
+				'google-sheets',
+				array_merge( $abilities, $fetch_handlers, $publish_handlers ),
+				array( 'datamachine/fetch-googlesheets', 'datamachine/publish-googlesheets', 'handler:googlesheets_fetch', 'handler:googlesheets_publish' ),
+				static function (): void {
+					new \DataMachineBusiness\Abilities\GoogleSheets\FetchGoogleSheetsAbility();
+					new \DataMachineBusiness\Abilities\GoogleSheets\PublishGoogleSheetsAbility();
+					new \DataMachineBusiness\Handlers\GoogleSheets\GoogleSheetsFetch();
+					new \DataMachineBusiness\Handlers\GoogleSheets\GoogleSheetsPublish();
+				}
+			),
+			new ProviderModule(
+				'google-drive',
+				array_merge( $abilities, $fetch_handlers ),
+				array( 'datamachine/fetch-googledrive', 'datamachine/list-googledrive-files', 'datamachine/read-googledrive-doc', 'datamachine/download-googledrive', 'handler:googledrive_fetch' ),
+				static function (): void {
+					new \DataMachineBusiness\Abilities\GoogleDrive\FetchGoogleDriveAbility();
+					new \DataMachineBusiness\Abilities\GoogleDrive\ListGoogleDriveFilesAbility();
+					new \DataMachineBusiness\Abilities\GoogleDrive\ReadGoogleDriveDocAbility();
+					new \DataMachineBusiness\Abilities\GoogleDrive\DownloadGoogleDriveAbility();
+					new \DataMachineBusiness\Handlers\GoogleDrive\GoogleDriveFetch();
+				}
+			),
+			new ProviderModule(
+				'pagespeed',
+				array_merge( $abilities, $tools ),
+				array( 'datamachine/pagespeed', 'tool:pagespeed', 'rest:datamachine/v1/analytics/pagespeed' ),
+				static function (): void {
+					new \DataMachineBusiness\Abilities\PageSpeed\PageSpeedAbility();
+					new \DataMachineBusiness\Tools\PageSpeedTool();
+					\DataMachineBusiness\Api\PageSpeedAnalytics::register();
+				}
+			),
+			new ProviderModule(
+				'google-search',
+				$tools,
+				array( 'tool:google_search' ),
+				static fn() => new \DataMachineBusiness\Tools\GoogleSearch()
+			),
+			new ProviderModule(
+				'google-search-console',
+				array_merge( $abilities, $tools ),
+				array( 'datamachine/google-search-console', 'datamachine/gsc-opportunity', 'tool:google_search_console', 'rest:datamachine/v1/analytics/gsc' ),
+				static function (): void {
+					new \DataMachineBusiness\Abilities\Analytics\GoogleSearchConsoleAbilities();
+					new \DataMachineBusiness\Abilities\Analytics\GscOpportunityAbility();
+					new \DataMachineBusiness\Tools\GoogleSearchConsole();
+					\DataMachineBusiness\Api\GoogleSearchConsoleAnalytics::register();
+				}
+			),
+			new ProviderModule(
+				'slack',
+				array_merge( $abilities, $fetch_handlers, $publish_handlers ),
+				array( 'datamachine/post-message-slack', 'datamachine/fetch-messages-slack', 'handler:slack_publish', 'handler:slack_fetch' ),
+				static function (): void {
+					new \DataMachineBusiness\Abilities\Slack\PostMessageSlackAbility();
+					new \DataMachineBusiness\Abilities\Slack\FetchMessagesSlackAbility();
+					new \DataMachineBusiness\Handlers\Slack\SlackPublish();
+					new \DataMachineBusiness\Handlers\Slack\SlackFetch();
+				}
+			),
+			new ProviderModule(
+				'discord',
+				array_merge( $abilities, $fetch_handlers, $publish_handlers ),
+				array( 'datamachine/post-message-discord', 'datamachine/fetch-messages-discord', 'handler:discord_publish', 'handler:discord_fetch' ),
+				static function (): void {
+					new \DataMachineBusiness\Abilities\Discord\PostMessageDiscordAbility();
+					new \DataMachineBusiness\Abilities\Discord\FetchMessagesDiscordAbility();
+					new \DataMachineBusiness\Handlers\Discord\DiscordPublish();
+					new \DataMachineBusiness\Handlers\Discord\DiscordFetch();
+				}
+			),
+			new ProviderModule(
+				'bing-webmaster',
+				array_merge( $abilities, $tools ),
+				array( 'datamachine/bing-webmaster', 'tool:bing_webmaster' ),
+				static function (): void {
+					new \DataMachineBusiness\Abilities\Analytics\BingWebmasterAbilities();
+					new \DataMachineBusiness\Tools\BingWebmaster();
+				}
+			),
+			new ProviderModule(
+				'amazon-affiliate',
+				$tools,
+				array( 'tool:amazon_affiliate_link' ),
+				static fn() => new \DataMachineBusiness\Tools\AmazonAffiliateLink()
+			),
+			new ProviderModule(
+				'media-hygiene',
+				$abilities,
+				array( 'datamachine/media-hygiene' ),
+				static fn() => new \DataMachineBusiness\Abilities\MediaHygiene\MediaHygieneAbility()
+			),
+			new ProviderModule(
+				'sendy',
+				$abilities,
+				array( 'datamachine/sendy-subscribe', 'datamachine/sendy-push-campaign', 'datamachine/sendy-list-campaigns', 'datamachine/sendy-get-campaign', 'datamachine/sendy-delete-campaign', 'datamachine/sendy-metrics' ),
+				static fn() => new \DataMachineBusiness\Abilities\Sendy\SendyAbilities()
+			),
+		);
+	}
+}

--- a/tests/google-search-tool-smoke.php
+++ b/tests/google-search-tool-smoke.php
@@ -7,11 +7,11 @@
 
 $root = dirname( __DIR__ );
 
-$plugin_file = file_get_contents( $root . '/data-machine-business.php' );
-$tool_file   = file_get_contents( $root . '/inc/Tools/GoogleSearch.php' );
+$providers_file = file_get_contents( $root . '/inc/Bootstrap/ProviderModules.php' );
+$tool_file      = file_get_contents( $root . '/inc/Tools/GoogleSearch.php' );
 
 $checks = array(
-	'plugin instantiates Google Search tool' => str_contains( $plugin_file, 'new \\DataMachineBusiness\\Tools\\GoogleSearch();' ),
+	'provider module instantiates Google Search tool' => str_contains( $providers_file, 'new \\DataMachineBusiness\\Tools\\GoogleSearch()' ),
 	'tool registers google_search slug'      => str_contains( $tool_file, "registerTool( 'google_search'" ),
 	'tool keeps existing config option'      => str_contains( $tool_file, "get_site_option( 'datamachine_search_config'" ),
 	'tool uses Custom Search API endpoint'   => str_contains( $tool_file, 'https://www.googleapis.com/customsearch/v1' ),

--- a/tests/pagespeed-ownership-smoke.php
+++ b/tests/pagespeed-ownership-smoke.php
@@ -19,12 +19,12 @@ foreach ( $required_files as $relative_path ) {
 	}
 }
 
-$plugin_file = file_get_contents( $root . '/data-machine-business.php' );
-$readme      = file_get_contents( $root . '/README.md' );
+$providers_file = file_get_contents( $root . '/inc/Bootstrap/ProviderModules.php' );
+$readme         = file_get_contents( $root . '/README.md' );
 
-foreach ( array( 'PageSpeedAbility', 'PageSpeedTool', 'PageSpeedAnalytics', 'PageSpeedCommand' ) as $symbol ) {
-	if ( false === strpos( $plugin_file, $symbol ) ) {
-		$failures[] = "Plugin bootstrap does not reference {$symbol}";
+foreach ( array( 'PageSpeedAbility', 'PageSpeedTool', 'PageSpeedAnalytics' ) as $symbol ) {
+	if ( false === strpos( $providers_file, $symbol ) ) {
+		$failures[] = "PageSpeed provider module does not reference {$symbol}";
 	}
 }
 

--- a/tests/provider-bootstrap-smoke.php
+++ b/tests/provider-bootstrap-smoke.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Provider bootstrap isolation and discovery matrix.
+ *
+ * Run with: php tests/provider-bootstrap-smoke.php
+ */
+
+$root       = dirname( __DIR__ );
+$failures   = array();
+$passes     = 0;
+$filters    = array();
+$registered = array();
+
+define( 'ABSPATH', $root . '/' );
+
+function add_filter( string $hook, callable $callback ): void {
+	global $filters;
+	$filters[ $hook ][] = $callback;
+}
+
+function apply_filters( string $hook, $value ) {
+	global $filters;
+	foreach ( $filters[ $hook ] ?? array() as $callback ) {
+		$value = $callback( $value );
+	}
+	return $value;
+}
+
+function assert_provider_bootstrap( bool $condition, string $name ): void {
+	global $failures, $passes;
+	if ( $condition ) {
+		++$passes;
+		return;
+	}
+
+	$failures[] = $name;
+}
+
+require_once $root . '/inc/Bootstrap/ProviderModule.php';
+require_once $root . '/inc/Bootstrap/ProviderBootstrap.php';
+require_once $root . '/inc/Bootstrap/ProviderModules.php';
+
+use DataMachineBusiness\Bootstrap\ProviderBootstrap;
+use DataMachineBusiness\Bootstrap\ProviderModule;
+use DataMachineBusiness\Bootstrap\ProviderModules;
+
+$module = static function ( string $id, callable $prerequisite, callable $initializer ) use ( &$registered ): ProviderModule {
+	return new ProviderModule(
+		$id,
+		array( 'optional/dependency' => $prerequisite ),
+		array( 'ability:' . $id ),
+		static function () use ( $id, $initializer, &$registered ): void {
+			$initializer();
+			$registered[] = $id;
+		}
+	);
+};
+
+$bootstrap = new ProviderBootstrap(
+	array(
+		$module( 'missing', static fn(): bool => false, static function (): void {} ),
+		$module(
+			'prerequisite-throws',
+			static function (): bool {
+				throw new RuntimeException( 'Broken prerequisite check.' );
+			},
+			static function (): void {}
+		),
+		$module(
+			'initializer-throws',
+			static fn(): bool => true,
+			static function (): void {
+				throw new RuntimeException( 'Broken provider.' );
+			}
+		),
+		new stdClass(),
+		$module( 'healthy-first', static fn(): bool => true, static function (): void {} ),
+		$module( 'healthy-second', static fn(): bool => true, static function (): void {} ),
+		$module( 'healthy-first', static fn(): bool => true, static function (): void {} ),
+	)
+);
+$bootstrap->register();
+$bootstrap->register();
+$availability = $bootstrap->availability();
+
+assert_provider_bootstrap( 'missing_prerequisites' === $availability['missing']['reason'], 'absent optional dependency is reported locally' );
+assert_provider_bootstrap( array( 'optional/dependency' ) === $availability['missing']['missing_prerequisites'], 'missing prerequisite is discoverable by name' );
+assert_provider_bootstrap( 'initialization_failed' === $availability['prerequisite-throws']['reason'], 'throwing prerequisite is isolated' );
+assert_provider_bootstrap( 'initialization_failed' === $availability['initializer-throws']['reason'], 'throwing initializer is isolated' );
+assert_provider_bootstrap( 'invalid_module' === $availability['invalid-module-3']['reason'], 'misconfigured module is isolated' );
+assert_provider_bootstrap( true === $availability['healthy-first']['available'] && true === $availability['healthy-second']['available'], 'unrelated providers remain available' );
+assert_provider_bootstrap( array( 'healthy-first', 'healthy-second' ) === $registered, 'registration is deterministic and duplicate-safe' );
+assert_provider_bootstrap( 6 === count( $availability ), 'duplicate provider declaration does not replace its first result' );
+
+$actual_modules = ProviderModules::all();
+$actual_ids     = array_map( static fn( ProviderModule $provider ): string => $provider->id(), $actual_modules );
+$expected_ids   = array(
+	'google-analytics',
+	'mediavine',
+	'content-insights',
+	'google-sheets',
+	'google-drive',
+	'pagespeed',
+	'google-search',
+	'google-search-console',
+	'slack',
+	'discord',
+	'bing-webmaster',
+	'amazon-affiliate',
+	'media-hygiene',
+	'sendy',
+);
+assert_provider_bootstrap( $expected_ids === $actual_ids, 'production provider order is explicit and deterministic' );
+
+$absent_dependency_bootstrap = new ProviderBootstrap( $actual_modules );
+$absent_dependency_bootstrap->register();
+$absent_dependency_matrix = $absent_dependency_bootstrap->availability();
+foreach ( $expected_ids as $provider_id ) {
+	assert_provider_bootstrap(
+		'missing_prerequisites' === $absent_dependency_matrix[ $provider_id ]['reason'],
+		"{$provider_id} declares its optional dependencies locally"
+	);
+}
+
+$sendy = $actual_modules[13]->capabilities();
+assert_provider_bootstrap(
+	array(
+		'datamachine/sendy-subscribe',
+		'datamachine/sendy-push-campaign',
+		'datamachine/sendy-list-campaigns',
+		'datamachine/sendy-get-campaign',
+		'datamachine/sendy-delete-campaign',
+		'datamachine/sendy-metrics',
+	) === $sendy,
+	'Sendy public ability contract is unchanged'
+);
+
+$discovery_log = array();
+$discovery     = array(
+	new ProviderModule(
+		'discovery-ready',
+		array( 'ready' => static fn(): bool => true ),
+		array( 'datamachine/discovery-ready' ),
+		static function () use ( &$discovery_log ): void {
+			$discovery_log[] = 'ready';
+		}
+	),
+	new ProviderModule(
+		'discovery-missing',
+		array( 'missing-package' => static fn(): bool => false ),
+		array( 'datamachine/discovery-missing' ),
+		static function () use ( &$discovery_log ): void {
+			$discovery_log[] = 'missing';
+		}
+	),
+);
+ProviderBootstrap::register_discovery();
+ProviderBootstrap::register_discovery();
+ProviderBootstrap::boot( $discovery );
+ProviderBootstrap::boot( $discovery );
+
+$provider_discovery   = apply_filters( 'datamachine_business_provider_availability', array() );
+$capability_discovery = apply_filters( 'datamachine_business_capability_availability', array() );
+assert_provider_bootstrap( array( 'ready' ) === $discovery_log, 'static bootstrap is idempotent' );
+assert_provider_bootstrap( 2 === count( $provider_discovery ), 'provider availability is discoverable' );
+assert_provider_bootstrap( true === $capability_discovery['datamachine/discovery-ready']['available'], 'available capability is discoverable' );
+assert_provider_bootstrap( false === $capability_discovery['datamachine/discovery-missing']['available'], 'unavailable capability is discoverable' );
+assert_provider_bootstrap( 1 === count( $filters['datamachine_business_provider_availability'] ), 'provider discovery registration is duplicate-safe' );
+assert_provider_bootstrap( 1 === count( $filters['datamachine_business_capability_availability'] ), 'capability discovery registration is duplicate-safe' );
+
+if ( ! empty( $failures ) ) {
+	echo "FAILURES:\n" . implode( "\n", $failures ) . "\n";
+	exit( 1 );
+}
+
+echo "{$passes} assertions passed.\n";


### PR DESCRIPTION
## Summary
- replace the serial root bootstrap with deterministic, idempotent Business-owned provider modules
- isolate missing prerequisites and thrown initialization failures so unrelated providers continue registering
- expose provider and capability readiness through `datamachine_business_provider_availability` and `datamachine_business_capability_availability`

## Provider isolation
Each existing Business integration is declared in `ProviderModules` with named local prerequisites, its outward capabilities, and its existing initializer. `ProviderBootstrap` validates and runs each declaration independently, catches provider-local failures, skips duplicates, and preserves declaration order. The root plugin file is now a thin composition root.

Availability records expose `available`, `reason`, `missing_prerequisites`, and `capabilities`. Capability discovery projects that status per existing ability, handler, tool, or REST identifier without changing any generic Data Machine layer.

## Compatibility
- preserves all existing ability slugs, handler slugs, tool IDs, REST registrations, OAuth/provider configuration, analytics integrations, and CLI registration
- preserves the complete credential-free Sendy ability surface introduced in #105
- changes no provider business logic, configuration storage, public payload, version, or changelog
- updates static Google Search and PageSpeed ownership checks to follow the new composition file

## Tests
- `php tests/provider-bootstrap-smoke.php` (30 assertions): absent and throwing prerequisites, throwing initialization, malformed modules, duplicate/idempotent registration, deterministic order, provider/capability discovery, every production module's local dependency declaration, unrelated-provider continuity, and Sendy compatibility
- passing standalone suites: Amazon Affiliate, Bing Webmaster, Google Search, GSC site URL guard, Mediavine dimensional, Sendy campaign abilities
- `homeboy review lint ... --changed-only`: PHPCS and PHPStan pass with no findings
- `homeboy review audit ... --profile architecture`: no introduced findings
- `homeboy review build`: production package and PHP syntax checks pass
- `composer validate --strict`: valid with the existing version-field warning
- `composer audit`: no packages to audit

The repository's PHPUnit wrapper reports zero discovered tests, and the configured PR-profile runner is unavailable locally (`No such file or directory` for the aggregate lint job; the direct WP Codebox PHPUnit job exits without test detail). Three unrelated standalone smoke assertions also fail identically on a clean `main` checkout; they are tracked in #106 rather than folded into this structural PR.

Closes #101.