### PR TITLE
feat: own IndexNow provider integration

### DIFF
--- a/inc/Abilities/SEO/IndexNowAbilities.php
+++ b/inc/Abilities/SEO/IndexNowAbilities.php
@@ -1,0 +1,299 @@
+<?php
+/**
+ * IndexNow abilities and automatic URL submission.
+ *
+ * @package DataMachineBusiness\Abilities\SEO
+ */
+
+namespace DataMachineBusiness\Abilities\SEO;
+
+use DataMachine\Abilities\AbilityRegistration;
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\HttpClient;
+use DataMachine\Core\PluginSettings;
+
+defined( 'ABSPATH' ) || exit;
+
+class IndexNowAbilities {
+
+	public const API_ENDPOINT = 'https://api.indexnow.org/indexnow';
+	public const MAX_BATCH_SIZE = 10000;
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->register_abilities();
+		add_action( 'wp_after_insert_post', array( __CLASS__, 'on_post_saved' ), 10, 4 );
+		add_action( 'parse_request', array( __CLASS__, 'serve_key_file' ) );
+		self::$registered = true;
+	}
+
+	public static function on_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Post $post_before = null ): void {
+		if ( 'publish' !== $post->post_status || ! PluginSettings::get( 'indexnow_enabled', false ) ) {
+			return;
+		}
+
+		$post_type = get_post_type_object( $post->post_type );
+		if ( ! $post_type || ! $post_type->public || wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
+
+		/**
+		 * Filters whether to skip the automatic per-post IndexNow ping.
+		 *
+		 * @param bool     $skip    Whether to skip the auto-submit. Default false.
+		 * @param int      $post_id Post ID being published or updated.
+		 * @param \WP_Post $post    Post object.
+		 */
+		if ( apply_filters( 'datamachine_indexnow_skip_auto_submit', false, $post_id, $post ) ) {
+			return;
+		}
+
+		$url = get_permalink( $post_id );
+		if ( empty( $url ) ) {
+			return;
+		}
+
+		$result = self::submit_urls( array( $url ) );
+		do_action(
+			'datamachine_log',
+			$result['success'] ? 'debug' : 'warning',
+			$result['success'] ? 'IndexNow: Submitted URL on publish' : 'IndexNow: Failed to submit URL on publish',
+			array(
+				'url'         => $url,
+				'post_id'     => $post_id,
+				'post_type'   => $post->post_type,
+				'old_status'  => $post_before ? $post_before->post_status : 'new',
+				'response'    => $result['message'] ?? $result['error'] ?? '',
+				'status_code' => $result['status_code'] ?? '',
+			)
+		);
+	}
+
+	public static function serve_key_file( \WP $wp ): void {
+		$key = self::get_api_key();
+		if ( empty( $key ) || trim( $wp->request, '/' ) !== $key . '.txt' ) {
+			return;
+		}
+
+		header( 'Content-Type: text/plain; charset=utf-8' );
+		header( 'X-Robots-Tag: noindex' );
+		header( 'Cache-Control: public, max-age=86400' );
+		status_header( 200 );
+		echo esc_html( $key );
+		exit;
+	}
+
+	public static function submit_urls( array $urls ): array {
+		if ( empty( $urls ) ) {
+			return array( 'success' => false, 'error' => 'No URLs provided' );
+		}
+
+		$key = self::get_or_generate_key();
+		if ( empty( $key ) ) {
+			return array( 'success' => false, 'error' => 'Could not generate IndexNow API key' );
+		}
+
+		$urls = array_slice( array_values( array_unique( array_filter( $urls ) ) ), 0, self::MAX_BATCH_SIZE );
+		$host = wp_parse_url( $urls[0], PHP_URL_HOST ) ?: wp_parse_url( home_url(), PHP_URL_HOST );
+		$result = HttpClient::post(
+			self::API_ENDPOINT,
+			array(
+				'headers' => array( 'Content-Type' => 'application/json; charset=utf-8' ),
+				'body'    => wp_json_encode(
+					array(
+						'host'        => $host,
+						'key'         => $key,
+						'keyLocation' => home_url( '/' . $key . '.txt' ),
+						'urlList'     => $urls,
+					)
+				),
+				'timeout' => 30,
+				'context' => 'IndexNow Submission',
+			)
+		);
+
+		if ( ! $result['success'] ) {
+			return array(
+				'success'     => false,
+				'error'       => $result['error'] ?? 'HTTP request failed',
+				'status_code' => $result['status_code'] ?? 0,
+			);
+		}
+
+		$status_code = $result['status_code'] ?? 0;
+		if ( in_array( $status_code, array( 200, 202 ), true ) ) {
+			return array(
+				'success'     => true,
+				'message'     => 200 === $status_code ? 'URL submitted and accepted' : 'URL received, will be processed',
+				'status_code' => $status_code,
+				'url_count'   => count( $urls ),
+			);
+		}
+
+		$messages = array(
+			400 => 'Invalid request — check URL format',
+			403 => 'API key not valid — verify key file is accessible',
+			422 => 'URL does not belong to the host',
+			429 => 'Too many requests — rate limited',
+		);
+
+		return array(
+			'success'     => false,
+			'error'       => $messages[ $status_code ] ?? 'Unexpected response code: ' . $status_code,
+			'status_code' => $status_code,
+		);
+	}
+
+	public static function get_api_key(): string {
+		return PluginSettings::get( 'indexnow_api_key', '' );
+	}
+
+	public static function get_or_generate_key(): string {
+		return self::get_api_key() ?: self::generate_key();
+	}
+
+	public static function generate_key(): string {
+		$key                              = str_replace( '-', '', wp_generate_uuid4() );
+		$settings                         = get_option( 'datamachine_settings', array() );
+		$settings['indexnow_api_key']     = $key;
+		update_option( 'datamachine_settings', $settings );
+		PluginSettings::clearCache();
+		do_action( 'datamachine_log', 'info', 'IndexNow: Generated new API key', array( 'key_preview' => substr( $key, 0, 8 ) . '...' ) );
+		return $key;
+	}
+
+	public static function verify_key_file(): array {
+		$key = self::get_api_key();
+		if ( empty( $key ) ) {
+			return array( 'success' => false, 'error' => 'No API key configured. Generate one first.' );
+		}
+
+		$url    = home_url( '/' . $key . '.txt' );
+		$result = HttpClient::get( $url, array( 'timeout' => 10, 'context' => 'IndexNow Key Verification' ) );
+		if ( ! $result['success'] ) {
+			return array( 'success' => false, 'url' => $url, 'error' => 'Key file not accessible: ' . ( $result['error'] ?? 'unknown error' ) );
+		}
+
+		if ( trim( $result['data'] ?? '' ) !== $key ) {
+			return array( 'success' => false, 'url' => $url, 'error' => 'Key file content does not match API key' );
+		}
+
+		return array( 'success' => true, 'url' => $url, 'message' => 'Key file verified successfully' );
+	}
+
+	public static function get_status(): array {
+		$key = self::get_api_key();
+		return array(
+			'enabled'      => (bool) PluginSettings::get( 'indexnow_enabled', false ),
+			'has_key'      => ! empty( $key ),
+			'key_preview'  => $key ? substr( $key, 0, 8 ) . '...' : '',
+			'key_file_url' => $key ? home_url( '/' . $key . '.txt' ) : '',
+			'endpoint'     => self::API_ENDPOINT,
+		);
+	}
+
+	private function register_abilities(): void {
+		AbilityRegistration::on_abilities_api_init(
+			function (): void {
+				$this->register_submit_ability();
+				$this->register_status_ability();
+				$this->register_generate_key_ability();
+				$this->register_verify_key_ability();
+			}
+		);
+	}
+
+	private function register_submit_ability(): void {
+		wp_register_ability(
+			'datamachine/indexnow-submit',
+			array(
+				'label'               => __( 'IndexNow Submit', 'data-machine-business' ),
+				'description'         => __( 'Submit one or more URLs to IndexNow for instant search engine indexing.', 'data-machine-business' ),
+				'category'            => 'datamachine-seo',
+				'input_schema'        => array( 'type' => 'object', 'required' => array( 'urls' ), 'properties' => array( 'urls' => array( 'type' => 'array', 'description' => __( 'Array of full URLs to submit', 'data-machine-business' ), 'items' => array( 'type' => 'string' ) ) ) ),
+				'output_schema'       => array( 'type' => 'object', 'properties' => array( 'success' => array( 'type' => 'boolean' ), 'message' => array( 'type' => 'string' ), 'url_count' => array( 'type' => 'integer' ), 'status_code' => array( 'type' => 'integer' ), 'error' => array( 'type' => 'string' ) ) ),
+				'execute_callback'    => array( $this, 'execute_submit' ),
+				'permission_callback' => fn() => PermissionHelper::can_manage(),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	private function register_status_ability(): void {
+		wp_register_ability(
+			'datamachine/indexnow-status',
+			array(
+				'label'               => __( 'IndexNow Status', 'data-machine-business' ),
+				'description'         => __( 'Get IndexNow integration status including enabled state and API key.', 'data-machine-business' ),
+				'category'            => 'datamachine-seo',
+				'input_schema'        => array( 'type' => 'object', 'properties' => array() ),
+				'output_schema'       => array( 'type' => 'object', 'properties' => array( 'success' => array( 'type' => 'boolean' ), 'enabled' => array( 'type' => 'boolean' ), 'has_key' => array( 'type' => 'boolean' ), 'key_preview' => array( 'type' => 'string' ), 'key_file_url' => array( 'type' => 'string' ), 'endpoint' => array( 'type' => 'string' ) ) ),
+				'execute_callback'    => array( $this, 'execute_status' ),
+				'permission_callback' => fn() => PermissionHelper::can_manage(),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	private function register_generate_key_ability(): void {
+		wp_register_ability(
+			'datamachine/indexnow-generate-key',
+			array(
+				'label'               => __( 'IndexNow Generate Key', 'data-machine-business' ),
+				'description'         => __( 'Generate a new IndexNow API key and save it to settings.', 'data-machine-business' ),
+				'category'            => 'datamachine-seo',
+				'input_schema'        => array( 'type' => 'object', 'properties' => array() ),
+				'output_schema'       => array( 'type' => 'object', 'properties' => array( 'success' => array( 'type' => 'boolean' ), 'key_preview' => array( 'type' => 'string' ), 'key_file_url' => array( 'type' => 'string' ), 'message' => array( 'type' => 'string' ) ) ),
+				'execute_callback'    => array( $this, 'execute_generate_key' ),
+				'permission_callback' => fn() => PermissionHelper::can_manage(),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	private function register_verify_key_ability(): void {
+		wp_register_ability(
+			'datamachine/indexnow-verify-key',
+			array(
+				'label'               => __( 'IndexNow Verify Key', 'data-machine-business' ),
+				'description'         => __( 'Verify that the IndexNow key file is accessible and correct.', 'data-machine-business' ),
+				'category'            => 'datamachine-seo',
+				'input_schema'        => array( 'type' => 'object', 'properties' => array() ),
+				'output_schema'       => array( 'type' => 'object', 'properties' => array( 'success' => array( 'type' => 'boolean' ), 'url' => array( 'type' => 'string' ), 'message' => array( 'type' => 'string' ), 'error' => array( 'type' => 'string' ) ) ),
+				'execute_callback'    => array( $this, 'execute_verify_key' ),
+				'permission_callback' => fn() => PermissionHelper::can_manage(),
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+	}
+
+	public function execute_submit( array $input ): array {
+		$urls = $input['urls'] ?? array();
+		if ( empty( $urls ) || ! is_array( $urls ) ) {
+			return array( 'success' => false, 'error' => 'urls parameter is required and must be a non-empty array' );
+		}
+
+		$urls = array_filter( array_map( 'esc_url_raw', $urls ) );
+		return empty( $urls ) ? array( 'success' => false, 'error' => 'No valid URLs after sanitization' ) : self::submit_urls( $urls );
+	}
+
+	public function execute_status( array $input ): array {
+		$status            = self::get_status();
+		$status['success'] = true;
+		return $status;
+	}
+
+	public function execute_generate_key( array $input ): array {
+		$key = self::generate_key();
+		return array( 'success' => true, 'key_preview' => substr( $key, 0, 8 ) . '...', 'key_file_url' => home_url( '/' . $key . '.txt' ), 'message' => 'New IndexNow API key generated' );
+	}
+
+	public function execute_verify_key( array $input ): array {
+		return self::verify_key_file();
+	}
+}

--- a/inc/Bootstrap/ProviderModules.php
+++ b/inc/Bootstrap/ProviderModules.php
@@ -28,6 +28,12 @@ final class ProviderModules {
 
 		return array(
 			new ProviderModule(
+				'indexnow',
+				$abilities,
+				array( 'datamachine/indexnow-submit', 'datamachine/indexnow-status', 'datamachine/indexnow-generate-key', 'datamachine/indexnow-verify-key' ),
+				static fn() => new \DataMachineBusiness\Abilities\SEO\IndexNowAbilities()
+			),
+			new ProviderModule(
 				'google-analytics',
 				array_merge( $abilities, $tools ),
 				array( 'datamachine/google-analytics', 'tool:google_analytics' ),

--- a/inc/Cli/CommandRegistry.php
+++ b/inc/Cli/CommandRegistry.php
@@ -25,14 +25,15 @@ final class CommandRegistry {
 	 * namespace, e.g. "datamachine analytics ga"). Order here determines
 	 * registration order.
 	 *
-	 * Every command this plugin owns is a flat `__invoke` command — the action
-	 * is a positional argument, not a WP-CLI subcommand — so each reflects to a
-	 * single `__default` entry carrying the command's own short description.
+	 * Most commands this plugin owns are flat `__invoke` commands. Provider
+	 * integrations that preserve an established subcommand contract may expose
+	 * public subcommand methods instead.
 	 *
 	 * @return array<string, class-string>
 	 */
 	public static function map(): array {
 		return array(
+			'datamachine indexnow'            => IndexNowCommand::class,
 			'datamachine analytics ga'        => GoogleAnalyticsCommand::class,
 			'datamachine analytics gsc'       => GoogleSearchConsoleCommand::class,
 			'datamachine analytics mediavine' => MediavineCommand::class,

--- a/inc/Cli/IndexNowCommand.php
+++ b/inc/Cli/IndexNowCommand.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * IndexNow WP-CLI command.
+ *
+ * @package DataMachineBusiness\Cli
+ */
+
+namespace DataMachineBusiness\Cli;
+
+use DataMachine\Cli\BaseCommand;
+use DataMachine\Core\PluginSettings;
+use DataMachineBusiness\Abilities\SEO\IndexNowAbilities;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+class IndexNowCommand extends BaseCommand {
+
+	/**
+	 * Submit one or more URLs to IndexNow for instant search engine indexing.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<url>...]
+	 * : One or more URLs to submit.
+	 *
+	 * [--post-id=<id>]
+	 * : Submit the permalink for a WordPress post ID.
+	 *
+	 * [--post-type=<type>]
+	 * : Submit all published posts of this type.
+	 *
+	 * [--limit=<number>]
+	 * : Limit the number of URLs when using --post-type. Default 100.
+	 *
+	 * @subcommand submit
+	 */
+	public function submit( array $args, array $assoc_args ): void {
+		$urls      = array();
+		$post_id   = $assoc_args['post-id'] ?? null;
+		$post_type = $assoc_args['post-type'] ?? null;
+		$limit     = intval( $assoc_args['limit'] ?? 100 );
+
+		if ( $post_id ) {
+			$url = get_permalink( intval( $post_id ) );
+			if ( ! $url ) {
+				WP_CLI::error( "Could not get permalink for post ID {$post_id}" );
+			}
+			$urls[] = $url;
+		} elseif ( $post_type ) {
+			$posts = get_posts( array( 'post_type' => $post_type, 'post_status' => 'publish', 'posts_per_page' => min( $limit, IndexNowAbilities::MAX_BATCH_SIZE ), 'fields' => 'ids' ) );
+			if ( empty( $posts ) ) {
+				WP_CLI::error( "No published posts found for post type '{$post_type}'" );
+			}
+			foreach ( $posts as $pid ) {
+				$url = get_permalink( $pid );
+				if ( $url ) {
+					$urls[] = $url;
+				}
+			}
+		} else {
+			$urls = $args;
+		}
+
+		if ( empty( $urls ) ) {
+			WP_CLI::error( 'No URLs provided. Pass URLs as arguments, or use --post-id or --post-type.' );
+		}
+
+		$count = count( $urls );
+		WP_CLI::log( "Submitting {$count} URL(s) to IndexNow..." );
+		$result = IndexNowAbilities::submit_urls( $urls );
+		if ( $result['success'] ) {
+			WP_CLI::success( $result['message'] . " ({$count} URL" . ( $count > 1 ? 's' : '' ) . ')' );
+			return;
+		}
+
+		$message = $result['error'] ?? 'Unknown error';
+		if ( ! empty( $result['status_code'] ) ) {
+			$message .= ' (HTTP ' . $result['status_code'] . ')';
+		}
+		WP_CLI::error( $message );
+	}
+
+	/**
+	 * Show IndexNow integration status.
+	 *
+	 * @subcommand status
+	 */
+	public function status( array $args, array $assoc_args ): void {
+		$status = IndexNowAbilities::get_status();
+		WP_CLI::log( '' );
+		WP_CLI::log( 'IndexNow Integration Status' );
+		WP_CLI::log( str_repeat( '─', 40 ) );
+		WP_CLI::log( 'Enabled:       ' . ( $status['enabled'] ? WP_CLI::colorize( '%GYes%n' ) : WP_CLI::colorize( '%RNo%n' ) ) );
+		WP_CLI::log( 'API Key:       ' . ( $status['has_key'] ? $status['key_preview'] : WP_CLI::colorize( '%RNot set%n' ) ) );
+		if ( $status['has_key'] ) {
+			WP_CLI::log( 'Key File URL:  ' . $status['key_file_url'] );
+		}
+		WP_CLI::log( 'Endpoint:      ' . $status['endpoint'] );
+		WP_CLI::log( '' );
+		if ( ! $status['has_key'] ) {
+			WP_CLI::log( WP_CLI::colorize( '%YRun `wp datamachine indexnow key generate` to create an API key.%n' ) );
+		} elseif ( ! $status['enabled'] ) {
+			WP_CLI::log( WP_CLI::colorize( '%YRun `wp datamachine settings set indexnow_enabled true` to enable auto-ping on publish.%n' ) );
+		}
+	}
+
+	/**
+	 * Manage the IndexNow API key.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Action to perform: generate, verify, show
+	 *
+	 * @subcommand key
+	 */
+	public function key( array $args, array $assoc_args ): void {
+		$action = $args[0] ?? '';
+		switch ( $action ) {
+			case 'generate':
+				$key = IndexNowAbilities::generate_key();
+				WP_CLI::success( 'Generated new IndexNow API key: ' . substr( $key, 0, 8 ) . '...' );
+				WP_CLI::log( 'Key file URL: ' . home_url( '/' . $key . '.txt' ) );
+				flush_rewrite_rules();
+				WP_CLI::log( 'Rewrite rules flushed.' );
+				break;
+			case 'verify':
+				WP_CLI::log( 'Verifying key file accessibility...' );
+				$result = IndexNowAbilities::verify_key_file();
+				if ( $result['success'] ) {
+					WP_CLI::success( $result['message'] );
+					WP_CLI::log( 'URL: ' . $result['url'] );
+				} else {
+					WP_CLI::error( $result['error'] . ( isset( $result['url'] ) ? "\nURL: " . $result['url'] : '' ) );
+				}
+				break;
+			case 'show':
+				$key = IndexNowAbilities::get_api_key();
+				if ( empty( $key ) ) {
+					WP_CLI::error( 'No IndexNow API key configured. Run: wp datamachine indexnow key generate' );
+				}
+				WP_CLI::log( $key );
+				break;
+			default:
+				WP_CLI::error( 'Unknown action: ' . $action . '. Valid actions: generate, verify, show' );
+		}
+	}
+
+	/**
+	 * Enable IndexNow auto-ping on publish.
+	 *
+	 * @subcommand enable
+	 */
+	public function enable( array $args, array $assoc_args ): void {
+		$settings                     = get_option( 'datamachine_settings', array() );
+		$settings['indexnow_enabled'] = true;
+		update_option( 'datamachine_settings', $settings );
+		PluginSettings::clearCache();
+		$key = IndexNowAbilities::get_or_generate_key();
+		WP_CLI::success( 'IndexNow auto-ping enabled. URLs will be submitted when posts are published.' );
+		WP_CLI::log( 'API key: ' . substr( $key, 0, 8 ) . '...' );
+	}
+
+	/**
+	 * Disable IndexNow auto-ping on publish.
+	 *
+	 * @subcommand disable
+	 */
+	public function disable( array $args, array $assoc_args ): void {
+		$settings                     = get_option( 'datamachine_settings', array() );
+		$settings['indexnow_enabled'] = false;
+		update_option( 'datamachine_settings', $settings );
+		PluginSettings::clearCache();
+		WP_CLI::success( 'IndexNow auto-ping disabled.' );
+	}
+}

--- a/tests/ability-registration-lifecycle-smoke.php
+++ b/tests/ability-registration-lifecycle-smoke.php
@@ -113,6 +113,7 @@ assert_ability_registration(
 );
 
 $ability_files = array(
+	'inc/Abilities/SEO/IndexNowAbilities.php',
 	'inc/Abilities/Analytics/BingWebmasterAbilities.php',
 	'inc/Abilities/Analytics/ContentFlagsAbility.php',
 	'inc/Abilities/Analytics/ContentPerformanceAbility.php',

--- a/tests/indexnow-ownership-smoke.php
+++ b/tests/indexnow-ownership-smoke.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Dependency-free continuity checks for the moved IndexNow integration.
+ */
+
+$root     = dirname( __DIR__ );
+$failures = array();
+
+$ability_path = $root . '/inc/Abilities/SEO/IndexNowAbilities.php';
+$command_path = $root . '/inc/Cli/IndexNowCommand.php';
+$provider     = file_get_contents( $root . '/inc/Bootstrap/ProviderModules.php' );
+$registry     = file_get_contents( $root . '/inc/Cli/CommandRegistry.php' );
+$ability      = file_get_contents( $ability_path );
+$command      = file_get_contents( $command_path );
+
+foreach ( array( $ability_path, $command_path ) as $path ) {
+	if ( ! file_exists( $path ) ) {
+		$failures[] = 'Missing owned file: ' . $path;
+	}
+}
+
+foreach ( array( 'datamachine/indexnow-submit', 'datamachine/indexnow-status', 'datamachine/indexnow-generate-key', 'datamachine/indexnow-verify-key' ) as $name ) {
+	if ( ! str_contains( $ability, $name ) || ! str_contains( $provider, $name ) ) {
+		$failures[] = 'Ability ownership or provider registration missing: ' . $name;
+	}
+}
+
+$continuity = array(
+	'namespace DataMachineBusiness\\Abilities\\SEO' => $ability,
+	'use DataMachine\\Core\\HttpClient'             => $ability,
+	'use DataMachine\\Core\\PluginSettings'         => $ability,
+	'use DataMachine\\Abilities\\PermissionHelper'  => $ability,
+	'AbilityRegistration::on_abilities_api_init'       => $ability,
+	"PluginSettings::get( 'indexnow_enabled'"         => $ability,
+	"PluginSettings::get( 'indexnow_api_key'"         => $ability,
+	"get_option( 'datamachine_settings'"              => $ability . $command,
+	'datamachine_indexnow_skip_auto_submit'            => $ability,
+	"add_action( 'wp_after_insert_post'"               => $ability,
+	"add_action( 'parse_request'"                      => $ability,
+	"\$key . '.txt'"                                  => $ability,
+	"'indexnow'"                                      => $provider,
+	"'datamachine indexnow'"                          => $registry,
+	'IndexNowCommand::class'                           => $registry,
+);
+
+foreach ( $continuity as $needle => $haystack ) {
+	if ( ! str_contains( $haystack, $needle ) ) {
+		$failures[] = 'Continuity marker missing: ' . $needle;
+	}
+}
+
+foreach ( array( 'MetaDescription', 'InternalLink' ) as $unrelated ) {
+	if ( str_contains( $ability . $command, $unrelated ) ) {
+		$failures[] = 'Unrelated SEO ownership moved: ' . $unrelated;
+	}
+}
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, "IndexNow ownership smoke failed:\n - " . implode( "\n - ", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo "IndexNow ownership smoke checks passed.\n";

--- a/tests/indexnow-registration-smoke.php
+++ b/tests/indexnow-registration-smoke.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Runtime registration and settings continuity smoke for IndexNow.
+ */
+
+namespace DataMachine\Abilities {
+	class AbilityRegistration {
+		public static function on_abilities_api_init( callable $callback ): void {
+			$callback();
+		}
+	}
+
+	class PermissionHelper {
+		public static function can_manage(): bool {
+			return true;
+		}
+	}
+}
+
+namespace DataMachine\Core {
+	class HttpClient {
+	}
+
+	class PluginSettings {
+		public static function get( string $key, $default = null ) {
+			return $GLOBALS['indexnow_options']['datamachine_settings'][ $key ] ?? $default;
+		}
+
+		public static function clearCache(): void {
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+
+	class WP_Post {
+	}
+
+	class WP {
+	}
+
+	$indexnow_actions = array();
+	$indexnow_abilities = array();
+	$indexnow_options = array(
+		'datamachine_settings' => array(
+			'unrelated_setting' => 'preserved',
+			'indexnow_enabled'  => true,
+			'indexnow_api_key'  => 'existing-indexnow-key',
+		),
+	);
+
+	function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		global $indexnow_actions;
+		$indexnow_actions[ $hook ] = compact( 'callback', 'priority', 'accepted_args' );
+	}
+
+	function wp_register_ability( string $name, array $definition ): void {
+		global $indexnow_abilities;
+		$indexnow_abilities[ $name ] = $definition;
+	}
+
+	function __( string $text, string $domain = '' ): string {
+		return $text;
+	}
+
+	function get_option( string $name, $default = false ) {
+		global $indexnow_options;
+		return $indexnow_options[ $name ] ?? $default;
+	}
+
+	function update_option( string $name, $value ): bool {
+		global $indexnow_options;
+		$indexnow_options[ $name ] = $value;
+		return true;
+	}
+
+	function wp_generate_uuid4(): string {
+		return '12345678-1234-1234-1234-123456789abc';
+	}
+
+	function do_action( string $hook, ...$args ): void {
+	}
+
+	function home_url( string $path = '' ): string {
+		return 'https://example.com' . $path;
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/Abilities/SEO/IndexNowAbilities.php';
+	require_once dirname( __DIR__ ) . '/inc/Cli/CommandRegistry.php';
+
+	new \DataMachineBusiness\Abilities\SEO\IndexNowAbilities();
+
+	$failures = array();
+	$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+		if ( ! $condition ) {
+			$failures[] = $message;
+		}
+	};
+
+	$assert(
+		array(
+			'datamachine/indexnow-submit',
+			'datamachine/indexnow-status',
+			'datamachine/indexnow-generate-key',
+			'datamachine/indexnow-verify-key',
+		) === array_keys( $indexnow_abilities ),
+		'all four stable abilities register'
+	);
+	$assert( isset( $indexnow_actions['wp_after_insert_post'] ), 'auto-submit hook registers' );
+	$assert( 4 === $indexnow_actions['wp_after_insert_post']['accepted_args'], 'auto-submit hook preserves four arguments' );
+	$assert( isset( $indexnow_actions['parse_request'] ), 'public key-file hook registers' );
+
+	$status = \DataMachineBusiness\Abilities\SEO\IndexNowAbilities::get_status();
+	$assert( true === $status['enabled'], 'existing indexnow_enabled setting is reused' );
+	$assert( 'existing-indexnow-key' === \DataMachineBusiness\Abilities\SEO\IndexNowAbilities::get_api_key(), 'existing indexnow_api_key setting is reused' );
+
+	$new_key = \DataMachineBusiness\Abilities\SEO\IndexNowAbilities::generate_key();
+	$assert( '12345678123412341234123456789abc' === $new_key, 'new key uses the established format' );
+	$assert( 'preserved' === $indexnow_options['datamachine_settings']['unrelated_setting'], 'key generation preserves other Data Machine settings' );
+	$assert( $new_key === $indexnow_options['datamachine_settings']['indexnow_api_key'], 'key generation writes the existing settings key' );
+
+	$commands = \DataMachineBusiness\Cli\CommandRegistry::map();
+	$assert( \DataMachineBusiness\Cli\IndexNowCommand::class === $commands['datamachine indexnow'], 'stable CLI command registers through CommandRegistry' );
+
+	if ( ! empty( $failures ) ) {
+		fwrite( STDERR, "IndexNow registration smoke failed:\n - " . implode( "\n - ", $failures ) . "\n" );
+		exit( 1 );
+	}
+
+	echo "IndexNow registration smoke checks passed.\n";
+}

--- a/tests/provider-bootstrap-smoke.php
+++ b/tests/provider-bootstrap-smoke.php
@@ -95,6 +95,7 @@ assert_provider_bootstrap( 6 === count( $availability ), 'duplicate provider dec
 $actual_modules = ProviderModules::all();
 $actual_ids     = array_map( static fn( ProviderModule $provider ): string => $provider->id(), $actual_modules );
 $expected_ids   = array(
+	'indexnow',
 	'google-analytics',
 	'mediavine',
 	'content-insights',
@@ -122,7 +123,7 @@ foreach ( $expected_ids as $provider_id ) {
 	);
 }
 
-$sendy = $actual_modules[13]->capabilities();
+$sendy = $actual_modules[14]->capabilities();
 assert_provider_bootstrap(
 	array(
 		'datamachine/sendy-subscribe',


### PR DESCRIPTION
## Summary
- move generic IndexNow transport, key management, verification, abilities, and CLI into Data Machine Business
- preserve the four `datamachine/indexnow-*` abilities, `wp datamachine indexnow`, existing setting keys, key route, and suppression filter
- register through DMB provider and command composition with focused continuity tests

## Landing order
1. Merge this provider-owner PR first.
2. Merge Extra-Chill/extrachill-seo#56 so Extra Chill policy delegates to this provider.
3. Merge the paired Data Machine core-removal PR last.

Closes #111.
Related: Extra-Chill/data-machine#2223, Extra-Chill/extrachill-seo#55.

## Testing
- `php tests/indexnow-ownership-smoke.php`
- `php tests/indexnow-registration-smoke.php`
- `php tests/provider-bootstrap-smoke.php`
- `php tests/ability-registration-lifecycle-smoke.php`
- PHP syntax checks for changed and added files

## AI assistance
- AI assistance: Yes
- Tool: OpenCode (GPT-5.6)
- Used for: implementation, tests, and ownership audit