### PR TITLE
feat: own image diagnostics and optimization

### DIFF
--- a/inc/Abilities/Media/BrokenImageReferenceAbilities.php
+++ b/inc/Abilities/Media/BrokenImageReferenceAbilities.php
@@ -1,0 +1,915 @@
+<?php
+/**
+ * Broken Image Reference Abilities
+ *
+ * Read-only diagnostic that scans published post content for image references
+ * whose local files are missing. Multisite-aware: a reference URL is resolved
+ * to its owning site's uploads base directory by matching the upload base URL
+ * prefix, which is correct for both subdomain and subdirectory installs and
+ * supports cross-site references (a post on one blog referencing an upload
+ * hosted by another network blog).
+ *
+ * The diagnostic never mutates posts or files.
+ *
+ * @package DataMachineBusiness\Abilities\Media
+ * @since 0.161.6
+ */
+
+namespace DataMachineBusiness\Abilities\Media;
+
+use DataMachine\Abilities\AbilityRegistration;
+use DataMachine\Abilities\PermissionHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+class BrokenImageReferenceAbilities {
+
+	/**
+	 * Image URL-bearing attributes recognized in <img> tags.
+	 *
+	 * `srcset`/`data-srcset`/`data-lazy-srcset` carry comma-separated candidate
+	 * lists that must be split into individual URLs.
+	 *
+	 * @var array<int, string>
+	 */
+	private const SRCSET_ATTRIBUTES = array( 'srcset', 'data-srcset', 'data-lazy-srcset' );
+
+	/**
+	 * Single-URL lazy-load / background image attributes.
+	 *
+	 * @var array<int, string>
+	 */
+	private const SINGLE_URL_ATTRIBUTES = array(
+		'src',
+		'data-src',
+		'data-lazy-src',
+		'data-original',
+		'data-bg',
+	);
+
+	/**
+	 * Attributes whose value is a full CSS background-image source set, e.g.
+	 * `data-bgset="url(...) , url(...)"`. Extracted via the url(...) extractor.
+	 *
+	 * @var array<int, string>
+	 */
+	private const BGSET_ATTRIBUTES = array( 'data-bgset' );
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/diagnose-broken-image-references',
+				array(
+					'label'               => 'Diagnose Broken Image References',
+					'description'         => 'Scan published post content for image references whose local files are missing. Multisite-aware (host -> upload directory) and cross-site safe. Read-only; never mutates posts or files.',
+					'category'            => 'datamachine-media',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'post_type' => array(
+								'type'        => 'string',
+								'description' => 'Post type to scan. Default: post.',
+								'default'     => 'post',
+							),
+							'post_id'   => array(
+								'type'        => 'integer',
+								'description' => 'Limit the scan to a single post ID on the current site.',
+							),
+							'limit'     => array(
+								'type'        => 'integer',
+								'description' => 'Maximum number of posts to scan. 0 for no limit. Default: 0.',
+								'default'     => 0,
+							),
+							'network'   => array(
+								'type'        => 'boolean',
+								'description' => 'Scan every site on the network (multisite only). Default: false (current site only).',
+								'default'     => false,
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'           => array( 'type' => 'boolean' ),
+							'posts_scanned'     => array( 'type' => 'integer' ),
+							'references_found'  => array( 'type' => 'integer' ),
+							'broken_count'      => array( 'type' => 'integer' ),
+							'broken_references' => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'object' ),
+							),
+							'message'           => array( 'type' => 'string' ),
+							'error'             => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'diagnoseBrokenImageReferences' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		AbilityRegistration::on_abilities_api_init( $register_callback );
+	}
+
+	/**
+	 * Scan published post content for image references that point at missing local files.
+	 *
+	 * Resolution is multisite-aware: each image URL is matched against the upload
+	 * base URL of every network site so that a post on one blog can legitimately
+	 * reference an upload hosted by another blog. External hosts (not part of the
+	 * network) are reported separately and never verified by default.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param array             $input        Ability input.
+	 * @param callable|null     $file_checker Optional file-existence checker. Defaults
+	 *                                        to native file_exists(). Test seam only.
+	 * @return array Diagnostic results.
+	 */
+	public static function diagnoseBrokenImageReferences( array $input = array(), ?callable $file_checker = null ): array {
+		$post_type = sanitize_text_field( $input['post_type'] ?? 'post' );
+		$post_id   = absint( $input['post_id'] ?? 0 );
+		$limit     = absint( $input['limit'] ?? 0 );
+		$network   = ! empty( $input['network'] );
+
+		$file_checker = is_callable( $file_checker ) ? $file_checker : 'file_exists';
+
+		$blog_uploads = self::build_blog_uploads_map( $network );
+
+		$blogs_to_scan = array_keys( $blog_uploads );
+		if ( ! $network ) {
+			$blogs_to_scan = array( get_current_blog_id() );
+		}
+
+		$broken      = array();
+		$posts_total = 0;
+		$refs_total  = 0;
+
+		foreach ( $blogs_to_scan as $scan_blog_id ) {
+			$switched = self::maybe_switch_to_blog( $scan_blog_id );
+
+			try {
+				$posts = self::fetch_posts_for_scan( $post_type, $post_id, $limit );
+
+				$current_home    = home_url();
+				$current_origin  = self::origin_from_url( $current_home );
+				$current_blog_id = get_current_blog_id();
+
+				foreach ( $posts as $post ) {
+					++$posts_total;
+					$content = is_object( $post ) ? (string) $post->post_content : '';
+					if ( '' === $content ) {
+						continue;
+					}
+
+					$raw_refs = self::extract_image_urls_from_html( $content );
+
+					$seen_urls = array();
+					foreach ( $raw_refs as $ref ) {
+						$normalized = self::normalize_image_url( $ref['url'], $current_origin );
+						if ( '' === $normalized ) {
+							continue;
+						}
+
+						$dedupe_key = $normalized;
+						if ( isset( $seen_urls[ $dedupe_key ] ) ) {
+							continue;
+						}
+						$seen_urls[ $dedupe_key ] = true;
+						++$refs_total;
+
+						$resolved = self::resolve_url_to_local( $normalized, $blog_uploads, $current_blog_id, $current_origin );
+
+						if ( 'local' !== $resolved['kind'] ) {
+							continue;
+						}
+
+						$path = $resolved['path'] ?? '';
+						if ( '' === $path ) {
+							continue;
+						}
+
+						if ( ! $file_checker( $path ) ) {
+							$broken[] = array(
+								'blog_id'    => (int) $current_blog_id,
+								'post_id'    => (int) ( is_object( $post ) ? $post->ID : 0 ),
+								'post_title' => is_object( $post ) ? (string) $post->post_title : '',
+								'url'        => $normalized,
+								'attribute'  => $ref['attribute'],
+								'host_blog'  => isset( $resolved['blog_id'] ) ? (int) $resolved['blog_id'] : 0,
+								'path'       => $path,
+								'reason'     => 'file_missing',
+							);
+						}
+					}
+				}
+			} finally {
+				if ( $switched ) {
+					restore_current_blog();
+				}
+			}
+		}
+
+		return array(
+			'success'           => true,
+			'posts_scanned'     => $posts_total,
+			'references_found'  => $refs_total,
+			'broken_count'      => count( $broken ),
+			'broken_references' => $broken,
+			'message'           => sprintf(
+				'Scanned %1$d post(s), %2$d image reference(s), found %3$d missing local file(s).',
+				$posts_total,
+				$refs_total,
+				count( $broken )
+			),
+		);
+	}
+
+	/**
+	 * Build the blog_id => upload dir map for every site to be considered.
+	 *
+	 * For network scans this iterates every site; otherwise it only contains the
+	 * current site. Each entry carries the base URL (for matching) and base
+	 * directory (for building the filesystem path).
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param bool $network Whether to include every network site.
+	 * @return array<int, array{baseurl: string, basedir: string}>
+	 */
+	private static function build_blog_uploads_map( bool $network ): array {
+		$site_ids = array( get_current_blog_id() );
+
+		if ( $network && is_multisite() ) {
+			$site_ids = array_map(
+				'intval',
+				get_sites(
+					array(
+						'fields' => 'ids',
+						'number' => '',
+					)
+				)
+			);
+			if ( empty( $site_ids ) ) {
+				$site_ids = array( get_current_blog_id() );
+			}
+		}
+
+		$map = array();
+		foreach ( $site_ids as $site_id ) {
+			$switched = self::maybe_switch_to_blog( $site_id );
+			try {
+				$uploads         = wp_get_upload_dir();
+				$map[ $site_id ] = array(
+					'baseurl' => isset( $uploads['baseurl'] ) ? (string) $uploads['baseurl'] : '',
+					'basedir' => isset( $uploads['basedir'] ) ? (string) $uploads['basedir'] : '',
+				);
+			} finally {
+				if ( $switched ) {
+					restore_current_blog();
+				}
+			}
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Fetch published posts (id + title + content) for the current blog.
+	 *
+	 * Streams content in bounded chunks keyed by ascending ID so peak memory
+	 * scales with the chunk size rather than the full content set, mirroring the
+	 * pattern established by InternalLinkingAbilities::buildLinkGraph().
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param string $post_type Post type to scan.
+	 * @param int    $post_id   Specific post ID (0 = scan all published).
+	 * @param int    $limit     Maximum posts (0 = no limit).
+	 * @return array<int, object>
+	 */
+	private static function fetch_posts_for_scan( string $post_type, int $post_id, int $limit ): array {
+		global $wpdb;
+
+		if ( $post_id > 0 ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$post = $wpdb->get_row(
+				$wpdb->prepare(
+					"SELECT ID, post_title, post_content FROM {$wpdb->posts}
+					WHERE ID = %d AND post_status = %s",
+					$post_id,
+					'publish'
+				)
+			);
+
+			return is_object( $post ) ? array( $post ) : array();
+		}
+
+		$posts = array();
+		$chunk = 100;
+		$last  = 0;
+		$cap   = $limit > 0;
+
+		do {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT ID, post_title, post_content FROM {$wpdb->posts}
+					WHERE post_type = %s AND post_status = %s AND ID > %d
+					ORDER BY ID ASC LIMIT %d",
+					$post_type,
+					'publish',
+					$last,
+					$chunk
+				)
+			);
+			if ( ! is_array( $rows ) || empty( $rows ) ) {
+				break;
+			}
+
+			foreach ( $rows as $row ) {
+				$posts[] = $row;
+				$last    = max( $last, (int) $row->ID );
+
+				if ( $cap && count( $posts ) >= $limit ) {
+					return $posts;
+				}
+			}
+			$rows_returned = count( $rows );
+		} while ( $rows_returned === $chunk );
+
+		return $posts;
+	}
+
+	/**
+	 * Extract image reference URLs from post HTML.
+	 *
+	 * Parses <img> tags via libxml (when available) with a regex fallback, then
+	 * collects every candidate URL from `src`, `srcset` candidates, and the
+	 * common lazy-load / responsive attributes. Pure: no WordPress dependencies.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param string $html Raw post content.
+	 * @return array<int, array{url: string, attribute: string}> Reference list in document order.
+	 */
+	public static function extract_image_urls_from_html( string $html ): array {
+		$img_tags = self::parse_img_tags( $html );
+
+		$refs = array();
+		foreach ( $img_tags as $attrs ) {
+			foreach ( self::SINGLE_URL_ATTRIBUTES as $attr ) {
+				$value = self::attr( $attrs, $attr );
+				if ( '' !== $value ) {
+					$refs[] = array(
+						'url'       => $value,
+						'attribute' => $attr,
+					);
+				}
+			}
+
+			foreach ( self::SRCSET_ATTRIBUTES as $attr ) {
+				$value = self::attr( $attrs, $attr );
+				if ( '' === $value ) {
+					continue;
+				}
+				foreach ( self::parse_srcset( $value ) as $candidate ) {
+					$refs[] = array(
+						'url'       => $candidate,
+						'attribute' => $attr,
+					);
+				}
+			}
+
+			foreach ( self::BGSET_ATTRIBUTES as $attr ) {
+				$value = self::attr( $attrs, $attr );
+				if ( '' === $value ) {
+					continue;
+				}
+				foreach ( self::parse_css_url_list( $value ) as $candidate ) {
+					$refs[] = array(
+						'url'       => $candidate,
+						'attribute' => $attr,
+					);
+				}
+			}
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * Parse all <img ...> tags from HTML into attribute maps.
+	 *
+	 * Uses DOMDocument when libxml is available; otherwise falls back to a
+	 * tolerant regex so the diagnostic degrades gracefully on hosts without the
+	 * extension. Attribute keys are lowercased.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param string $html Raw HTML.
+	 * @return array<int, array<string, string>>
+	 */
+	private static function parse_img_tags( string $html ): array {
+		if ( '' === trim( $html ) ) {
+			return array();
+		}
+
+		$parsed = self::parse_img_tags_dom( $html );
+		if ( null !== $parsed ) {
+			return $parsed;
+		}
+
+		return self::parse_img_tags_regex( $html );
+	}
+
+	/**
+	 * DOMDocument-based <img> parser. Returns null when libxml is unavailable.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param string $html Raw HTML.
+	 * @return array<int, array<string, string>>|null
+	 */
+	private static function parse_img_tags_dom( string $html ): ?array {
+		if ( ! class_exists( 'DOMDocument' ) || ! function_exists( 'libxml_use_internal_errors' ) ) {
+			return null;
+		}
+
+		$previous = libxml_use_internal_errors( true );
+		try {
+			$dom = new \DOMDocument();
+			// Suppress encoding sniffing issues by prefixing an encoding declaration.
+			$loaded = @$dom->loadHTML( '<?xml encoding="UTF-8"?>' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- libxml emits unactionable HTML warnings on real-world markup.
+			if ( ! $loaded ) {
+				return null;
+			}
+
+			$tags = $dom->getElementsByTagName( 'img' );
+			$out  = array();
+			foreach ( $tags as $node ) {
+				/** @var \DOMElement $node */
+				if ( ! $node->hasAttributes() ) {
+					continue;
+				}
+				$map = array();
+				foreach ( $node->attributes as $attribute ) {
+					$name         = strtolower( $attribute->nodeName );
+					$map[ $name ] = trim( $attribute->nodeValue ?? '' );
+				}
+				$out[] = $map;
+			}
+
+			return $out;
+		} finally {
+			libxml_clear_errors();
+			libxml_use_internal_errors( $previous );
+		}
+	}
+
+	/**
+	 * Regex fallback <img> parser for environments without libxml.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param string $html Raw HTML.
+	 * @return array<int, array<string, string>>
+	 */
+	private static function parse_img_tags_regex( string $html ): array {
+		$out = array();
+		if ( false === preg_match_all( '/<img\b[^>]*>/i', $html, $matches ) ) {
+			return $out;
+		}
+
+		foreach ( $matches[0] as $tag ) {
+			if ( false === preg_match_all( '/([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s"\'`=<>]+))/', $tag, $attr_matches, PREG_SET_ORDER ) ) {
+				continue;
+			}
+
+			$map = array();
+			foreach ( $attr_matches as $m ) {
+				$name         = strtolower( $m[1] );
+				$value        = isset( $m[2] ) && '' !== $m[2] ? $m[2] : ( isset( $m[3] ) && '' !== $m[3] ? $m[3] : ( $m[4] ?? '' ) );
+				$map[ $name ] = trim( $value );
+			}
+			$out[] = $map;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Parse a srcset string into its component image URLs.
+	 *
+	 * A srcset is a comma-separated list of `URL descriptor` tokens where the
+	 * descriptor is a width (`1x`, `480w`) or pixel density. This strips the
+	 * descriptor and returns only URLs. Pure.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param string $srcset Raw srcset attribute value.
+	 * @return array<int, string>
+	 */
+	public static function parse_srcset( string $srcset ): array {
+		if ( '' === trim( $srcset ) ) {
+			return array();
+		}
+
+		$urls = array();
+		foreach ( explode( ',', $srcset ) as $candidate ) {
+			$candidate = trim( $candidate );
+			if ( '' === $candidate ) {
+				continue;
+			}
+			// A descriptor is a trailing token like "480w" or "2x" preceded by space.
+			$parts = preg_split( '/\s+/', $candidate );
+			if ( ! is_array( $parts ) || empty( $parts ) ) {
+				continue;
+			}
+			$url = trim( $parts[0] );
+			if ( '' !== $url ) {
+				$urls[] = $url;
+			}
+		}
+
+		return $urls;
+	}
+
+	/**
+	 * Extract url(...) references from a CSS background-style value.
+	 *
+	 * Handles data-bgset / data-bg values like `url(a.jpg) 1x, url(b.jpg) 2x`.
+	 * Pure.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param string $value Raw attribute value.
+	 * @return array<int, string>
+	 */
+	public static function parse_css_url_list( string $value ): array {
+		if ( '' === trim( $value ) ) {
+			return array();
+		}
+
+		$urls = array();
+		if ( false === preg_match_all( '/url\(\s*[\'"]?([^\'")]+)[\'"]?\s*\)/i', $value, $matches, PREG_SET_ORDER ) ) {
+			return $urls;
+		}
+
+		foreach ( $matches as $m ) {
+			$url = trim( $m[1] );
+			if ( '' !== $url ) {
+				$urls[] = $url;
+			}
+		}
+
+		return $urls;
+	}
+
+	/**
+	 * Normalize a raw image URL to an absolute URL.
+	 *
+	 * Resolves root-relative (`/wp-content/...`) and protocol-relative
+	 * (`//host/...`) URLs against the current site origin. Data URIs, mailto,
+	 * and other non-fetchable schemes yield an empty string. Pure.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param string $url            Raw URL from markup.
+	 * @param string $current_origin Current site origin, e.g. `https://extrachill.com`.
+	 * @return string Absolute URL, or '' for unusable schemes.
+	 */
+	public static function normalize_image_url( string $url, string $current_origin ): string {
+		$url = trim( $url );
+		if ( '' === $url ) {
+			return '';
+		}
+
+		$lower = strtolower( $url );
+		foreach ( array( 'data:', 'mailto:', 'tel:', 'javascript:', 'blob:' ) as $skip ) {
+			if ( str_starts_with( $lower, $skip ) ) {
+				return '';
+			}
+		}
+
+		// Protocol-relative.
+		if ( str_starts_with( $url, '//' ) ) {
+			$scheme = self::scheme_from_origin( $current_origin );
+
+			return '' !== $scheme ? $scheme . ':' . $url : '';
+		}
+
+		// Root-relative or relative without a scheme.
+		if ( ! preg_match( '#^[a-zA-Z][a-zA-Z0-9+.\-]*://#', $url ) ) {
+			$origin = rtrim( $current_origin, '/' );
+			$lead   = str_starts_with( $url, '/' ) ? '' : '/';
+
+			return $origin . $lead . $url;
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Resolve an absolute image URL to a local filesystem path.
+	 *
+	 * Matches the URL against each site's upload base URL prefix (longest-prefix
+	 * wins), which is correct for both subdomain and subdirectory multisite and
+	 * for cross-site references. URLs whose host never matches a network site are
+	 * classified `external`. Pure given the maps.
+	 *
+	 * The URL remainder below the matched upload base is URL-decoded exactly once
+	 * (the URL-to-filename boundary) before joining to the uploads base directory.
+	 * See {@see build_contained_upload_path()} for the decode boundary and
+	 * containment rules.
+	 *
+	 * @since 0.161.6
+	 * @since 0.162.1 Decode encoded upload paths once and contain them under basedir.
+	 *
+	 * @param string                                                        $url              Absolute URL.
+	 * @param array<int, array{baseurl: string, basedir: string}>           $blog_uploads     Blog upload maps.
+	 * @param int                                                           $current_blog_id  Current blog ID (unused but reserved for context).
+	 * @param string                                                        $current_origin   Current site origin.
+	 * @return array{kind: string, path: string|null, blog_id: int|null}
+	 */
+	public static function resolve_url_to_local( string $url, array $blog_uploads, int $current_blog_id, string $current_origin ): array {
+		unset( $current_blog_id, $current_origin ); // Reserved for future heuristics; intentionally unused now.
+
+		$url = trim( $url );
+		if ( '' === $url ) {
+			return array(
+				'kind'    => 'unresolvable',
+				'path'    => null,
+				'blog_id' => null,
+			);
+		}
+
+		$url_host = strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) );
+
+		$best_blog_id = null;
+		$best_baseurl = '';
+		foreach ( $blog_uploads as $blog_id => $uploads ) {
+			$baseurl = $uploads['baseurl'] ?? '';
+			if ( '' === $baseurl ) {
+				continue;
+			}
+
+			$baseurl_host = strtolower( (string) wp_parse_url( $baseurl, PHP_URL_HOST ) );
+			if ( '' !== $url_host && '' !== $baseurl_host && $url_host !== $baseurl_host ) {
+				continue;
+			}
+
+			if ( ! self::url_starts_with( $url, $baseurl ) ) {
+				continue;
+			}
+
+			if ( strlen( $baseurl ) > strlen( $best_baseurl ) ) {
+				$best_baseurl = $baseurl;
+				$best_blog_id = $blog_id;
+			}
+		}
+
+		if ( null === $best_blog_id ) {
+			// No upload base matched; classify by whether the host is on-network.
+			if ( '' !== $url_host && self::host_is_network_host( $url_host, $blog_uploads ) ) {
+				return array(
+					'kind'    => 'unresolvable',
+					'path'    => null,
+					'blog_id' => null,
+				);
+			}
+
+			return array(
+				'kind'    => 'external',
+				'path'    => null,
+				'blog_id' => null,
+			);
+		}
+
+		$basedir  = $blog_uploads[ $best_blog_id ]['basedir'] ?? '';
+		$relative = substr( $url, strlen( $best_baseurl ) );
+		$fs_path  = self::build_contained_upload_path( $basedir, $relative );
+
+		if ( null === $fs_path ) {
+			// Empty remainder or a decoded traversal/separator escape attempt.
+			return array(
+				'kind'    => 'unresolvable',
+				'path'    => null,
+				'blog_id' => null,
+			);
+		}
+
+		return array(
+			'kind'    => 'local',
+			'path'    => $fs_path,
+			'blog_id' => $best_blog_id,
+		);
+	}
+
+	/**
+	 * Build a contained filesystem path for the URL remainder below an upload base.
+	 *
+	 * The remainder (the raw URL substring after the matched upload base URL) is
+	 * URL-decoded exactly once before being joined to the uploads base directory.
+	 * `rawurldecode()` is the correct path-component decoder: it maps `%20` to a
+	 * space, `%2B` to a literal `+`, and — for Blogger migration URLs — `%2528`
+	 * to the literal filename fragment `%28`. The result is never decoded again,
+	 * so a double-encoded sequence like `%252e%252e%252f` stays an inert literal
+	 * filename (`%2e%2e%2f`) rather than a traversal.
+	 *
+	 * Containment is enforced lexically: `realpath()` is unusable here because
+	 * this diagnostic verifies files that are expected to be *missing*. Any path
+	 * segment equal to `..` is rejected outright, which also catches decoded
+	 * separator escapes (e.g. `%2f..%2f` decodes to `/../`). Query strings and
+	 * fragments are dropped before lookup since they are not part of the filename.
+	 *
+	 * @since 0.162.1
+	 *
+	 * @param string $basedir   Absolute uploads base directory (no trailing slash expected).
+	 * @param string $remainder Raw URL remainder after the upload base URL (starts with `/`, `?`, or empty).
+	 * @return string|null Contained filesystem path under basedir, or null when the
+	 *                     remainder is empty or attempts to escape the base.
+	 */
+	private static function build_contained_upload_path( string $basedir, string $remainder ): ?string {
+		if ( '' === $basedir ) {
+			return null;
+		}
+
+		// Query strings and fragments are not part of the filesystem name.
+		$split     = preg_split( '/[?#]/', $remainder, 2 );
+		$path_part = is_array( $split ) ? (string) $split[0] : $remainder;
+
+		// Decode exactly once: URL representation -> literal filesystem name.
+		// A single pass maps `%2528` to `%28`; further decoding is intentionally
+		// avoided so double-encoded traversal stays an inert literal.
+		$decoded = rawurldecode( $path_part );
+
+		$segments = explode( '/', $decoded );
+		$clean    = array();
+		foreach ( $segments as $segment ) {
+			if ( '' === $segment || '.' === $segment ) {
+				// Collapse empty (leading/duplicate separators) and current-dir segments.
+				continue;
+			}
+
+			if ( '..' === $segment || false !== strpos( $segment, "\0" ) ) {
+				// Reject decoded traversal (`..`, including `%2e%2e` variants) and
+				// null-byte injection outright; a contained upload never needs them.
+				return null;
+			}
+
+			$clean[] = $segment;
+		}
+
+		if ( empty( $clean ) ) {
+			// The URL pointed at the upload root itself (or carried only a query).
+			return null;
+		}
+
+		$fs_path = $basedir . '/' . implode( '/', $clean );
+
+		// Normalize directory separators for the platform.
+		return str_replace( '/', DIRECTORY_SEPARATOR, $fs_path );
+	}
+
+	/**
+	 * Whether a host matches any site in the upload map.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param string                                                        $host          Lowercased host.
+	 * @param array<int, array{baseurl: string, basedir: string}>           $blog_uploads  Blog upload maps.
+	 * @return bool
+	 */
+	private static function host_is_network_host( string $host, array $blog_uploads ): bool {
+		foreach ( $blog_uploads as $uploads ) {
+			$baseurl_host = strtolower( (string) wp_parse_url( $uploads['baseurl'] ?? '', PHP_URL_HOST ) );
+			if ( $host === $baseurl_host ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Case-insensitive, slash-sensitive URL prefix check.
+	 *
+	 * Ensures the candidate base is a real directory prefix — e.g. so that
+	 * `https://x/uploads` does not match a URL under `https://x/uploads-other`.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param string $url     Candidate URL.
+	 * @param string $baseurl Base URL to test against.
+	 * @return bool
+	 */
+	private static function url_starts_with( string $url, string $baseurl ): bool {
+		if ( '' === $baseurl ) {
+			return false;
+		}
+
+		$url_lower  = strtolower( $url );
+		$base_lower = strtolower( $baseurl );
+
+		if ( ! str_starts_with( $url_lower, $base_lower ) ) {
+			return false;
+		}
+
+		$next = substr( $url_lower, strlen( $base_lower ) );
+
+		// A trailing path separator (or query) marks a genuine child path.
+		return '' === $next || '/' === $next[0] || '?' === $next[0];
+	}
+
+	/**
+	 * Extract the scheme from an origin URL.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param string $origin Origin URL.
+	 * @return string
+	 */
+	private static function scheme_from_origin( string $origin ): string {
+		$scheme = strtolower( (string) wp_parse_url( $origin, PHP_URL_SCHEME ) );
+
+		return in_array( $scheme, array( 'http', 'https' ), true ) ? $scheme : 'https';
+	}
+
+	/**
+	 * Extract the origin (scheme://host[:port]) from a URL.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param string $url Full URL.
+	 * @return string Origin or '' if unparseable.
+	 */
+	public static function origin_from_url( string $url ): string {
+		$parts = wp_parse_url( $url );
+		if ( empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return '';
+		}
+
+		$origin = $parts['scheme'] . '://' . $parts['host'];
+		if ( ! empty( $parts['port'] ) ) {
+			$origin .= ':' . $parts['port'];
+		}
+
+		return $origin;
+	}
+
+	/**
+	 * Case-insensitive attribute fetch with default.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param array  $attrs Attribute map (lowercased keys expected).
+	 * @param string $name  Attribute name.
+	 * @return string
+	 */
+	private static function attr( array $attrs, string $name ): string {
+		$name = strtolower( $name );
+		foreach ( $attrs as $key => $value ) {
+			if ( strtolower( (string) $key ) === $name ) {
+				$value = is_string( $value ) ? $value : (string) $value;
+
+				return trim( $value );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Switch to a blog unless already on it.
+	 *
+	 * @since 0.161.6
+	 *
+	 * @param int $blog_id Target blog ID.
+	 * @return bool Whether a switch occurred (caller must restore).
+	 */
+	private static function maybe_switch_to_blog( int $blog_id ): bool {
+		if ( ! is_multisite() ) {
+			return false;
+		}
+		if ( get_current_blog_id() === $blog_id ) {
+			return false;
+		}
+
+		switch_to_blog( $blog_id );
+
+		return true;
+	}
+}

--- a/inc/Abilities/Media/ImageOptimizationAbilities.php
+++ b/inc/Abilities/Media/ImageOptimizationAbilities.php
@@ -1,0 +1,418 @@
+<?php
+/**
+ * Image Optimization Abilities
+ *
+ * Diagnose and fix oversized/unoptimized images in the WordPress media library.
+ * Uses WordPress's native image editor (Imagick or GD) for compression and
+ * WebP conversion — no external API or plugin dependencies.
+ *
+ * @package DataMachineBusiness\Abilities\Media
+ * @since 0.42.0
+ */
+
+namespace DataMachineBusiness\Abilities\Media;
+
+use DataMachine\Abilities\AbilityRegistration;
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Engine\Tasks\TaskScheduler;
+
+defined( 'ABSPATH' ) || exit;
+
+class ImageOptimizationAbilities {
+
+	/**
+	 * Default file size threshold in bytes (200KB).
+	 */
+	const DEFAULT_SIZE_THRESHOLD = 204800;
+
+	/**
+	 * Default JPEG/WebP quality for compression.
+	 */
+	const DEFAULT_QUALITY = 82;
+
+	/**
+	 * Number of attachments inspected per optimization candidate query.
+	 */
+	const OPTIMIZATION_SCAN_PAGE_SIZE = 100;
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$this->registerAbilities();
+		self::$registered = true;
+	}
+
+	private function registerAbilities(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/diagnose-images',
+				array(
+					'label'               => 'Diagnose Images',
+					'description'         => 'Scan the media library for oversized images, missing WebP variants, and missing thumbnail sizes.',
+					'category'            => 'datamachine-media',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'size_threshold' => array(
+								'type'        => 'integer',
+								'description' => 'File size threshold in bytes. Images larger than this are flagged. Default: 204800 (200KB).',
+								'default'     => self::DEFAULT_SIZE_THRESHOLD,
+							),
+							'limit'          => array(
+								'type'        => 'integer',
+								'description' => 'Maximum images to scan. Default: 500.',
+								'default'     => 500,
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'            => array( 'type' => 'boolean' ),
+							'total_images'       => array( 'type' => 'integer' ),
+							'total_size'         => array( 'type' => 'integer' ),
+							'oversized_count'    => array( 'type' => 'integer' ),
+							'missing_webp_count' => array( 'type' => 'integer' ),
+							'potential_savings'  => array( 'type' => 'integer' ),
+							'oversized_images'   => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'object' ),
+							),
+						),
+					),
+					'execute_callback'    => array( self::class, 'diagnoseImages' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'datamachine/optimize-images',
+				array(
+					'label'               => 'Optimize Images',
+					'description'         => 'Compress oversized images and generate WebP variants. Uses WordPress image editor (Imagick/GD). Batch-aware.',
+					'category'            => 'datamachine-media',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'attachment_id'  => array(
+								'type'        => 'integer',
+								'description' => 'Specific attachment ID to optimize.',
+							),
+							'size_threshold' => array(
+								'type'        => 'integer',
+								'description' => 'Only optimize images larger than this (bytes). Default: 204800 (200KB).',
+								'default'     => self::DEFAULT_SIZE_THRESHOLD,
+							),
+							'quality'        => array(
+								'type'        => 'integer',
+								'description' => 'JPEG/WebP compression quality (1-100). Default: 82.',
+								'default'     => self::DEFAULT_QUALITY,
+							),
+							'webp'           => array(
+								'type'        => 'boolean',
+								'description' => 'Generate WebP variant. Default: true.',
+								'default'     => true,
+							),
+							'limit'          => array(
+								'type'        => 'integer',
+								'description' => 'Maximum images to optimize in one batch. Default: 50.',
+								'default'     => 50,
+							),
+							'dry_run'        => array(
+								'type'        => 'boolean',
+								'description' => 'Preview changes without applying them. Default: false.',
+								'default'     => false,
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'        => array( 'type' => 'boolean' ),
+							'queued_count'   => array( 'type' => 'integer' ),
+							'batch_id'       => array( 'anyOf' => array( array( 'type' => 'integer' ), array( 'type' => 'null' ) ) ),
+							'scanned_count'  => array( 'type' => 'integer' ),
+							'eligible_count' => array( 'type' => 'integer' ),
+							'scan_complete'  => array( 'type' => 'boolean' ),
+							'message'        => array( 'type' => 'string' ),
+							'error'          => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'optimizeImages' ),
+					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		AbilityRegistration::on_abilities_api_init( $register_callback );
+	}
+
+	/**
+	 * Diagnose image optimization issues across the media library.
+	 *
+	 * Scans for oversized images, missing WebP variants, and reports
+	 * potential savings from compression.
+	 *
+	 * @param array $input Ability input.
+	 * @return array Diagnostic results.
+	 */
+	public static function diagnoseImages( array $input = array() ): array {
+		$size_threshold = absint( $input['size_threshold'] ?? self::DEFAULT_SIZE_THRESHOLD );
+		$limit          = absint( $input['limit'] ?? 500 );
+
+		$attachments = get_posts(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image',
+				'post_status'    => 'inherit',
+				'posts_per_page' => $limit,
+				'fields'         => 'ids',
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			)
+		);
+
+		$total_size         = 0;
+		$oversized_count    = 0;
+		$missing_webp_count = 0;
+		$potential_savings  = 0;
+		$oversized_images   = array();
+
+		foreach ( $attachments as $attachment_id ) {
+			$file_path = get_attached_file( $attachment_id );
+			if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+				continue;
+			}
+
+			$file_size   = filesize( $file_path );
+			$total_size += $file_size;
+			$metadata    = wp_get_attachment_metadata( $attachment_id );
+			$mime_type   = get_post_mime_type( $attachment_id );
+
+			// Check for WebP variant.
+			$has_webp  = false;
+			$webp_path = preg_replace( '/\.(jpe?g|png|gif)$/i', '.webp', $file_path );
+			if ( file_exists( $webp_path ) ) {
+				$has_webp = true;
+			}
+
+			// Also check WP's sources array (WP 6.1+ generates WebP subsizes).
+			if ( ! $has_webp && ! empty( $metadata['sources'] ) ) {
+				foreach ( $metadata['sources'] as $source ) {
+					if ( 'image/webp' === ( $source['mime'] ?? '' ) ) {
+						$has_webp = true;
+						break;
+					}
+				}
+			}
+
+			if ( ! $has_webp && in_array( $mime_type, array( 'image/jpeg', 'image/png' ), true ) ) {
+				++$missing_webp_count;
+			}
+
+			// Check oversized.
+			if ( $file_size > $size_threshold ) {
+				++$oversized_count;
+
+				// Estimate savings (target ~60% reduction for heavily oversized).
+				$estimated_savings  = (int) ( $file_size * 0.4 );
+				$potential_savings += $estimated_savings;
+
+				$width  = $metadata['width'] ?? 0;
+				$height = $metadata['height'] ?? 0;
+
+				$oversized_images[] = array(
+					'attachment_id' => $attachment_id,
+					'title'         => get_the_title( $attachment_id ),
+					'file_size'     => $file_size,
+					'file_size_hr'  => size_format( $file_size ),
+					'dimensions'    => $width . 'x' . $height,
+					'mime_type'     => $mime_type,
+					'has_webp'      => $has_webp,
+				);
+			}
+		}
+
+		// Sort oversized by file size descending.
+		usort( $oversized_images, fn( $a, $b ) => $b['file_size'] - $a['file_size'] );
+
+		return array(
+			'success'              => true,
+			'total_images'         => count( $attachments ),
+			'total_size'           => $total_size,
+			'total_size_hr'        => size_format( $total_size ),
+			'oversized_count'      => $oversized_count,
+			'missing_webp_count'   => $missing_webp_count,
+			'potential_savings'    => $potential_savings,
+			'potential_savings_hr' => size_format( $potential_savings ),
+			'size_threshold'       => $size_threshold,
+			'size_threshold_hr'    => size_format( $size_threshold ),
+			'oversized_images'     => $oversized_images,
+		);
+	}
+
+	/**
+	 * Queue image optimization for oversized images.
+	 *
+	 * Finds eligible images and schedules them for batch optimization
+	 * via the TaskScheduler. Each image is optimized individually as
+	 * a system task (compression + optional WebP generation).
+	 *
+	 * @param array $input Ability input.
+	 * @return array Scheduling result.
+	 */
+	public static function optimizeImages( array $input = array() ): array {
+		$attachment_id  = absint( $input['attachment_id'] ?? 0 );
+		$size_threshold = absint( $input['size_threshold'] ?? self::DEFAULT_SIZE_THRESHOLD );
+		$quality        = absint( $input['quality'] ?? self::DEFAULT_QUALITY );
+		$webp           = $input['webp'] ?? true;
+		$limit          = absint( $input['limit'] ?? 50 );
+		$dry_run        = ! empty( $input['dry_run'] );
+
+		$quality = max( 1, min( 100, $quality ) );
+
+		// Resolve eligible attachment IDs.
+		$attachment_ids = array();
+		$scanned_count  = 0;
+		$scan_complete  = true;
+
+		if ( $attachment_id > 0 ) {
+			$attachment_ids[] = $attachment_id;
+			$scanned_count    = 1;
+		} else {
+			$offset        = 0;
+			$scan_complete = false;
+			$eligible_count = 0;
+
+			while ( $eligible_count < $limit ) {
+				$page = get_posts(
+					array(
+						'post_type'      => 'attachment',
+						'post_mime_type' => 'image',
+						'post_status'    => 'inherit',
+						'posts_per_page' => self::OPTIMIZATION_SCAN_PAGE_SIZE,
+						'offset'         => $offset,
+						'fields'         => 'ids',
+						'orderby'        => array(
+							'date' => 'DESC',
+							'ID'   => 'DESC',
+						),
+						'no_found_rows'  => true,
+					)
+				);
+
+				$page_count = count( $page );
+				$offset    += $page_count;
+
+				foreach ( $page as $id ) {
+					++$scanned_count;
+					$file_path = get_attached_file( $id );
+					if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+						continue;
+					}
+
+					$file_size = filesize( $file_path );
+					if ( $file_size > $size_threshold ) {
+						$attachment_ids[] = $id;
+						++$eligible_count;
+						if ( $eligible_count >= $limit ) {
+							break;
+						}
+					}
+				}
+
+				if ( $scanned_count === $offset && $page_count < self::OPTIMIZATION_SCAN_PAGE_SIZE ) {
+					$scan_complete = true;
+					break;
+				}
+			}
+		}
+
+		$scan_coverage = array(
+			'scanned_count'  => $scanned_count,
+			'eligible_count' => count( $attachment_ids ),
+			'scan_complete'  => $scan_complete,
+		);
+
+		if ( empty( $attachment_ids ) ) {
+			return array_merge( array(
+				'success'      => true,
+				'queued_count' => 0,
+				'message'      => 'No oversized images found to optimize.',
+			), $scan_coverage );
+		}
+
+		if ( $dry_run ) {
+			$preview = array();
+			foreach ( $attachment_ids as $id ) {
+				$file_path = get_attached_file( $id );
+				$file_size = $file_path ? filesize( $file_path ) : 0;
+				$preview[] = array(
+					'attachment_id' => $id,
+					'title'         => get_the_title( $id ),
+					'file_size'     => size_format( $file_size ),
+					'mime_type'     => get_post_mime_type( $id ),
+				);
+			}
+
+			return array_merge( array(
+				'success'        => true,
+				'queued_count'   => 0,
+				'dry_run'        => true,
+				'would_optimize' => $preview,
+				'message'        => sprintf( '%d image(s) would be optimized (dry run).', count( $preview ) ),
+			), $scan_coverage );
+		}
+
+		// Build per-item params for batch scheduling.
+		$item_params = array();
+		foreach ( $attachment_ids as $id ) {
+			$item_params[] = array(
+				'attachment_id' => $id,
+				'quality'       => $quality,
+				'webp'          => $webp,
+				'source'        => 'ability',
+			);
+		}
+
+		$acting             = datamachine_resolve_system_agent_context();
+		$user_id            = $acting['user_id'];
+		$agent_id           = $acting['agent_id'];
+		$triggering_user_id = $acting['triggering_user_id'];
+
+		$batch = TaskScheduler::scheduleBatch(
+			'image_optimization',
+			$item_params,
+			array(
+				'user_id'            => $user_id,
+				'agent_id'           => $agent_id,
+				'triggering_user_id' => $triggering_user_id,
+			)
+		);
+
+		if ( false === $batch ) {
+			return array_merge( array(
+				'success'      => false,
+				'queued_count' => 0,
+				'message'      => 'Failed to schedule optimization batch.',
+				'error'        => 'Task batch scheduling failed.',
+			), $scan_coverage );
+		}
+
+		return array_merge( array(
+			'success'      => true,
+			'queued_count' => count( $attachment_ids ),
+			'batch_id'     => $batch['batch_id'] ?? null,
+			'message'      => sprintf(
+				'Image optimization scheduled for %d image(s).',
+				count( $attachment_ids )
+			),
+		), $scan_coverage );
+	}
+}

--- a/inc/Bootstrap/ProviderModules.php
+++ b/inc/Bootstrap/ProviderModules.php
@@ -16,6 +16,10 @@ final class ProviderModules {
 		$abilities        = array(
 			'DataMachine\\Abilities\\AbilityRegistration' => static fn(): bool => class_exists( 'DataMachine\\Abilities\\AbilityRegistration' ),
 		);
+		$system_tasks     = array(
+			'DataMachine\\Engine\\AI\\System\\Tasks\\SystemTask' => static fn(): bool => class_exists( 'DataMachine\\Engine\\AI\\System\\Tasks\\SystemTask' ),
+			'DataMachine\\Engine\\Tasks\\TaskScheduler'           => static fn(): bool => class_exists( 'DataMachine\\Engine\\Tasks\\TaskScheduler' ),
+		);
 		$tools            = array(
 			'DataMachine\\Engine\\AI\\Tools\\BaseTool' => static fn(): bool => class_exists( 'DataMachine\\Engine\\AI\\Tools\\BaseTool' ),
 		);
@@ -149,6 +153,21 @@ final class ProviderModules {
 				$abilities,
 				array( 'datamachine/media-hygiene' ),
 				static fn() => new \DataMachineBusiness\Abilities\MediaHygiene\MediaHygieneAbility()
+			),
+			new ProviderModule(
+				'image-diagnostics',
+				array_merge( $abilities, $system_tasks ),
+				array(
+					'datamachine/diagnose-images',
+					'datamachine/optimize-images',
+					'datamachine/diagnose-broken-image-references',
+					'task:image_optimization',
+				),
+				static function (): void {
+					new \DataMachineBusiness\Abilities\Media\ImageOptimizationAbilities();
+					new \DataMachineBusiness\Abilities\Media\BrokenImageReferenceAbilities();
+					\DataMachineBusiness\Engine\AI\System\Tasks\ImageOptimizationTask::register();
+				}
 			),
 			new ProviderModule(
 				'sendy',

--- a/inc/Engine/AI/System/Tasks/ImageOptimizationTask.php
+++ b/inc/Engine/AI/System/Tasks/ImageOptimizationTask.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Image Optimization System Task
+ *
+ * Compresses oversized images and generates WebP variants using WordPress's
+ * native image editor (Imagick or GD). No external API dependencies.
+ *
+ * @package DataMachineBusiness\Engine\AI\System\Tasks
+ * @since 0.42.0
+ * @since 0.72.0 Migrated to getWorkflow() + executeTask() contract.
+ */
+
+namespace DataMachineBusiness\Engine\AI\System\Tasks;
+
+use DataMachine\Engine\AI\System\Tasks\SystemTask;
+
+defined( 'ABSPATH' ) || exit;
+
+class ImageOptimizationTask extends SystemTask {
+
+	private static bool $registered = false;
+
+	/**
+	 * Register this task with Data Machine's task registry.
+	 */
+	public static function register(): void {
+		if ( self::$registered ) {
+			return;
+		}
+
+		add_filter( 'datamachine_tasks', array( self::class, 'registerTask' ) );
+		self::$registered = true;
+	}
+
+	/**
+	 * @param array<string, string> $tasks Registered task handlers.
+	 * @return array<string, string>
+	 */
+	public static function registerTask( array $tasks ): array {
+		$tasks['image_optimization'] = self::class;
+
+		return $tasks;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getTaskType(): string {
+		return 'image_optimization';
+	}
+
+	/**
+	 * @return array
+	 */
+	public static function getTaskMeta(): array {
+		return array(
+			'label'           => 'Image Optimization',
+			'description'     => 'Compress oversized images and generate WebP variants using WordPress image editor (Imagick/GD). No external API needed.',
+			'setting_key'     => '',
+			'default_enabled' => false,
+			'trigger'         => 'On-demand via CLI or ability',
+			'trigger_type'    => 'manual',
+			'supports_run'    => false,
+		);
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function supportsUndo(): bool {
+		return true;
+	}
+
+	/**
+	 * Execute image optimization for a single attachment.
+	 *
+	 * @param int   $jobId  DM Job ID.
+	 * @param array $params Engine data with attachment_id, quality, webp.
+	 */
+	public function executeTask( int $jobId, array $params ): void {
+		$attachment_id = absint( $params['attachment_id'] ?? 0 );
+		$quality       = absint( $params['quality'] ?? 82 );
+		$webp          = $params['webp'] ?? true;
+
+		if ( $attachment_id <= 0 ) {
+			$this->failJob( $jobId, 'Missing attachment_id.' );
+			return;
+		}
+
+		$file_path = get_attached_file( $attachment_id );
+		if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+			$this->failJob( $jobId, 'Attachment file not found: ' . ( $file_path ? $file_path : 'empty path' ) );
+			return;
+		}
+
+		$mime_type     = get_post_mime_type( $attachment_id );
+		$original_size = filesize( $file_path );
+		$effects       = array();
+		$results       = array(
+			'attachment_id' => $attachment_id,
+			'original_size' => $original_size,
+			'compressed'    => false,
+			'webp_created'  => false,
+		);
+
+		if ( in_array( $mime_type, array( 'image/jpeg', 'image/png', 'image/webp' ), true ) ) {
+			$compress_result = $this->compressImage( $file_path, $mime_type, $quality, $attachment_id );
+
+			if ( $compress_result['success'] ) {
+				$results['compressed']  = true;
+				$results['new_size']    = $compress_result['new_size'];
+				$results['savings']     = $original_size - $compress_result['new_size'];
+				$results['savings_pct'] = $original_size > 0 ? round( ( $results['savings'] / $original_size ) * 100, 1 ) : 0;
+
+				$effects[] = array(
+					'type'          => 'attachment_file_modified',
+					'target'        => array(
+						'attachment_id' => $attachment_id,
+						'file_path'     => $file_path,
+					),
+					'previous_size' => $original_size,
+					'new_size'      => $compress_result['new_size'],
+				);
+
+				$metadata = wp_get_attachment_metadata( $attachment_id );
+				if ( is_array( $metadata ) ) {
+					$metadata['filesize'] = $compress_result['new_size'];
+					wp_update_attachment_metadata( $attachment_id, $metadata );
+				}
+			}
+		}
+
+		if ( $webp && in_array( $mime_type, array( 'image/jpeg', 'image/png' ), true ) ) {
+			$webp_result = $this->generateWebP( $file_path, $quality, $attachment_id );
+
+			if ( $webp_result['success'] ) {
+				$results['webp_created'] = true;
+				$results['webp_path']    = $webp_result['webp_path'];
+				$results['webp_size']    = $webp_result['webp_size'];
+
+				$effects[] = array(
+					'type'   => 'file_created',
+					'target' => array(
+						'file_path' => $webp_result['webp_path'],
+					),
+				);
+			}
+		}
+
+		$results['effects']      = $effects;
+		$results['completed_at'] = current_time( 'mysql' );
+
+		$this->completeJob( $jobId, $results );
+	}
+
+	/**
+	 * @param string $file_path     Absolute path.
+	 * @param string $mime_type     MIME type.
+	 * @param int    $quality       Compression quality.
+	 * @param int    $attachment_id Attachment ID.
+	 * @return array{success: bool, new_size: int, error: string}
+	 */
+	private function compressImage( string $file_path, string $mime_type, int $quality, int $attachment_id ): array {
+		$editor = wp_get_image_editor( $file_path );
+
+		if ( is_wp_error( $editor ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Image editor not available: ' . $editor->get_error_message(),
+			);
+		}
+
+		$editor->set_quality( $quality );
+		$saved = $editor->save( $file_path, $mime_type );
+
+		if ( is_wp_error( $saved ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Compression failed: ' . $saved->get_error_message(),
+			);
+		}
+
+		clearstatcache( true, $file_path );
+		return array(
+			'success'  => true,
+			'new_size' => filesize( $file_path ),
+		);
+	}
+
+	/**
+	 * @param string $file_path     Source image.
+	 * @param int    $quality       WebP quality.
+	 * @param int    $attachment_id Attachment ID.
+	 * @return array{success: bool, webp_path: string, webp_size: int, error: string}
+	 */
+	private function generateWebP( string $file_path, int $quality, int $attachment_id ): array {
+		$webp_path = preg_replace( '/\.(jpe?g|png)$/i', '.webp', $file_path );
+
+		if ( file_exists( $webp_path ) ) {
+			return array(
+				'success'   => true,
+				'webp_path' => $webp_path,
+				'webp_size' => filesize( $webp_path ),
+			);
+		}
+
+		$editor = wp_get_image_editor( $file_path );
+		if ( is_wp_error( $editor ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Image editor not available: ' . $editor->get_error_message(),
+			);
+		}
+
+		$editor->set_quality( $quality );
+		$saved = $editor->save( $webp_path, 'image/webp' );
+
+		if ( is_wp_error( $saved ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'WebP generation failed: ' . $saved->get_error_message(),
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'webp_path' => $saved['path'],
+			'webp_size' => filesize( $saved['path'] ),
+		);
+	}
+}

--- a/tests/ability-registration-lifecycle-smoke.php
+++ b/tests/ability-registration-lifecycle-smoke.php
@@ -130,6 +130,8 @@ $ability_files = array(
 	'inc/Abilities/GoogleSheets/FetchGoogleSheetsAbility.php',
 	'inc/Abilities/GoogleSheets/PublishGoogleSheetsAbility.php',
 	'inc/Abilities/MediaHygiene/MediaHygieneAbility.php',
+	'inc/Abilities/Media/BrokenImageReferenceAbilities.php',
+	'inc/Abilities/Media/ImageOptimizationAbilities.php',
 	'inc/Abilities/PageSpeed/PageSpeedAbility.php',
 	'inc/Abilities/Sendy/SendyAbilities.php',
 	'inc/Abilities/Slack/FetchMessagesSlackAbility.php',

--- a/tests/image-broken-reference-multisite-smoke.php
+++ b/tests/image-broken-reference-multisite-smoke.php
@@ -1,0 +1,481 @@
+<?php
+/**
+ * Smoke tests for BrokenImageReferenceAbilities.
+ *
+ * Covers the load-bearing multisite resolution logic plus the pure parsing
+ * helpers. Runs standalone (no WordPress install required) via:
+ *
+ *   php tests/image-broken-reference-multisite-smoke.php
+ *
+ * @package DataMachineBusiness\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+// --- WordPress function stubs ------------------------------------------------
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ): int {
+		return max( 0, (int) $value );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ): string {
+		return trim( (string) $value );
+	}
+}
+
+/**
+ * Parse a URL with component support, mirroring wp_parse_url.
+ *
+ * @param string $url      URL.
+ * @param int    $component Component.
+ * @return mixed
+ */
+function wp_parse_url( string $url, int $component = -1 ) {
+	$parsed = parse_url( $url );
+	if ( ! is_array( $parsed ) ) {
+		$parsed = array();
+	}
+	if ( -1 === $component ) {
+		return $parsed;
+	}
+	$map = array(
+		PHP_URL_SCHEME => 'scheme',
+		PHP_URL_HOST   => 'host',
+		PHP_URL_PORT   => 'port',
+		PHP_URL_PATH   => 'path',
+		PHP_URL_QUERY  => 'query',
+	);
+	$key = $map[ $component ] ?? null;
+	if ( null === $key ) {
+		return null;
+	}
+
+	return $parsed[ $key ] ?? null;
+}
+
+// --- Multisite blog stack ----------------------------------------------------
+
+$GLOBALS['__dm_current_blog'] = 1;
+$GLOBALS['__dm_blog_stack']   = array();
+
+$GLOBALS['__dm_blog_uploads'] = array(
+	1 => array(
+		'baseurl' => 'https://extrachill.com/wp-content/uploads',
+		'basedir' => '/var/www/uploads',
+	),
+	2 => array(
+		'baseurl' => 'https://community.extrachill.com/wp-content/uploads/sites/2',
+		'basedir' => '/var/www/uploads/sites/2',
+	),
+);
+
+$GLOBALS['__dm_blog_home'] = array(
+	1 => 'https://extrachill.com',
+	2 => 'https://community.extrachill.com',
+);
+
+function is_multisite(): bool {
+	return true;
+}
+
+function get_current_blog_id(): int {
+	return $GLOBALS['__dm_current_blog'];
+}
+
+function switch_to_blog( int $blog_id ): void {
+	$GLOBALS['__dm_blog_stack'][] = $GLOBALS['__dm_current_blog'];
+	$GLOBALS['__dm_current_blog'] = $blog_id;
+}
+
+function restore_current_blog(): void {
+	if ( empty( $GLOBALS['__dm_blog_stack'] ) ) {
+		$GLOBALS['__dm_current_blog'] = 1;
+		return;
+	}
+	$GLOBALS['__dm_current_blog'] = array_pop( $GLOBALS['__dm_blog_stack'] );
+}
+
+function get_sites( array $args = array() ) {
+	if ( isset( $args['fields'] ) && 'ids' === $args['fields'] ) {
+		return array( 1, 2 );
+	}
+	return array();
+}
+
+function wp_get_upload_dir(): array {
+	$blog_id = $GLOBALS['__dm_current_blog'];
+	return $GLOBALS['__dm_blog_uploads'][ $blog_id ] ?? array(
+		'baseurl' => '',
+		'basedir' => '',
+	);
+}
+
+function home_url( string $path = '' ): string {
+	$blog_id = $GLOBALS['__dm_current_blog'];
+	$origin  = $GLOBALS['__dm_blog_home'][ $blog_id ] ?? 'https://extrachill.com';
+	return $origin . $path;
+}
+
+// --- Fake wpdb with per-blog post fixtures -----------------------------------
+
+class Datamachine_Broken_Image_Wpdb {
+	public string $posts = 'wp_posts';
+
+	public function prepare( string $query, ...$args ): array {
+		return array(
+			'query' => $query,
+			'args'  => $args,
+		);
+	}
+
+	public function get_results( array $prepared ): array {
+		// Distinguish the single-post lookup (ID = %d, 2 args) from the
+		// chunked scan (4 args). For the chunked scan, return the current
+		// blog's rows whose ID > last_id.
+		$blog_id = $GLOBALS['__dm_current_blog'];
+		$rows    = $GLOBALS['__dm_broken_image_rows'][ $blog_id ] ?? array();
+
+		if ( count( $prepared['args'] ) <= 2 ) {
+			$target = (int) ( $prepared['args'][0] ?? 0 );
+			foreach ( $rows as $row ) {
+				if ( (int) $row->ID === $target ) {
+					return array( $row );
+				}
+			}
+			return array();
+		}
+
+		$last  = (int) ( $prepared['args'][2] ?? 0 );
+		$limit = (int) ( $prepared['args'][3] ?? 100 );
+		$out   = array_values(
+			array_filter(
+				$rows,
+				static fn( $row ) => (int) $row->ID > $last
+			)
+		);
+		usort( $out, static fn( $a, $b ) => (int) $a->ID <=> (int) $b->ID );
+
+		return array_slice( $out, 0, $limit );
+	}
+
+	public function get_row( array $prepared ) {
+		$results = $this->get_results( $prepared );
+		return $results[0] ?? null;
+	}
+}
+
+$GLOBALS['wpdb'] = new Datamachine_Broken_Image_Wpdb();
+
+require_once dirname( __DIR__ ) . '/inc/Abilities/Media/BrokenImageReferenceAbilities.php';
+
+use DataMachineBusiness\Abilities\Media\BrokenImageReferenceAbilities;
+
+$assertions = 0;
+$failures   = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$assertions, &$failures ): void {
+	++$assertions;
+	if ( $condition ) {
+		echo "  [PASS] {$message}\n";
+		return;
+	}
+	$failures[] = $message;
+	echo "  [FAIL] {$message}\n";
+};
+
+echo "Broken image reference multisite smoke\n\n";
+
+// --- Pure helper: parse_srcset -----------------------------------------------
+
+echo "parse_srcset:\n";
+$urls = BrokenImageReferenceAbilities::parse_srcset( 'https://x/a-480w.jpg 480w, https://x/a-960w.jpg 960w 2x, https://x/a.webp 1x' );
+$assert( 3 === count( $urls ), 'srcset splits into 3 candidates' );
+$assert( 'https://x/a-480w.jpg' === $urls[0], 'first srcset url strips 480w descriptor' );
+$assert( 'https://x/a-960w.jpg' === $urls[1], 'second srcset url strips 960w 2x descriptor' );
+$assert( 'https://x/a.webp' === $urls[2], 'third srcset url strips 1x descriptor' );
+$assert( array() === BrokenImageReferenceAbilities::parse_srcset( '' ), 'empty srcset yields no urls' );
+
+// --- Pure helper: parse_css_url_list -----------------------------------------
+
+echo "\nparse_css_url_list:\n";
+$bg = BrokenImageReferenceAbilities::parse_css_url_list( 'url(/wp-content/uploads/a.jpg) 1x, url("https://x/b.jpg") 2x' );
+$assert( 2 === count( $bg ), 'data-bgset extracts two url(...) candidates' );
+$assert( '/wp-content/uploads/a.jpg' === $bg[0], 'first css url path extracted' );
+$assert( 'https://x/b.jpg' === $bg[1], 'second css url with quotes extracted' );
+
+// --- Pure helper: normalize_image_url ----------------------------------------
+
+echo "\nnormalize_image_url:\n";
+$origin = 'https://extrachill.com';
+$assert( 'https://extrachill.com/wp-content/uploads/x.jpg' === BrokenImageReferenceAbilities::normalize_image_url( '/wp-content/uploads/x.jpg', $origin ), 'root-relative url resolves to origin' );
+$assert( 'https://community.extrachill.com/foo.jpg' === BrokenImageReferenceAbilities::normalize_image_url( '//community.extrachill.com/foo.jpg', $origin ), 'protocol-relative url gets scheme' );
+$assert( 'https://extrachill.com/a.jpg' === BrokenImageReferenceAbilities::normalize_image_url( 'a.jpg', $origin ), 'bare relative path resolves' );
+$assert( '' === BrokenImageReferenceAbilities::normalize_image_url( 'data:image/png;base64,abc', $origin ), 'data uri is dropped' );
+$assert( '' === BrokenImageReferenceAbilities::normalize_image_url( 'mailto:foo@bar.com', $origin ), 'mailto is dropped' );
+$assert( 'https://x/y.jpg' === BrokenImageReferenceAbilities::normalize_image_url( 'https://x/y.jpg', $origin ), 'absolute url is unchanged' );
+
+// --- Pure helper: extract_image_urls_from_html -------------------------------
+
+echo "\nextract_image_urls_from_html:\n";
+$html = '<p><img src="https://x/a.jpg" srcset="https://x/a-480w.jpg 480w, https://x/a-960w.jpg 960w" data-src="https://x/b.jpg" data-lazy-src="https://x/c.jpg" data-srcset="https://x/d.jpg 1x" alt="hi"><img data-bg="https://x/bg.jpg" data-bgset="url(https://x/bg2.jpg)"></p>';
+$refs = BrokenImageReferenceAbilities::extract_image_urls_from_html( $html );
+$urls_found = array();
+foreach ( $refs as $ref ) {
+	$urls_found[] = $ref['url'] . '@' . $ref['attribute'];
+}
+$assert( in_array( 'https://x/a.jpg@src', $urls_found, true ), 'src attribute captured' );
+$assert( in_array( 'https://x/a-480w.jpg@srcset', $urls_found, true ), 'srcset 480w candidate captured' );
+$assert( in_array( 'https://x/a-960w.jpg@srcset', $urls_found, true ), 'srcset 960w candidate captured' );
+$assert( in_array( 'https://x/b.jpg@data-src', $urls_found, true ), 'data-src lazy attribute captured' );
+$assert( in_array( 'https://x/c.jpg@data-lazy-src', $urls_found, true ), 'data-lazy-src attribute captured' );
+$assert( in_array( 'https://x/d.jpg@data-srcset', $urls_found, true ), 'data-srcset candidate captured' );
+$assert( in_array( 'https://x/bg.jpg@data-bg', $urls_found, true ), 'data-bg attribute captured' );
+$assert( in_array( 'https://x/bg2.jpg@data-bgset', $urls_found, true ), 'data-bgset url() captured' );
+$assert( array() === BrokenImageReferenceAbilities::extract_image_urls_from_html( 'no images here' ), 'html without imgs yields nothing' );
+
+// data uri inside src is present but later dropped by normalize; confirm extraction still sees it.
+$data_refs = BrokenImageReferenceAbilities::extract_image_urls_from_html( '<img src="data:image/png;base64,xx">' );
+$assert( 1 === count( $data_refs ), 'data-uri src is extracted (normalize drops it downstream)' );
+
+// --- Pure helper: resolve_url_to_local ---------------------------------------
+
+echo "\nresolve_url_to_local (multisite + cross-site):\n";
+$blog_uploads = array(
+	1 => array(
+		'baseurl' => 'https://extrachill.com/wp-content/uploads',
+		'basedir' => '/var/www/uploads',
+	),
+	2 => array(
+		'baseurl' => 'https://community.extrachill.com/wp-content/uploads/sites/2',
+		'basedir' => '/var/www/uploads/sites/2',
+	),
+);
+
+$r1 = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/a.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r1['kind'], 'same-site upload resolves as local' );
+$assert( 1 === $r1['blog_id'], 'same-site upload maps to blog 1' );
+$assert( DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'www' . DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . '2024' . DIRECTORY_SEPARATOR . '01' . DIRECTORY_SEPARATOR . 'a.jpg' === $r1['path'], 'same-site path is basedir + relative' );
+
+$r2 = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://community.extrachill.com/wp-content/uploads/sites/2/2024/02/cross.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r2['kind'], 'cross-site upload resolves as local' );
+$assert( 2 === $r2['blog_id'], 'cross-site upload maps to blog 2 even when scanned from blog 1' );
+$assert( DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'www' . DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . '2' . DIRECTORY_SEPARATOR . '2024' . DIRECTORY_SEPARATOR . '02' . DIRECTORY_SEPARATOR . 'cross.jpg' === $r2['path'], 'cross-site path uses blog 2 basedir' );
+
+$rext = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://cdn.example.com/img.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'external' === $rext['kind'], 'off-network host is external' );
+$assert( null === $rext['path'], 'external has no path' );
+
+// Subdirectory-style longest-prefix correctness: a host on network but a path
+// that merely shares a prefix string should not match.
+$r_prefix = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads-other/x.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'external' === $r_prefix['kind'] || 'unresolvable' === $r_prefix['kind'], 'shared-prefix sibling directory does not falsely match upload base' );
+
+// --- Encoded upload path resolution (issue #2887) ----------------------------
+
+echo "\nresolve_url_to_local (encoded upload paths):\n";
+$sep = DIRECTORY_SEPARATOR;
+
+// %20 decodes once to a literal space.
+$r_space = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/my%20file.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r_space['kind'], '%20 url resolves as local' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/2024/01/my file.jpg' ) === $r_space['path'], '%20 decodes once to a literal space in the path' );
+
+// %2B decodes once to a literal '+'. rawurldecode keeps a literal '+' intact.
+$r_plus = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/a%2Bb.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r_plus['kind'], '%2B url resolves as local' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/2024/01/a+b.jpg' ) === $r_plus['path'], '%2B decodes once to a literal plus sign' );
+
+// A literal '+' in the URL path must NOT become a space (path semantics, not query).
+$r_lit_plus = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/a+b.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/2024/01/a+b.jpg' ) === $r_lit_plus['path'], 'literal plus in path stays a plus (rawurldecode, not urldecode)' );
+
+// The Blogger migration case: %2528 -> %28 (decoded exactly once, not re-decoded).
+$r_blogger = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/blogger/s1600/Abstract-ECF%25281%2529.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r_blogger['kind'], 'Blogger-encoded %2528 url resolves as local' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/blogger/s1600/Abstract-ECF%281%29.jpg' ) === $r_blogger['path'], '%2528 decodes once to the literal %28 filename on disk' );
+
+// Unicode filename (UTF-8 bytes percent-encoded) decodes once to the multibyte name.
+$r_uni = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/caf%C3%A9.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r_uni['kind'], 'unicode-encoded url resolves as local' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/2024/01/caf' . "\xc3\xa9" . '.jpg' ) === $r_uni['path'], 'unicode %C3%A9 decodes once to the UTF-8 filename' );
+
+// Decoded traversal must be rejected (never produce a local path above basedir).
+$r_trav = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/../../etc/passwd', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'unresolvable' === $r_trav['kind'], 'decoded ../ traversal is rejected as unresolvable' );
+$assert( null === $r_trav['path'], 'decoded traversal yields no filesystem path' );
+
+// Encoded separator escape (%2f..%2f) decodes to /../ and must be rejected.
+$r_enc_trav = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/foo%2f..%2f..%2fsecret', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'unresolvable' === $r_enc_trav['kind'], 'encoded separator traversal (%2f..%2f) is rejected' );
+
+// Single-encoded %2e%2e traversal must also be rejected.
+$r_dot_enc = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/%2e%2e/%2e%2e/etc', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'unresolvable' === $r_dot_enc['kind'], 'encoded %2e%2e traversal is rejected' );
+
+// Double-encoded traversal decodes once to a literal (inert) name and stays contained.
+$r_double = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/%252e%252e%252flogo.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r_double['kind'], 'double-encoded traversal stays local (single decode only)' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/%2e%2e%2flogo.jpg' ) === $r_double['path'], 'double-encoded sequence is not re-decoded, stays a literal filename' );
+
+// Query strings and fragments must be stripped before filesystem lookup.
+$r_query = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://extrachill.com/wp-content/uploads/2024/01/cache.jpg?v=123', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/2024/01/cache.jpg' ) === $r_query['path'], 'query string is stripped from the filesystem path' );
+
+// Cross-site encoded path still resolves against the owning site's base.
+$r_cross_enc = BrokenImageReferenceAbilities::resolve_url_to_local( 'https://community.extrachill.com/wp-content/uploads/sites/2/2024/02/cross%20shot.jpg', $blog_uploads, 1, 'https://extrachill.com' );
+$assert( 'local' === $r_cross_enc['kind'], 'cross-site encoded url resolves as local' );
+$assert( 2 === $r_cross_enc['blog_id'], 'cross-site encoded url attributes to owning blog 2' );
+$assert( str_replace( '/', $sep, '/var/www/uploads/sites/2/2024/02/cross shot.jpg' ) === $r_cross_enc['path'], 'cross-site encoded path uses blog 2 basedir with decoded name' );
+
+// --- Full orchestration: diagnoseBrokenImageReferences -----------------------
+
+echo "\ndiagnoseBrokenImageReferences (full scan):\n";
+
+$GLOBALS['__dm_broken_image_rows'] = array(
+	1 => array(
+		(object) array(
+			'ID'           => 10,
+			'post_title'   => 'Post on main site',
+			'post_content' => '<img src="https://extrachill.com/wp-content/uploads/2024/01/missing.jpg">'
+				. '<img srcset="https://extrachill.com/wp-content/uploads/2024/01/present.jpg 480w, https://extrachill.com/wp-content/uploads/2024/01/missing.jpg 960w">'
+				. '<img data-src="https://community.extrachill.com/wp-content/uploads/sites/2/2024/02/cross_missing.jpg">'
+				. '<img src="https://cdn.example.com/external.jpg">'
+				. '<img src="data:image/png;base64,deadbeef">'
+				. '<img src="/wp-content/uploads/2024/01/rootrelative_missing.jpg">',
+		),
+		(object) array(
+			'ID'           => 11,
+			'post_title'   => 'Post with present cross-site',
+			'post_content' => '<img src="https://community.extrachill.com/wp-content/uploads/sites/2/2024/02/cross_present.jpg">',
+		),
+		(object) array(
+			'ID'           => 12,
+			'post_title'   => 'Post with present Blogger-encoded image',
+			'post_content' => '<img src="https://extrachill.com/wp-content/uploads/blogger/s1600/Abstract-ECF%25281%2529.jpg">',
+		),
+	),
+	2 => array(),
+);
+
+// file_exists stub: only "present" paths exist.
+$present = array(
+	'/var/www/uploads/2024/01/present.jpg',
+	'/var/www/uploads/sites/2/2024/02/cross_present.jpg',
+	'/var/www/uploads/blogger/s1600/Abstract-ECF%281%29.jpg',
+);
+$sep        = DIRECTORY_SEPARATOR;
+$present_n  = array_map( static fn( $p ) => str_replace( '/', $sep, $p ), $present );
+$file_check = static function ( string $path ) use ( $present_n ): bool {
+	return in_array( $path, $present_n, true );
+};
+
+$result = BrokenImageReferenceAbilities::diagnoseBrokenImageReferences(
+	array(
+		'post_type' => 'post',
+		'network'   => true,
+	),
+	$file_check
+);
+
+$assert( true === $result['success'], 'network scan returns success' );
+$assert( 3 === $result['posts_scanned'], 'three posts scanned (blog 2 has no posts)' );
+
+$broken = $result['broken_references'];
+$urls   = array();
+foreach ( $broken as $b ) {
+	$urls[] = $b['url'];
+}
+
+$missing_main = 'https://extrachill.com/wp-content/uploads/2024/01/missing.jpg';
+$cross_missing = 'https://community.extrachill.com/wp-content/uploads/sites/2/2024/02/cross_missing.jpg';
+$root_missing  = 'https://extrachill.com/wp-content/uploads/2024/01/rootrelative_missing.jpg';
+
+$assert( in_array( $missing_main, $urls, true ), 'missing main-site file reported' );
+$assert( in_array( $cross_missing, $urls, true ), 'missing cross-site (blog 2) file reported from a blog 1 post' );
+$assert( in_array( $root_missing, $urls, true ), 'root-relative missing file reported' );
+$assert( ! in_array( 'https://cdn.example.com/external.jpg', $urls, true ), 'external url is not reported as missing local' );
+
+// The Blogger-encoded image whose decoded filename exists on disk must NOT be
+// reported as broken — the concrete production false-positive from issue #2887.
+$blogger_present_url = 'https://extrachill.com/wp-content/uploads/blogger/s1600/Abstract-ECF%25281%2529.jpg';
+$assert( ! in_array( $blogger_present_url, $urls, true ), 'present Blogger-encoded (%2528 -> %28) image is not a false positive' );
+
+// Dedup: missing.jpg appears in src AND srcset but must be reported once.
+$duplicate_count = 0;
+foreach ( $broken as $b ) {
+	if ( $missing_main === $b['url'] ) {
+		++$duplicate_count;
+	}
+}
+$assert( 1 === $duplicate_count, 'duplicate url within a post is deduplicated to one report' );
+
+// Cross-site host_blog attribution.
+foreach ( $broken as $b ) {
+	if ( $cross_missing === $b['url'] ) {
+		$assert( 2 === $b['host_blog'], 'cross-site missing reference attributes host_blog=2 (owning site)' );
+		$assert( 1 === $b['blog_id'], 'cross-site missing reference keeps blog_id=1 (post site)' );
+	}
+}
+
+// Present files are NOT reported.
+$assert( ! in_array( 'https://extrachill.com/wp-content/uploads/2024/01/present.jpg', $urls, true ), 'present main-site file is not reported' );
+$assert( ! in_array( 'https://community.extrachill.com/wp-content/uploads/sites/2/2024/02/cross_present.jpg', $urls, true ), 'present cross-site file is not reported' );
+
+// references_found counts deduped local+external refs that were processed
+// (data: uri is dropped at normalize, so it is never counted).
+$assert( $result['references_found'] >= 4, 'references_found counts deduped candidates' );
+
+// --- Single-site (no network) scan -------------------------------------------
+
+echo "\ndiagnoseBrokenImageReferences (single-site scan):\n";
+$GLOBALS['__dm_current_blog'] = 1;
+$GLOBALS['__dm_blog_stack']   = array();
+
+$single = BrokenImageReferenceAbilities::diagnoseBrokenImageReferences(
+	array(
+		'post_type' => 'post',
+		'network'   => false,
+	),
+	$file_check
+);
+
+$assert( true === $single['success'], 'single-site scan returns success' );
+$assert( 3 === $single['posts_scanned'], 'single-site scan reads the current blog posts' );
+
+// --- single post_id scope ----------------------------------------------------
+
+echo "\ndiagnoseBrokenImageReferences (single post scope):\n";
+$GLOBALS['__dm_current_blog'] = 1;
+$GLOBALS['__dm_blog_stack']   = array();
+
+$one = BrokenImageReferenceAbilities::diagnoseBrokenImageReferences(
+	array(
+		'post_id' => 11,
+	),
+	$file_check
+);
+
+$assert( true === $one['success'], 'single post scan returns success' );
+$assert( 1 === $one['posts_scanned'], 'single post scan reads exactly one post' );
+$assert( 0 === $one['broken_count'], 'post 11 has only a present file' );
+
+// --- blog stack is always restored -------------------------------------------
+
+$GLOBALS['__dm_current_blog'] = 1;
+$GLOBALS['__dm_blog_stack']   = array();
+BrokenImageReferenceAbilities::diagnoseBrokenImageReferences( array( 'network' => true ), $file_check );
+$assert( 1 === get_current_blog_id(), 'current blog is restored after a network scan' );
+$assert( empty( $GLOBALS['__dm_blog_stack'] ), 'blog stack is balanced after a network scan' );
+
+echo "\n" . $assertions . ' assertions, ' . count( $failures ) . " failures\n";
+
+if ( ! empty( $failures ) ) {
+	exit( 1 );
+}
+
+echo "Broken image reference multisite smoke passed.\n";

--- a/tests/image-diagnostics-ownership-smoke.php
+++ b/tests/image-diagnostics-ownership-smoke.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Ownership and task registration continuity for DMB image diagnostics.
+ */
+
+namespace {
+	$root     = dirname( __DIR__ );
+	$failures = array();
+	$filters  = array();
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', $root . '/' );
+	}
+
+	function add_filter( string $hook, callable $callback ): void {
+		global $filters;
+		$filters[ $hook ][] = $callback;
+	}
+
+	function image_diagnostics_assert( bool $condition, string $message ): void {
+		global $failures;
+		if ( ! $condition ) {
+			$failures[] = $message;
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI\System\Tasks {
+	abstract class SystemTask {}
+}
+
+namespace {
+	$ability_paths = array(
+		$root . '/inc/Abilities/Media/ImageOptimizationAbilities.php',
+		$root . '/inc/Abilities/Media/BrokenImageReferenceAbilities.php',
+	);
+	$task_path     = $root . '/inc/Engine/AI/System/Tasks/ImageOptimizationTask.php';
+	$provider_path = $root . '/inc/Bootstrap/ProviderModules.php';
+
+	foreach ( array_merge( $ability_paths, array( $task_path ) ) as $path ) {
+		image_diagnostics_assert( file_exists( $path ), 'Missing DMB-owned file: ' . $path );
+	}
+
+	$abilities = file_get_contents( $ability_paths[0] ) . file_get_contents( $ability_paths[1] );
+	$task      = file_get_contents( $task_path );
+	$provider  = file_get_contents( $provider_path );
+
+	foreach ( array( 'datamachine/diagnose-images', 'datamachine/optimize-images', 'datamachine/diagnose-broken-image-references' ) as $slug ) {
+		image_diagnostics_assert( str_contains( $abilities, $slug ), 'Owned ability slug missing: ' . $slug );
+		image_diagnostics_assert( str_contains( $provider, $slug ), 'Provider capability missing: ' . $slug );
+	}
+
+	$continuity = array(
+		'namespace DataMachineBusiness\\Abilities\\Media'                         => $abilities,
+		'use DataMachine\\Abilities\\AbilityRegistration'                       => $abilities,
+		'use DataMachine\\Abilities\\PermissionHelper'                          => $abilities,
+		'use DataMachine\\Engine\\Tasks\\TaskScheduler'                        => $abilities,
+		'AbilityRegistration::on_abilities_api_init'                               => $abilities,
+		'datamachine_resolve_system_agent_context'                                 => $abilities,
+		"'show_in_rest'=>true"                                                    => str_replace( array( "\t", ' ' ), '', $abilities ),
+		'namespace DataMachineBusiness\\Engine\\AI\\System\\Tasks'           => $task,
+		'use DataMachine\\Engine\\AI\\System\\Tasks\\SystemTask'           => $task,
+		"return 'image_optimization'"                                             => $task,
+		"'attachment_file_modified'"                                             => $task,
+		"'file_created'"                                                         => $task,
+		"'task:image_optimization'"                                              => $provider,
+		'DataMachineBusiness\\Engine\\AI\\System\\Tasks\\ImageOptimizationTask::register' => $provider,
+	);
+
+	foreach ( $continuity as $needle => $haystack ) {
+		image_diagnostics_assert( str_contains( $haystack, $needle ), 'Continuity marker missing: ' . $needle );
+	}
+
+	foreach ( array( 'AltText', 'ImageGeneration', 'ImageTemplate', 'VideoMetadata', 'UploadValidation' ) as $unrelated ) {
+		image_diagnostics_assert( ! str_contains( $abilities . $task . $provider, $unrelated ), 'Unrelated media ownership moved: ' . $unrelated );
+	}
+
+	require_once $task_path;
+	\DataMachineBusiness\Engine\AI\System\Tasks\ImageOptimizationTask::register();
+	\DataMachineBusiness\Engine\AI\System\Tasks\ImageOptimizationTask::register();
+	image_diagnostics_assert( 1 === count( $filters['datamachine_tasks'] ?? array() ), 'Task filter registration is idempotent' );
+
+	$registered_tasks = ( $filters['datamachine_tasks'][0] )( array( 'existing' => 'ExistingTask' ) );
+	image_diagnostics_assert( 'ExistingTask' === $registered_tasks['existing'], 'Task registration preserves existing handlers' );
+	image_diagnostics_assert(
+		\DataMachineBusiness\Engine\AI\System\Tasks\ImageOptimizationTask::class === $registered_tasks['image_optimization'],
+		'image_optimization resolves to the DMB task class'
+	);
+
+	if ( ! empty( $failures ) ) {
+		fwrite( STDERR, "Image diagnostics ownership smoke failed:\n - " . implode( "\n - ", $failures ) . "\n" );
+		exit( 1 );
+	}
+
+	echo "Image diagnostics ownership smoke checks passed.\n";
+}

--- a/tests/image-optimization-pagination-smoke.php
+++ b/tests/image-optimization-pagination-smoke.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Pure-PHP smoke test for image optimization candidate pagination.
+ *
+ * Run with: php tests/image-optimization-pagination-smoke.php
+ *
+ * @package DataMachineBusiness\Tests
+ */
+
+namespace {
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+$GLOBALS['__image_optimization_attachments'] = array();
+$GLOBALS['__image_optimization_files']       = array();
+$GLOBALS['__image_optimization_queries']     = array();
+$GLOBALS['__image_optimization_failures']    = 0;
+
+function image_optimization_assert( bool $condition, string $message ): void {
+	if ( $condition ) {
+		echo "  PASS: {$message}\n";
+		return;
+	}
+
+	echo "  FAIL: {$message}\n";
+	++$GLOBALS['__image_optimization_failures'];
+}
+
+function image_optimization_fixture( array $sizes ): void {
+	$GLOBALS['__image_optimization_attachments'] = array_keys( $sizes );
+	$GLOBALS['__image_optimization_files']       = array();
+	$GLOBALS['__image_optimization_queries']     = array();
+
+	foreach ( $sizes as $attachment_id => $size ) {
+		$file = tempnam( sys_get_temp_dir(), 'dm-image-scan-' );
+		file_put_contents( $file, str_repeat( 'x', $size ) );
+		$GLOBALS['__image_optimization_files'][ $attachment_id ] = $file;
+	}
+}
+
+function image_optimization_cleanup(): void {
+	foreach ( $GLOBALS['__image_optimization_files'] as $file ) {
+		unlink( $file );
+	}
+}
+}
+
+namespace DataMachineBusiness\Abilities\Media {
+function absint( $value ): int {
+	return abs( (int) $value );
+}
+
+function get_posts( array $args ): array {
+	$GLOBALS['__image_optimization_queries'][] = $args;
+	return array_slice(
+		$GLOBALS['__image_optimization_attachments'],
+		(int) ( $args['offset'] ?? 0 ),
+		(int) $args['posts_per_page']
+	);
+}
+
+function get_attached_file( int $attachment_id ): string {
+	return $GLOBALS['__image_optimization_files'][ $attachment_id ] ?? '';
+}
+
+function get_the_title( int $attachment_id ): string {
+	return 'Image ' . $attachment_id;
+}
+
+function get_post_mime_type( int $attachment_id ): string {
+	unset( $attachment_id );
+	return 'image/jpeg';
+}
+
+function size_format( int $bytes ): string {
+	return $bytes . ' B';
+}
+}
+
+namespace {
+require_once dirname( __DIR__ ) . '/inc/Abilities/Media/ImageOptimizationAbilities.php';
+
+use DataMachineBusiness\Abilities\Media\ImageOptimizationAbilities;
+
+echo "=== image-optimization-pagination-smoke ===\n";
+
+$sizes      = array_fill( 1, 100, 5 );
+$sizes[101] = 20;
+image_optimization_fixture( $sizes );
+$result = ImageOptimizationAbilities::optimizeImages(
+	array(
+		'size_threshold' => 10,
+		'limit'          => 1,
+		'dry_run'        => true,
+	)
+);
+image_optimization_assert( array( 101 ) === array_column( $result['would_optimize'], 'attachment_id' ), 'finds an eligible image beyond the first page' );
+image_optimization_assert( 101 === $result['scanned_count'], 'reports all inspected attachments across pages' );
+image_optimization_assert( true === $result['scan_complete'], 'reports complete coverage when the final page is exhausted' );
+image_optimization_cleanup();
+
+$sizes      = array_fill( 1, 100, 5 );
+$sizes[101] = 20;
+$sizes[102] = 20;
+$sizes[103] = 20;
+$sizes[104] = 20;
+image_optimization_fixture( $sizes );
+$result = ImageOptimizationAbilities::optimizeImages(
+	array(
+		'size_threshold' => 10,
+		'limit'          => 3,
+		'dry_run'        => true,
+	)
+);
+image_optimization_assert( array( 101, 102, 103 ) === array_column( $result['would_optimize'], 'attachment_id' ), 'stops at the eligible limit across pages' );
+image_optimization_assert( 3 === $result['eligible_count'], 'reports the bounded eligible result count' );
+image_optimization_assert( 103 === $result['scanned_count'], 'counts only attachments evaluated for eligibility' );
+image_optimization_assert( false === $result['scan_complete'], 'reports partial coverage when the eligible limit stops the scan' );
+image_optimization_cleanup();
+
+$sizes = array_fill( 1, 205, 5 );
+image_optimization_fixture( $sizes );
+$result = ImageOptimizationAbilities::optimizeImages(
+	array(
+		'size_threshold' => 10,
+		'limit'          => 2,
+		'dry_run'        => true,
+	)
+);
+image_optimization_assert( 205 === $result['scanned_count'], 'continues until all attachments are exhausted' );
+image_optimization_assert( 0 === $result['eligible_count'], 'reports no eligible images after a complete scan' );
+image_optimization_assert( true === $result['scan_complete'], 'marks exhausted attachment coverage complete' );
+image_optimization_assert( array( 0, 100, 200 ) === array_column( $GLOBALS['__image_optimization_queries'], 'offset' ), 'uses deterministic bounded offsets' );
+image_optimization_cleanup();
+
+if ( $GLOBALS['__image_optimization_failures'] > 0 ) {
+	exit( 1 );
+}
+
+echo "All image optimization pagination checks passed.\n";
+}

--- a/tests/provider-bootstrap-smoke.php
+++ b/tests/provider-bootstrap-smoke.php
@@ -109,6 +109,7 @@ $expected_ids   = array(
 	'bing-webmaster',
 	'amazon-affiliate',
 	'media-hygiene',
+	'image-diagnostics',
 	'sendy',
 );
 assert_provider_bootstrap( $expected_ids === $actual_ids, 'production provider order is explicit and deterministic' );
@@ -123,7 +124,7 @@ foreach ( $expected_ids as $provider_id ) {
 	);
 }
 
-$sendy = $actual_modules[14]->capabilities();
+$sendy = $actual_modules[15]->capabilities();
 assert_provider_bootstrap(
 	array(
 		'datamachine/sendy-subscribe',


### PR DESCRIPTION
## Summary
- move image optimization, broken-reference diagnosis, and the `image_optimization` task into Data Machine Business
- preserve all three ability slugs, task/effect contracts, pagination, multisite behavior, permissions, REST visibility, and dry-run semantics
- register through existing provider and task extension points without collapsing these operations into the existing media-hygiene action schema

## Boundary
Data Machine core retains upload, validation, video metadata, image generation, alt text, template rendering, files, scheduling, and system-agent context.

## Landing order
Merge this provider-owner PR before Extra-Chill/data-machine#3182.

Closes #113.
Related: Extra-Chill/data-machine#2223.

## Testing
- `php tests/image-diagnostics-ownership-smoke.php`
- `php tests/image-optimization-pagination-smoke.php`
- `php tests/image-broken-reference-multisite-smoke.php` (72 assertions)
- `php tests/provider-bootstrap-smoke.php`
- `php tests/ability-registration-lifecycle-smoke.php`
- syntax checks and `git diff --check`

## AI assistance
- AI assistance: Yes
- Tool: OpenCode (GPT-5.6)
- Used for: ownership audit, extraction, and continuity tests