### PR TITLE
feat: add bounded GA4 aggregate reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ Actions:
 - `new_vs_returning`
 - `network_density`
 - `path_sequence`
+- `aggregate_report`
 
-Common options include `--start-date`, `--end-date`, `--limit`, `--page-filter`, `--hostname`, `--sort-by`, `--order`, `--compare`, and `--format`.
+Common options include `--start-date`, `--end-date`, `--limit`, `--page-filter`, `--hostname`, `--sort-by`, `--order`, `--compare`, and `--format`. `aggregate_report` accepts bounded JSON flags: `--date-range`, `--comparison-date-range`, `--dimensions`, `--metrics`, `--filters`, and `--order-by`.
 
 ```bash
 wp datamachine analytics ga page_stats --hostname=example.com --compare

--- a/docs/google-analytics.md
+++ b/docs/google-analytics.md
@@ -36,6 +36,21 @@ Existing GA4 installations do not need a migration step. Data Machine Business u
 - `new_vs_returning`
 - `network_density`
 - `path_sequence`
+- `aggregate_report`
+
+### `aggregate_report`
+
+`aggregate_report` is the composable, bounded GA4 Data API surface. It accepts exact `date_range` and optional `comparison_date_range` objects (`start_date` and `end_date`), each limited to 400 inclusive days; up to three approved dimensions, eight approved metrics, four AND-combined string filters, two orderings, and 100 rows. It uses one `batchRunReports` call for one or two periods, requests `TOTAL` metric aggregations and property quota, and returns per-period rows, totals, counts, timezone/currency, quota remaining, and explicit sampling, thresholding, other-row, truncation, and empty-result limitations. The upstream batch response must have `kind: "analyticsData#batchRunReports"`, and every upstream report must have `kind: "analyticsData#runReport"`; both values are validated before normalization and omitted from the normalized result.
+
+This action requires Data Machine's HTTP client contracts from issues #3177 and #3231 or later: `HttpClient::post()` must forward the standard `limit_response_size` option to WordPress HTTP requests and honor `log_response_body_preview: false` for non-2xx log contexts. Data Machine Business supplies both bounded options and does not implement or wrap the HTTP client.
+
+Approved dimensions are `browser`, `country`, `date`, `deviceCategory`, `eventName`, `firstUserDefaultChannelGroup`, `firstUserMedium`, `firstUserSource`, `hostName`, `landingPage`, `month`, `newVsReturning`, `operatingSystem`, `pagePath`, `pageTitle`, `region`, `sessionCampaignName`, `sessionDefaultChannelGroup`, `sessionMedium`, `sessionSource`, and `week`. Approved metrics are `activeUsers`, `averageSessionDuration`, `bounceRate`, `engagedSessions`, `engagementRate`, `eventCount`, `eventsPerSession`, `keyEvents`, `newUsers`, `screenPageViews`, `screenPageViewsPerSession`, `sessionKeyEventRate`, `sessions`, `sessionsPerUser`, `totalUsers`, and `userKeyEventRate`.
+
+Ordering fields must be in the matching selected dimensions or metrics list. Filter objects use `field_name`, `match_type` (`EXACT`, `CONTAINS`, `BEGINS_WITH`, or `ENDS_WITH`), `value`, and optional `case_sensitive` or `exclude` booleans. The configured numeric property ID is used unless `property_id` is explicitly supplied under the existing permission gate. WP-CLI supports the same request with `--property-id=<numeric-id>` plus JSON `--date-range`, `--comparison-date-range`, `--dimensions`, `--metrics`, `--filters`, and `--order-by` flags.
+
+```bash
+wp datamachine analytics ga aggregate_report --date-range='{"start_date":"2026-01-01","end_date":"2026-01-31"}' --dimensions='["country"]' --metrics='["sessions","activeUsers"]' --order-by='[{"type":"metric","name":"sessions","descending":true}]' --format=json
+```
 
 ### Bounded page breakdowns
 

--- a/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
+++ b/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
@@ -91,6 +91,14 @@ class GoogleAnalyticsAbilities {
 	 */
 	const MAX_LIMIT = 10000;
 
+	const AGGREGATE_MAX_DATE_RANGE_DAYS = 400;
+	const AGGREGATE_MAX_ROWS = 100;
+	const AGGREGATE_MAX_RESPONSE_BYTES = 4194304;
+	const AGGREGATE_BATCH_RESPONSE_KIND = 'analyticsData#batchRunReports';
+	const AGGREGATE_REPORT_RESPONSE_KIND = 'analyticsData#runReport';
+	const AGGREGATE_DIMENSIONS = array( 'browser', 'country', 'date', 'deviceCategory', 'eventName', 'firstUserDefaultChannelGroup', 'firstUserMedium', 'firstUserSource', 'hostName', 'landingPage', 'month', 'newVsReturning', 'operatingSystem', 'pagePath', 'pageTitle', 'region', 'sessionCampaignName', 'sessionDefaultChannelGroup', 'sessionMedium', 'sessionSource', 'week' );
+	const AGGREGATE_METRICS = array( 'activeUsers', 'averageSessionDuration', 'bounceRate', 'engagedSessions', 'engagementRate', 'eventCount', 'eventsPerSession', 'keyEvents', 'newUsers', 'screenPageViews', 'screenPageViewsPerSession', 'sessionKeyEventRate', 'sessions', 'sessionsPerUser', 'totalUsers', 'userKeyEventRate' );
+
 	/**
 	 * Share at which unknown landing-page coverage is material to analysis.
 	 *
@@ -179,7 +187,7 @@ class GoogleAnalyticsAbilities {
 
 	private function registerAbilities(): void {
 		$register_callback = function () {
-			$valid_actions = array_merge( array_keys( self::ACTION_REPORTS ), array( 'realtime', 'path_sequence' ) );
+			$valid_actions = array_merge( array_keys( self::ACTION_REPORTS ), array( 'realtime', 'path_sequence', 'aggregate_report' ) );
 
 			wp_register_ability(
 				'datamachine/google-analytics',
@@ -187,56 +195,7 @@ class GoogleAnalyticsAbilities {
 					'label'               => 'Google Analytics',
 					'description'         => 'Fetch visitor analytics data from Google Analytics (GA4) Data API',
 					'category'            => 'datamachine-analytics',
-					'input_schema'        => array(
-						'type'       => 'object',
-						'required'   => array( 'action' ),
-						'properties' => array(
-							'action'      => array(
-								'type'        => 'string',
-								'enum'        => $valid_actions,
-								'description' => 'Action to perform. Acquisition reports are bounded presets: landing_page_acquisition groups session-entry landingPage by session source/medium; page_acquisition groups touched pagePath by session source/medium; page_audience groups touched pagePath by country/device. Other actions: page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics, landing_pages, engagement, new_vs_returning, network_density (referrer proxy), path_sequence (ordered v1alpha funnel report).',
-							),
-							'property_id' => array(
-								'type'        => 'string',
-								'description' => 'GA4 property ID (numeric). Defaults to configured property ID.',
-							),
-							'start_date'  => array(
-								'type'        => 'string',
-								'description' => 'Start date in YYYY-MM-DD format (defaults to 28 days ago). Not used for realtime.',
-							),
-							'end_date'    => array(
-								'type'        => 'string',
-								'description' => 'End date in YYYY-MM-DD format (defaults to yesterday). Not used for realtime.',
-							),
-							'limit'       => array(
-								'type'        => 'integer',
-								'minimum'     => 1,
-								'maximum'     => self::MAX_LIMIT,
-								'description' => 'Row limit (default: 25, max: 10000). For path_sequence this instead selects how many top hosts (by sessions) to pair, default 6, clamped to 12 — fan-out grows ~N*(N-1) funnel calls.',
-							),
-							'page_filter' => array(
-								'type'        => 'string',
-								'description' => 'Filter results to pages with paths containing this string.',
-							),
-							'hostname'    => array(
-								'type'        => 'string',
-								'description' => 'Filter to pages on this hostname (for multisite GA4 properties).',
-							),
-							'sort_by'     => array(
-								'type'        => 'string',
-								'description' => 'Sort results by this metric or dimension field name.',
-							),
-							'order'       => array(
-								'type'        => 'string',
-								'enum'        => array( 'asc', 'desc' ),
-								'description' => 'Sort direction: asc or desc (default: desc).',
-							),
-							'compare'     => array(
-								'type'        => 'boolean',
-								'description' => 'Compare against the previous period of equal length. Adds delta columns.',
-							),
-						),
-					),
+					'input_schema'        => self::inputSchema( $valid_actions ),
 					'output_schema'       => self::outputSchema(),
 					'execute_callback'    => array( self::class, 'fetchStats' ),
 					'permission_callback' => fn() => PermissionHelper::can_manage(),
@@ -299,8 +258,329 @@ class GoogleAnalyticsAbilities {
 					),
 				),
 				'error'                      => array( 'type' => 'string' ),
+				'reports'                    => array( 'type' => 'array', 'maxItems' => 2, 'items' => self::aggregateReportOutputSchema() ),
+				'dimensions'                 => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => self::AGGREGATE_DIMENSIONS ) ),
+				'metrics'                    => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => self::AGGREGATE_METRICS ) ),
+				'filters'                    => array( 'type' => 'array', 'items' => self::aggregateFilterSchema() ),
 			),
 		);
+	}
+
+	public static function aggregateInputSchema(): array {
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => array( 'action', 'date_range', 'metrics' ),
+			'properties'           => array(
+				'action'                => array( 'type' => 'string', 'enum' => array( 'aggregate_report' ) ),
+				'property_id'           => array( 'type' => 'string', 'pattern' => '^\\d{6,20}$' ),
+				'date_range'            => self::aggregateDateRangeSchema(),
+				'comparison_date_range' => self::aggregateDateRangeSchema(),
+				'dimensions'            => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => self::AGGREGATE_DIMENSIONS ), 'maxItems' => 3, 'uniqueItems' => true ),
+				'metrics'               => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => self::AGGREGATE_METRICS ), 'minItems' => 1, 'maxItems' => 8, 'uniqueItems' => true ),
+				'filters'               => array( 'type' => 'array', 'maxItems' => 4, 'items' => self::aggregateFilterSchema() ),
+				'order_by'              => array( 'type' => 'array', 'maxItems' => 2, 'items' => self::aggregateOrderSchema() ),
+				'limit'                 => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::AGGREGATE_MAX_ROWS ),
+			),
+		);
+	}
+
+	/** Closed action-specific schemas keep aggregate bounds visible to consumers. */
+	public static function inputSchema( array $valid_actions = array() ): array {
+		$legacy_actions  = array_diff( $valid_actions ?: array_merge( array_keys( self::ACTION_REPORTS ), array( 'realtime', 'path_sequence' ) ), array( 'aggregate_report' ) );
+		$aggregate       = self::aggregateInputSchema();
+		$legacy_fields   = array(
+			'action'      => array( 'type' => 'string', 'enum' => array_values( $legacy_actions ) ),
+			'property_id' => array( 'type' => 'string' ),
+			'start_date'  => array( 'type' => 'string' ),
+			'end_date'    => array( 'type' => 'string' ),
+			'limit'       => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::MAX_LIMIT ),
+			'page_filter' => array( 'type' => 'string' ),
+			'hostname'    => array( 'type' => 'string' ),
+			'sort_by'     => array( 'type' => 'string' ),
+			'order'       => array( 'type' => 'string', 'enum' => array( 'asc', 'desc' ) ),
+			'compare'     => array( 'type' => 'boolean' ),
+		);
+		return array(
+			'oneOf' => array(
+				array(
+					'type'                 => 'object',
+					'required'             => array( 'action' ),
+					'properties'           => $legacy_fields,
+				),
+				$aggregate,
+			),
+		);
+	}
+
+	public static function aggregateDateRangeSchema(): array {
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => array( 'start_date', 'end_date' ),
+			'properties'           => array(
+				'start_date' => array( 'type' => 'string', 'pattern' => '^\\d{4}-\\d{2}-\\d{2}$' ),
+				'end_date'   => array( 'type' => 'string', 'pattern' => '^\\d{4}-\\d{2}-\\d{2}$' ),
+			),
+		);
+	}
+
+	public static function aggregateFilterSchema(): array {
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => array( 'field_name', 'match_type', 'value' ),
+			'properties'           => array(
+				'field_name'     => array( 'type' => 'string', 'enum' => self::AGGREGATE_DIMENSIONS ),
+				'match_type'     => array( 'type' => 'string', 'enum' => array( 'EXACT', 'CONTAINS', 'BEGINS_WITH', 'ENDS_WITH' ) ),
+				'value'          => array( 'type' => 'string', 'minLength' => 1, 'maxLength' => 200 ),
+				'case_sensitive' => array( 'type' => 'boolean' ),
+				'exclude'        => array( 'type' => 'boolean' ),
+			),
+		);
+	}
+
+	public static function aggregateOrderSchema(): array {
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => array( 'type', 'name' ),
+			'properties'           => array(
+				'type'       => array( 'type' => 'string', 'enum' => array( 'dimension', 'metric' ) ),
+				'name'       => array( 'type' => 'string' ),
+				'descending' => array( 'type' => 'boolean' ),
+			),
+		);
+	}
+
+	private static function aggregateReportOutputSchema(): array {
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => array( 'label', 'date_range', 'rows', 'totals', 'returned_row_count', 'row_count', 'quota_remaining', 'coverage_limits' ),
+			'properties'           => array(
+				'label'              => array( 'type' => 'string', 'enum' => array( 'primary', 'comparison' ) ),
+				'date_range'         => self::aggregateDateRangeSchema(),
+				'rows'               => array( 'type' => 'array', 'maxItems' => self::AGGREGATE_MAX_ROWS, 'items' => array( 'type' => 'object', 'additionalProperties' => false, 'required' => array( 'dimensions', 'metrics' ), 'properties' => array( 'dimensions' => self::aggregateOutputRecordSchema( self::AGGREGATE_DIMENSIONS, 3, 2000 ), 'metrics' => self::aggregateOutputRecordSchema( self::AGGREGATE_METRICS, 8, 200 ) ) ) ),
+				'totals'             => self::aggregateOutputRecordSchema( self::AGGREGATE_METRICS, 8, 200 ),
+				'returned_row_count' => array( 'type' => 'integer' ),
+				'row_count'          => array( 'type' => 'integer' ),
+				'quota_remaining'    => array( 'type' => 'object', 'maxProperties' => 10, 'additionalProperties' => array( 'type' => 'integer', 'minimum' => 0 ) ),
+				'coverage_limits'    => array( 'type' => 'array', 'maxItems' => 10, 'items' => array( 'type' => 'string', 'maxLength' => 300 ) ),
+				'time_zone'          => array( 'type' => 'string', 'maxLength' => 100 ),
+				'currency_code'      => array( 'type' => 'string', 'maxLength' => 20 ),
+			),
+		);
+	}
+
+	private static function aggregateOutputRecordSchema( array $names, int $max_items, int $max_length ): array {
+		$properties = array();
+		foreach ( $names as $name ) {
+			$properties[ $name ] = array( 'type' => 'string', 'maxLength' => $max_length );
+		}
+		return array( 'type' => 'object', 'additionalProperties' => false, 'maxProperties' => $max_items, 'properties' => $properties );
+	}
+
+	/** Build one bounded batchRunReports request body or return an error message. */
+	public static function buildAggregateReportRequestBody( array $input ) {
+		$error = self::validateAggregateInput( $input );
+		if ( null !== $error ) {
+			return new \WP_Error( 'invalid_ga_aggregate_request', $error );
+		}
+
+		$build_expression = static function ( array $filter ): array {
+			$expression = array( 'filter' => array( 'fieldName' => $filter['field_name'], 'stringFilter' => array( 'matchType' => $filter['match_type'], 'value' => $filter['value'], 'caseSensitive' => ! empty( $filter['case_sensitive'] ) ) ) );
+			return ! empty( $filter['exclude'] ) ? array( 'notExpression' => $expression ) : $expression;
+		};
+		$body = array(
+			'dateRanges'           => array( array( 'startDate' => $input['date_range']['start_date'], 'endDate' => $input['date_range']['end_date'] ) ),
+			'dimensions'           => array_map( static fn( string $name ): array => array( 'name' => $name ), $input['dimensions'] ?? array() ),
+			'metrics'              => array_map( static fn( string $name ): array => array( 'name' => $name ), $input['metrics'] ),
+			'limit'                => (int) ( $input['limit'] ?? 25 ),
+			'keepEmptyRows'        => false,
+			'metricAggregations'   => array( 'TOTAL' ),
+			'returnPropertyQuota'  => true,
+		);
+		if ( ! empty( $input['filters'] ) ) {
+			$body['dimensionFilter'] = array( 'andGroup' => array( 'expressions' => array_map( $build_expression, $input['filters'] ) ) );
+		}
+		if ( ! empty( $input['order_by'] ) ) {
+			$body['orderBys'] = array_map(
+				static fn( array $order ): array => array_merge( 'metric' === $order['type'] ? array( 'metric' => array( 'metricName' => $order['name'] ) ) : array( 'dimension' => array( 'dimensionName' => $order['name'] ) ), array( 'desc' => ! array_key_exists( 'descending', $order ) || $order['descending'] ) ),
+				$input['order_by']
+			);
+		}
+		return $body;
+	}
+
+	private static function validateAggregateInput( array $input ): ?string {
+		$allowed = array( 'action', 'property_id', 'date_range', 'comparison_date_range', 'dimensions', 'metrics', 'filters', 'order_by', 'limit' );
+		if ( array_diff( array_keys( $input ), $allowed ) ) { return 'aggregate_report accepts only its documented fields.'; }
+		foreach ( array( 'date_range', 'metrics' ) as $required ) { if ( ! array_key_exists( $required, $input ) ) { return "aggregate_report requires {$required}."; } }
+		foreach ( array( 'date_range', 'comparison_date_range' ) as $key ) {
+			if ( ! isset( $input[ $key ] ) ) { continue; }
+			$range = $input[ $key ];
+			if ( ! is_array( $range ) || array_diff( array_keys( $range ), array( 'start_date', 'end_date' ) ) || ! isset( $range['start_date'], $range['end_date'] ) || ! self::isValidAggregateDate( $range['start_date'] ) || ! self::isValidAggregateDate( $range['end_date'] ) ) { return "{$key} must contain exact start_date and end_date values in YYYY-MM-DD format."; }
+			$days = (int) ( ( strtotime( $range['end_date'] . ' UTC' ) - strtotime( $range['start_date'] . ' UTC' ) ) / DAY_IN_SECONDS ) + 1;
+			if ( $days < 1 || $days > self::AGGREGATE_MAX_DATE_RANGE_DAYS ) { return "{$key} must be between 1 and " . self::AGGREGATE_MAX_DATE_RANGE_DAYS . ' inclusive days.'; }
+		}
+		$dimensions = $input['dimensions'] ?? array(); $metrics = $input['metrics'];
+		if ( ! is_array( $dimensions ) || count( $dimensions ) > 3 || count( $dimensions ) !== count( array_filter( $dimensions, 'is_string' ) ) || count( $dimensions ) !== count( array_unique( $dimensions ) ) || array_diff( $dimensions, self::AGGREGATE_DIMENSIONS ) ) { return 'dimensions must contain up to three unique approved dimensions.'; }
+		if ( ! is_array( $metrics ) || count( $metrics ) < 1 || count( $metrics ) > 8 || count( $metrics ) !== count( array_filter( $metrics, 'is_string' ) ) || count( $metrics ) !== count( array_unique( $metrics ) ) || array_diff( $metrics, self::AGGREGATE_METRICS ) ) { return 'metrics must contain one to eight unique approved metrics.'; }
+		if ( ! isset( $input['limit'] ) ) { $input['limit'] = 25; }
+		if ( ! is_int( $input['limit'] ) && ! ctype_digit( (string) $input['limit'] ) || (int) $input['limit'] < 1 || (int) $input['limit'] > self::AGGREGATE_MAX_ROWS ) { return 'limit must be an integer from 1 to 100.'; }
+		if ( ! is_array( $input['filters'] ?? array() ) || count( $input['filters'] ?? array() ) > 4 ) { return 'filters supports at most four entries.'; }
+		foreach ( $input['filters'] ?? array() as $filter ) {
+			if ( ! is_array( $filter ) || array_diff( array_keys( $filter ), array( 'field_name', 'match_type', 'value', 'case_sensitive', 'exclude' ) ) || ! in_array( $filter['field_name'] ?? '', self::AGGREGATE_DIMENSIONS, true ) || ! in_array( $filter['match_type'] ?? '', array( 'EXACT', 'CONTAINS', 'BEGINS_WITH', 'ENDS_WITH' ), true ) || ! is_string( $filter['value'] ?? null ) || '' === $filter['value'] || strlen( $filter['value'] ) > 200 || ( isset( $filter['case_sensitive'] ) && ! is_bool( $filter['case_sensitive'] ) ) || ( isset( $filter['exclude'] ) && ! is_bool( $filter['exclude'] ) ) ) { return 'filters must contain approved bounded string dimension filters.'; }
+		}
+		if ( ! is_array( $input['order_by'] ?? array() ) || count( $input['order_by'] ?? array() ) > 2 ) { return 'order_by supports at most two entries.'; }
+		foreach ( $input['order_by'] ?? array() as $order ) {
+			if ( ! is_array( $order ) || array_diff( array_keys( $order ), array( 'type', 'name', 'descending' ) ) || ! in_array( $order['type'] ?? '', array( 'dimension', 'metric' ), true ) || ! in_array( $order['name'] ?? '', 'dimension' === ( $order['type'] ?? '' ) ? $dimensions : $metrics, true ) || ( isset( $order['descending'] ) && ! is_bool( $order['descending'] ) ) ) { return 'Each ordering must select a requested dimension or metric.'; }
+		}
+		return null;
+	}
+
+	private static function isValidAggregateDate( $date ): bool {
+		return is_string( $date ) && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) && gmdate( 'Y-m-d', strtotime( $date . ' UTC' ) ) === $date;
+	}
+
+	/** Resolve the configured default or an explicit aggregate property ID. */
+	public static function resolveAggregatePropertyId( array $input, array $config ) {
+		$property_id = ! empty( $input['property_id'] ) ? sanitize_text_field( $input['property_id'] ) : ( $config['property_id'] ?? '' );
+		if ( ! is_string( $property_id ) || ! preg_match( '/^\d{6,20}$/', $property_id ) ) {
+			return new \WP_Error( 'invalid_ga_aggregate_property', 'GA4 property ID must be numeric.' );
+		}
+		return $property_id;
+	}
+
+	private static function fetchAggregateReport( array $input, string $access_token, string $property_id ): array {
+		$batch = self::buildAggregateBatchRequest( $input, $property_id, $access_token );
+		if ( is_wp_error( $batch ) ) { return array( 'success' => false, 'error' => $batch->get_error_message() ); }
+		$result = HttpClient::post( $batch['url'], $batch['options'] );
+		if ( ! $result['success'] ) { return array( 'success' => false, 'error' => self::formatAggregateHttpError( $result ) ); }
+		$data = json_decode( $result['data'], true );
+		if ( json_last_error() !== JSON_ERROR_NONE || ! is_array( $data ) ) { return array( 'success' => false, 'error' => 'Google Analytics returned an unexpected aggregate report response.' ); }
+		if ( array_key_exists( 'error', $data ) ) {
+			$error = self::formatAggregateApiError( $data['error'] );
+			return array( 'success' => false, 'error' => $error ?? 'Google Analytics returned an unexpected aggregate report response.' );
+		}
+		if ( array_diff( array_keys( $data ), array( 'reports', 'kind' ) ) || ! isset( $data['kind'] ) || self::AGGREGATE_BATCH_RESPONSE_KIND !== $data['kind'] || ! isset( $data['reports'] ) || ! is_array( $data['reports'] ) || ! array_is_list( $data['reports'] ) || count( $data['reports'] ) !== count( $batch['ranges'] ) ) { return array( 'success' => false, 'error' => 'Google Analytics returned an unexpected aggregate report response.' ); }
+		$reports = array();
+		foreach ( $data['reports'] as $index => $report ) {
+			$normalized = self::normalizeAggregateReport( $report, $batch['ranges'][ $index ], $input['dimensions'] ?? array(), $input['metrics'] );
+			if ( is_wp_error( $normalized ) ) { return array( 'success' => false, 'error' => $normalized->get_error_message() ); }
+			$normalized['label'] = 0 === $index ? 'primary' : 'comparison';
+			$reports[] = $normalized;
+		}
+		return array( 'success' => true, 'action' => 'aggregate_report', 'dimensions' => $input['dimensions'] ?? array(), 'metrics' => $input['metrics'], 'filters' => $input['filters'] ?? array(), 'reports' => $reports );
+	}
+
+	/** Return a canonical GA4 error without exposing a provider response body. */
+	private static function formatAggregateHttpError( array $result ): string {
+		$status_code = $result['status_code'] ?? 0;
+		$body        = $result['data'] ?? '';
+		if ( is_int( $status_code ) && is_string( $body ) && strlen( $body ) <= self::AGGREGATE_MAX_RESPONSE_BYTES ) {
+			$data = json_decode( $body, true );
+			if ( JSON_ERROR_NONE === json_last_error() && is_array( $data ) && array_keys( $data ) === array( 'error' ) ) {
+				$error = self::formatAggregateApiError( $data['error'], $status_code );
+				if ( null !== $error ) {
+					return $error;
+				}
+			}
+		}
+
+		return is_int( $status_code ) && $status_code >= 100 && $status_code <= 599
+			? "GA4 request failed with HTTP {$status_code}."
+			: 'GA4 request failed before a response was received.';
+	}
+
+	/** Validate the bounded Google error envelope and return its safe canonical message. */
+	private static function formatAggregateApiError( $error, ?int $http_status = null ): ?string {
+		if ( ! is_array( $error ) || array_diff( array_keys( $error ), array( 'code', 'message', 'status', 'details' ) ) || ! isset( $error['code'], $error['message'], $error['status'] ) || ! is_int( $error['code'] ) || ! is_string( $error['message'] ) || '' === $error['message'] || strlen( $error['message'] ) > 1000 || ! is_string( $error['status'] ) || ! preg_match( '/^[A-Z_]{3,64}$/', $error['status'] ) || ( null !== $http_status && $error['code'] !== $http_status ) ) {
+			return null;
+		}
+
+		$messages = array(
+			'PERMISSION_DENIED' => 'Permission denied.',
+			'UNAUTHENTICATED'    => 'Authentication failed.',
+			'INVALID_ARGUMENT'   => 'The aggregate report request was rejected.',
+			'NOT_FOUND'          => 'The requested GA4 property was not found.',
+			'RESOURCE_EXHAUSTED' => 'GA4 quota is exhausted.',
+			'FAILED_PRECONDITION' => 'The GA4 property is not ready for this request.',
+			'UNAVAILABLE'        => 'GA4 is temporarily unavailable.',
+			'INTERNAL'           => 'GA4 encountered an internal error.',
+		);
+		return 'GA4 API error (' . $error['code'] . ' ' . $error['status'] . '): ' . ( $messages[ $error['status'] ] ?? 'The GA4 request failed.' );
+	}
+
+	/** Build the single bounded HTTP batch request without exposing credentials. */
+	public static function buildAggregateBatchRequest( array $input, string $property_id, string $access_token ) {
+		$primary = self::buildAggregateReportRequestBody( $input );
+		if ( is_wp_error( $primary ) ) { return $primary; }
+		$requests = array( $primary );
+		$ranges   = array( $input['date_range'] );
+		if ( isset( $input['comparison_date_range'] ) ) {
+			$comparison = $input;
+			$comparison['date_range'] = $input['comparison_date_range'];
+			unset( $comparison['comparison_date_range'] );
+			$requests[] = self::buildAggregateReportRequestBody( $comparison );
+			if ( is_wp_error( $requests[1] ) ) { return $requests[1]; }
+			$ranges[] = $input['comparison_date_range'];
+		}
+		return array(
+			'url'     => self::API_BASE . $property_id . ':batchRunReports',
+			'options' => array( 'timeout' => 30, 'limit_response_size' => self::AGGREGATE_MAX_RESPONSE_BYTES, 'log_response_body_preview' => false, 'headers' => array( 'Authorization' => 'Bearer ' . $access_token, 'Content-Type' => 'application/json' ), 'body' => wp_json_encode( array( 'requests' => $requests ) ), 'context' => 'Google Analytics Data API aggregate report' ),
+			'ranges'  => $ranges,
+		);
+	}
+
+	/** Normalize a single batch report without inventing coverage guarantees. */
+	public static function normalizeAggregateReport( array $report, array $date_range, array $expected_dimensions = array(), array $expected_metrics = array() ) {
+		$invalid = static fn(): \WP_Error => new \WP_Error( 'invalid_ga_aggregate_response', 'Google Analytics returned a malformed aggregate report.' );
+		if ( ! isset( $report['kind'] ) || self::AGGREGATE_REPORT_RESPONSE_KIND !== $report['kind'] ) { return $invalid(); }
+		unset( $report['kind'] );
+		$dimension_headers = $report['dimensionHeaders'] ?? array();
+		$metric_headers    = $report['metricHeaders'] ?? array();
+		$raw_rows          = $report['rows'] ?? array();
+		$raw_totals        = $report['totals'] ?? array();
+		if ( ! is_array( $dimension_headers ) || ! is_array( $metric_headers ) || ! is_array( $raw_rows ) || ! is_array( $raw_totals ) || ! array_is_list( $dimension_headers ) || ! array_is_list( $metric_headers ) || ! array_is_list( $raw_rows ) || ! array_is_list( $raw_totals ) || count( $raw_rows ) > self::AGGREGATE_MAX_ROWS ) { return $invalid(); }
+		$headers = static function ( array $items ) { $names = array(); foreach ( $items as $item ) { if ( ! is_array( $item ) || array_diff( array_keys( $item ), array( 'name', 'type' ) ) || ! isset( $item['name'] ) || ! is_string( $item['name'] ) || '' === $item['name'] || strlen( $item['name'] ) > 100 || ( isset( $item['type'] ) && ( ! is_string( $item['type'] ) || strlen( $item['type'] ) > 100 ) ) ) { return false; } $names[] = $item['name']; } return $names; };
+		$dimensions = $headers( $dimension_headers ); $metrics = $headers( $metric_headers );
+		if ( false === $dimensions || false === $metrics || ( ! empty( $raw_rows ) && ( $dimensions !== $expected_dimensions || $metrics !== $expected_metrics ) ) || ( ! empty( $raw_totals ) && $metrics !== $expected_metrics ) || ( empty( $raw_rows ) && empty( $raw_totals ) && ( ! empty( $dimensions ) && $dimensions !== $expected_dimensions || ! empty( $metrics ) && $metrics !== $expected_metrics ) ) ) { return $invalid(); }
+		$dimensions = empty( $dimensions ) ? $expected_dimensions : $dimensions;
+		$metrics    = empty( $metrics ) ? $expected_metrics : $metrics;
+		$record = static function ( array $headers, array $values, int $max_length ) { if ( ! array_is_list( $values ) || count( $values ) !== count( $headers ) ) { return false; } $out = array(); foreach ( $headers as $index => $name ) { $value = $values[ $index ] ?? null; if ( ! is_array( $value ) || array_keys( $value ) !== array( 'value' ) || ! is_string( $value['value'] ) || strlen( $value['value'] ) > $max_length ) { return false; } $out[ $name ] = $value['value']; } return $out; };
+		$rows = array();
+		foreach ( $raw_rows as $row ) {
+			if ( ! is_array( $row ) || array_diff( array_keys( $row ), array( 'dimensionValues', 'metricValues' ) ) || ! isset( $row['dimensionValues'], $row['metricValues'] ) ) { return $invalid(); }
+			$dimension_values = $record( $dimensions, $row['dimensionValues'], 2000 ); $metric_values = $record( $metrics, $row['metricValues'], 200 );
+			if ( false === $dimension_values || false === $metric_values ) { return $invalid(); }
+			$rows[] = array( 'dimensions' => $dimension_values, 'metrics' => $metric_values );
+		}
+		$limits = array(); $metadata = $report['metadata'] ?? array();
+		if ( ! is_array( $metadata ) || array_diff( array_keys( $metadata ), array( 'dataLossFromOtherRow', 'subjectToThresholding', 'samplingMetadatas', 'timeZone', 'currencyCode', 'emptyReason', 'schemaRestrictionResponse' ) ) || ( isset( $metadata['dataLossFromOtherRow'] ) && ! is_bool( $metadata['dataLossFromOtherRow'] ) ) || ( isset( $metadata['subjectToThresholding'] ) && ! is_bool( $metadata['subjectToThresholding'] ) ) || ( isset( $metadata['timeZone'] ) && ( ! is_string( $metadata['timeZone'] ) || strlen( $metadata['timeZone'] ) > 100 ) ) || ( isset( $metadata['currencyCode'] ) && ( ! is_string( $metadata['currencyCode'] ) || strlen( $metadata['currencyCode'] ) > 20 ) ) || ( isset( $metadata['emptyReason'] ) && ( ! is_string( $metadata['emptyReason'] ) || '' === $metadata['emptyReason'] || strlen( $metadata['emptyReason'] ) > 100 ) ) ) { return $invalid(); }
+		if ( ! empty( $metadata['dataLossFromOtherRow'] ) ) { $limits[] = 'Some dimension values were grouped into an other row, so the returned breakdown is incomplete.'; }
+		if ( ! empty( $metadata['subjectToThresholding'] ) ) { $limits[] = 'Google Analytics applied a privacy threshold to this report.'; }
+		if ( isset( $metadata['emptyReason'] ) ) { $limits[] = 'Google Analytics reported an empty result for this report.'; }
+		if ( isset( $metadata['schemaRestrictionResponse'] ) ) {
+			$restriction = $metadata['schemaRestrictionResponse'];
+			if ( ! is_array( $restriction ) || array_keys( $restriction ) !== array( 'activeMetricRestrictions' ) || ! is_array( $restriction['activeMetricRestrictions'] ) || ! array_is_list( $restriction['activeMetricRestrictions'] ) || count( $restriction['activeMetricRestrictions'] ) > count( $expected_metrics ) ) { return $invalid(); }
+			foreach ( $restriction['activeMetricRestrictions'] as $metric_restriction ) {
+				if ( ! is_array( $metric_restriction ) || count( $metric_restriction ) !== 2 || array_diff( array_keys( $metric_restriction ), array( 'metricName', 'restrictedMetricTypes' ) ) || ! isset( $metric_restriction['metricName'], $metric_restriction['restrictedMetricTypes'] ) || ! is_string( $metric_restriction['metricName'] ) || '' === $metric_restriction['metricName'] || strlen( $metric_restriction['metricName'] ) > 100 || ! in_array( $metric_restriction['metricName'], $expected_metrics, true ) || ! is_array( $metric_restriction['restrictedMetricTypes'] ) || ! array_is_list( $metric_restriction['restrictedMetricTypes'] ) || count( $metric_restriction['restrictedMetricTypes'] ) < 1 || count( $metric_restriction['restrictedMetricTypes'] ) > 2 || count( $metric_restriction['restrictedMetricTypes'] ) !== count( array_unique( $metric_restriction['restrictedMetricTypes'] ) ) || array_diff( $metric_restriction['restrictedMetricTypes'], array( 'RESTRICTED_METRIC_TYPE_UNSPECIFIED', 'COST_DATA', 'REVENUE_DATA' ) ) ) { return $invalid(); }
+			}
+			if ( ! empty( $restriction['activeMetricRestrictions'] ) ) { $limits[] = 'Google Analytics restricted one or more requested metrics.'; }
+		}
+		if ( isset( $metadata['samplingMetadatas'] ) && ( ! is_array( $metadata['samplingMetadatas'] ) || ! array_is_list( $metadata['samplingMetadatas'] ) || count( $metadata['samplingMetadatas'] ) > 5 ) ) { return $invalid(); }
+		foreach ( $metadata['samplingMetadatas'] ?? array() as $sampling ) { if ( ! is_array( $sampling ) || array_diff( array_keys( $sampling ), array( 'samplesReadCount', 'samplingSpaceSize' ) ) || ( isset( $sampling['samplesReadCount'] ) && ( ! is_string( $sampling['samplesReadCount'] ) || ! ctype_digit( $sampling['samplesReadCount'] ) ) ) || ( isset( $sampling['samplingSpaceSize'] ) && ( ! is_string( $sampling['samplingSpaceSize'] ) || ! ctype_digit( $sampling['samplingSpaceSize'] ) ) ) ) { return $invalid(); } $limits[] = 'Google Analytics sampled ' . ( $sampling['samplesReadCount'] ?? 'an unknown number of' ) . ' records from ' . ( $sampling['samplingSpaceSize'] ?? 'an unknown sampling space' ) . '.'; }
+		if ( isset( $report['rowCount'] ) && ( ! is_int( $report['rowCount'] ) || $report['rowCount'] < 0 ) ) { return $invalid(); }
+		$row_count = $report['rowCount'] ?? count( $rows );
+		if ( $row_count > count( $rows ) ) { $limits[] = 'The result is truncated to ' . count( $rows ) . ' of ' . $row_count . ' matching rows.'; }
+		if ( empty( $rows ) ) { $limits[] = 'No rows matched the requested report.'; }
+		if ( count( $raw_totals ) > 1 || ( 1 === count( $raw_totals ) && ( ! is_array( $raw_totals[0] ) || array_keys( $raw_totals[0] ) !== array( 'metricValues' ) ) ) ) { return $invalid(); }
+		$totals = empty( $raw_totals ) ? array_fill_keys( $metrics, '' ) : $record( $metrics, $raw_totals[0]['metricValues'], 200 );
+		if ( false === $totals || ( isset( $report['propertyQuota'] ) && ! is_array( $report['propertyQuota'] ) ) ) { return $invalid(); }
+		$quota = array(); foreach ( $report['propertyQuota'] ?? array() as $name => $value ) { if ( ! is_string( $name ) || ! is_array( $value ) || array_diff( array_keys( $value ), array( 'consumed', 'remaining' ) ) || ( isset( $value['consumed'] ) && ( ! is_int( $value['consumed'] ) || $value['consumed'] < 0 ) ) || ( isset( $value['remaining'] ) && ( ! is_int( $value['remaining'] ) || $value['remaining'] < 0 ) ) ) { return $invalid(); } if ( isset( $value['remaining'] ) ) { $quota[ $name ] = $value['remaining']; } }
+		return array( 'date_range' => $date_range, 'rows' => $rows, 'totals' => $totals, 'returned_row_count' => count( $rows ), 'row_count' => $row_count, 'time_zone' => $metadata['timeZone'] ?? '', 'currency_code' => $metadata['currencyCode'] ?? '', 'quota_remaining' => $quota, 'coverage_limits' => $limits );
 	}
 
 	/**
@@ -312,7 +592,7 @@ class GoogleAnalyticsAbilities {
 	public static function fetchStats( array $input ): array {
 		$action = sanitize_text_field( $input['action'] ?? '' );
 
-		$valid_actions = array_merge( array_keys( self::ACTION_REPORTS ), array( 'realtime', 'path_sequence' ) );
+		$valid_actions = array_merge( array_keys( self::ACTION_REPORTS ), array( 'realtime', 'path_sequence', 'aggregate_report' ) );
 		if ( empty( $action ) || ! in_array( $action, $valid_actions, true ) ) {
 			return array(
 				'success' => false,
@@ -354,6 +634,13 @@ class GoogleAnalyticsAbilities {
 				'success' => false,
 				'error'   => 'No GA4 property ID configured or provided.',
 			);
+		}
+		if ( 'aggregate_report' === $action ) {
+			$aggregate_property_id = self::resolveAggregatePropertyId( $input, $config );
+			if ( is_wp_error( $aggregate_property_id ) ) {
+				return array( 'success' => false, 'error' => $aggregate_property_id->get_error_message() );
+			}
+			return self::fetchAggregateReport( $input, $access_token, $aggregate_property_id );
 		}
 
 		// Route to realtime handler.

--- a/inc/Cli/GoogleAnalyticsCommand.php
+++ b/inc/Cli/GoogleAnalyticsCommand.php
@@ -47,6 +47,7 @@ class GoogleAnalyticsCommand extends BaseCommand {
 			'new_vs_returning'         => 'New vs returning user split',
 			'network_density'          => 'Cross-site journey density via referrer host',
 			'path_sequence'            => 'Ordered cross-host path sequences (funnel report)',
+			'aggregate_report'         => 'Bounded aggregate report from JSON query options',
 		);
 	}
 
@@ -56,7 +57,7 @@ class GoogleAnalyticsCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * <action>
-	 * : Action to perform: page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics, landing_pages, landing_page_acquisition, page_acquisition, page_audience, engagement, new_vs_returning, network_density, path_sequence.
+	 * : Action to perform: page_stats, traffic_sources, date_stats, realtime, top_events, user_demographics, landing_pages, landing_page_acquisition, page_acquisition, page_audience, engagement, new_vs_returning, network_density, path_sequence, aggregate_report.
 	 *
 	 * [--start-date=<date>]
 	 * : Start date in YYYY-MM-DD format (default: 28 days ago). Not used for realtime.
@@ -65,7 +66,10 @@ class GoogleAnalyticsCommand extends BaseCommand {
 	 * : End date in YYYY-MM-DD format (default: yesterday). Not used for realtime.
 	 *
 	 * [--limit=<number>]
-	 * : Row limit (default: 25, max: 10000).
+	 * : Row limit (default: 25). aggregate_report max: 100; legacy actions max: 10000.
+	 *
+	 * [--property-id=<id>]
+	 * : GA4 property ID. Defaults to the configured property; aggregate_report requires a numeric ID.
 	 *
 	 * [--page-filter=<string>]
 	 * : Filter results to pages with paths containing this string.
@@ -81,6 +85,24 @@ class GoogleAnalyticsCommand extends BaseCommand {
 	 *
 	 * [--compare]
 	 * : Compare against the previous period of equal length. Adds delta columns.
+	 *
+	 * [--date-range=<json>]
+	 * : aggregate_report primary range JSON: {"start_date":"YYYY-MM-DD","end_date":"YYYY-MM-DD"}.
+	 *
+	 * [--comparison-date-range=<json>]
+	 * : Optional aggregate_report comparison range JSON.
+	 *
+	 * [--dimensions=<json>]
+	 * : aggregate_report dimensions JSON array (up to 3 approved names).
+	 *
+	 * [--metrics=<json>]
+	 * : aggregate_report metrics JSON array (1-8 approved names).
+	 *
+	 * [--filters=<json>]
+	 * : aggregate_report filters JSON array (up to 4 AND string filters).
+	 *
+	 * [--order-by=<json>]
+	 * : aggregate_report ordering JSON array (up to 2 selected fields).
 	 *
 	 * [--format=<format>]
 	 * : Output format.
@@ -130,6 +152,9 @@ class GoogleAnalyticsCommand extends BaseCommand {
 	 *     # Ordered cross-host journeys (true network density)
 	 *     wp datamachine analytics ga path_sequence
 	 *
+	 *     # Bounded aggregate report (use --format=json for nested output)
+	 *     wp datamachine analytics ga aggregate_report --date-range='{"start_date":"2026-01-01","end_date":"2026-01-31"}' --dimensions='["country"]' --metrics='["sessions"]' --format=json
+	 *
 	 *     # Filter by hostname for multisite
 	 *     wp datamachine analytics ga page_stats --hostname=events.example.com
 	 *
@@ -148,6 +173,7 @@ class GoogleAnalyticsCommand extends BaseCommand {
 			$input,
 			$assoc_args,
 			array(
+				'property-id' => 'property_id',
 				'start-date'  => 'start_date',
 				'end-date'    => 'end_date',
 				'limit'       => 'limit',
@@ -157,6 +183,11 @@ class GoogleAnalyticsCommand extends BaseCommand {
 				'order'       => 'order',
 			)
 		);
+		foreach ( array( 'date-range' => 'date_range', 'comparison-date-range' => 'comparison_date_range', 'dimensions' => 'dimensions', 'metrics' => 'metrics', 'filters' => 'filters', 'order-by' => 'order_by' ) as $flag => $key ) {
+			if ( isset( $assoc_args[ $flag ] ) ) {
+				$input[ $key ] = json_decode( $assoc_args[ $flag ], true );
+			}
+		}
 
 		// --compare is a boolean flag (no value).
 		if ( isset( $assoc_args['compare'] ) ) {

--- a/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
+++ b/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
@@ -66,62 +66,31 @@ class GoogleAnalytics extends BaseTool {
 	 * @return array Tool definition array.
 	 */
 	public function getToolDefinition(): array {
-		$valid_actions = array_merge( array_keys( GoogleAnalyticsAbilities::ACTION_REPORTS ), array( 'realtime', 'path_sequence' ) );
+		$valid_actions = array_merge( array_keys( GoogleAnalyticsAbilities::ACTION_REPORTS ), array( 'realtime', 'path_sequence', 'aggregate_report' ) );
+		$legacy_actions = array_values( array_diff( $valid_actions, array( 'aggregate_report' ) ) );
+		$legacy_properties = array(
+			'action'      => array( 'type' => 'string', 'enum' => $legacy_actions, 'description' => 'Choose a bounded preset report. landing_page_acquisition uses session-entry landingPage x session source/medium and discloses material `(not set)` coverage without filtering it. page_acquisition uses touched pagePath x session source/medium. page_audience uses touched pagePath x country/device.' ),
+			'property_id' => array( 'type' => 'string', 'description' => 'GA4 property ID (numeric). Defaults to the configured property ID.' ),
+			'start_date'  => array( 'type' => 'string', 'description' => 'Start date in YYYY-MM-DD format (defaults to 28 days ago). Not used for realtime action.' ),
+			'end_date'    => array( 'type' => 'string', 'description' => 'End date in YYYY-MM-DD format (defaults to yesterday). Not used for realtime action.' ),
+			'limit'       => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => GoogleAnalyticsAbilities::MAX_LIMIT, 'description' => 'Row limit (default: 25, max: 10000).' ),
+			'page_filter' => array( 'type' => 'string', 'description' => 'Filter results to pages with paths containing this string.' ),
+			'hostname'    => array( 'type' => 'string', 'description' => 'Filter to pages on this hostname (for multisite GA4 properties).' ),
+			'sort_by'     => array( 'type' => 'string', 'description' => 'Sort results by this metric or dimension field name (e.g. bounceRate, sessions, engagementRate).' ),
+			'order'       => array( 'type' => 'string', 'enum' => array( 'asc', 'desc' ), 'description' => 'Sort direction: asc or desc (default: desc).' ),
+			'compare'     => array( 'type' => 'boolean', 'description' => 'Compare against the previous period of equal length. Adds delta percentage columns.' ),
+		);
 
 		return array(
 			'class'           => __CLASS__,
 			'method'          => 'handle_tool_call',
-			'description'     => 'Fetch visitor analytics from Google Analytics (GA4), including fixed landing-page acquisition, touched-page acquisition, and page audience breakdowns. Landing-page acquisition preserves `(not set)` rows and reports unknown-dimension coverage metadata. Supports sorting, hostname and page filtering, and period-over-period comparison without arbitrary dimension selection.',
+			'description'     => 'Fetch visitor analytics from Google Analytics (GA4). Fixed actions retain their existing presets. aggregate_report is a bounded, read-only aggregate query with exact dates, reviewed fields, totals, quota, and explicit coverage limitations.',
 			'requires_config' => true,
 			'parameters'      => array(
-				'type'       => 'object',
-				'properties' => array(
-					'action'      => array(
-						'type'        => 'string',
-						'enum'        => $valid_actions,
-						'description' => 'Choose a bounded report. landing_page_acquisition uses session-entry landingPage x session source/medium and discloses material `(not set)` coverage without filtering it. page_acquisition uses touched pagePath x session source/medium. page_audience uses touched pagePath x country/device.',
-					),
-					'property_id' => array(
-					'type'        => 'string',
-					'description' => 'GA4 property ID (numeric). Defaults to the configured property ID.',
+				'oneOf' => array(
+					array( 'type' => 'object', 'required' => array( 'action' ), 'properties' => $legacy_properties ),
+					GoogleAnalyticsAbilities::aggregateInputSchema(),
 				),
-					'start_date'  => array(
-					'type'        => 'string',
-					'description' => 'Start date in YYYY-MM-DD format (defaults to 28 days ago). Not used for realtime action.',
-				),
-					'end_date'    => array(
-					'type'        => 'string',
-					'description' => 'End date in YYYY-MM-DD format (defaults to yesterday). Not used for realtime action.',
-				),
-					'limit'       => array(
-					'type'        => 'integer',
-					'minimum'     => 1,
-					'maximum'     => GoogleAnalyticsAbilities::MAX_LIMIT,
-					'description' => 'Row limit (default: 25, max: 10000).',
-				),
-					'page_filter' => array(
-					'type'        => 'string',
-					'description' => 'Filter results to pages with paths containing this string.',
-				),
-					'hostname'    => array(
-					'type'        => 'string',
-					'description' => 'Filter to pages on this hostname (for multisite GA4 properties).',
-				),
-					'sort_by'     => array(
-					'type'        => 'string',
-					'description' => 'Sort results by this metric or dimension field name (e.g. bounceRate, sessions, engagementRate).',
-				),
-					'order'       => array(
-					'type'        => 'string',
-					'enum'        => array( 'asc', 'desc' ),
-					'description' => 'Sort direction: asc or desc (default: desc).',
-				),
-					'compare'     => array(
-					'type'        => 'boolean',
-					'description' => 'Compare against the previous period of equal length. Adds delta percentage columns.',
-				),
-				),
-				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
+++ b/tests/Unit/Abilities/Analytics/GoogleAnalyticsAbilitiesTest.php
@@ -230,14 +230,18 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 		$reflection = new \ReflectionClass( GoogleAnalytics::class );
 		$tool       = $reflection->newInstanceWithoutConstructor();
 		$definition = $tool->getToolDefinition();
-		$parameters = $definition['parameters']['properties'];
+		$legacy_parameters = $definition['parameters']['oneOf'][0]['properties'];
+		$aggregate_parameters = $definition['parameters']['oneOf'][1]['properties'];
 
-		$this->assertContains( 'landing_page_acquisition', $parameters['action']['enum'] );
-		$this->assertContains( 'page_acquisition', $parameters['action']['enum'] );
-		$this->assertContains( 'page_audience', $parameters['action']['enum'] );
-		$this->assertSame( array( 'asc', 'desc' ), $parameters['order']['enum'] );
-		$this->assertSame( 1, $parameters['limit']['minimum'] );
-		$this->assertSame( GoogleAnalyticsAbilities::MAX_LIMIT, $parameters['limit']['maximum'] );
+		$this->assertContains( 'landing_page_acquisition', $legacy_parameters['action']['enum'] );
+		$this->assertContains( 'page_acquisition', $legacy_parameters['action']['enum'] );
+		$this->assertContains( 'page_audience', $legacy_parameters['action']['enum'] );
+		$this->assertNotContains( 'aggregate_report', $legacy_parameters['action']['enum'] );
+		$this->assertSame( array( 'asc', 'desc' ), $legacy_parameters['order']['enum'] );
+		$this->assertSame( 1, $legacy_parameters['limit']['minimum'] );
+		$this->assertSame( GoogleAnalyticsAbilities::MAX_LIMIT, $legacy_parameters['limit']['maximum'] );
+		$this->assertSame( array( 'aggregate_report' ), $aggregate_parameters['action']['enum'] );
+		$this->assertSame( GoogleAnalyticsAbilities::AGGREGATE_MAX_ROWS, $aggregate_parameters['limit']['maximum'] );
 	}
 
 	public function test_report_rows_keep_dimensions_and_cast_numeric_metrics(): void {
@@ -802,6 +806,158 @@ class GoogleAnalyticsAbilitiesTest extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( GoogleAnalyticsAbilities::MAX_LIMIT, $body['limit'] );
+	}
+
+	public function test_aggregate_request_is_bounded_and_uses_total_quota_batch_shape(): void {
+		$body = GoogleAnalyticsAbilities::buildAggregateReportRequestBody( array(
+			'action' => 'aggregate_report',
+			'date_range' => array( 'start_date' => '2026-01-01', 'end_date' => '2026-01-31' ),
+			'dimensions' => array( 'country' ), 'metrics' => array( 'sessions', 'activeUsers' ), 'limit' => 100,
+			'filters' => array( array( 'field_name' => 'hostName', 'match_type' => 'EXACT', 'value' => 'example.com' ) ),
+			'order_by' => array( array( 'type' => 'metric', 'name' => 'sessions', 'descending' => true ) ),
+		) );
+		$this->assertNotWPError( $body );
+		$this->assertSame( array( 'TOTAL' ), $body['metricAggregations'] );
+		$this->assertTrue( $body['returnPropertyQuota'] );
+		$this->assertSame( 'example.com', $body['dimensionFilter']['andGroup']['expressions'][0]['filter']['stringFilter']['value'] );
+		$this->assertSame( 'sessions', $body['orderBys'][0]['metric']['metricName'] );
+	}
+
+	/** @dataProvider invalid_aggregate_inputs */
+	public function test_aggregate_request_rejects_invalid_bounds_and_fields( array $input ): void {
+		$this->assertWPError( GoogleAnalyticsAbilities::buildAggregateReportRequestBody( $input ) );
+	}
+
+	public function test_aggregate_normalization_discloses_all_coverage_limits(): void {
+		$report = GoogleAnalyticsAbilities::normalizeAggregateReport( array(
+			'kind' => GoogleAnalyticsAbilities::AGGREGATE_REPORT_RESPONSE_KIND,
+			'dimensionHeaders' => array( array( 'name' => 'country' ) ), 'metricHeaders' => array( array( 'name' => 'sessions' ) ),
+			'rows' => array( array( 'dimensionValues' => array( array( 'value' => 'US' ) ), 'metricValues' => array( array( 'value' => '5' ) ) ) ),
+			'totals' => array( array( 'metricValues' => array( array( 'value' => '9' ) ) ) ), 'rowCount' => 9,
+			'metadata' => array( 'dataLossFromOtherRow' => true, 'subjectToThresholding' => true, 'samplingMetadatas' => array( array( 'samplesReadCount' => '10', 'samplingSpaceSize' => '100' ) ), 'timeZone' => 'UTC', 'currencyCode' => 'USD' ),
+			'propertyQuota' => array( 'tokensPerDay' => array( 'remaining' => 42 ) ),
+		), array( 'start_date' => '2026-01-01', 'end_date' => '2026-01-31' ), array( 'country' ), array( 'sessions' ) );
+		$this->assertNotWPError( $report );
+		$this->assertSame( '5', $report['rows'][0]['metrics']['sessions'] );
+		$this->assertSame( '9', $report['totals']['sessions'] );
+		$this->assertSame( 42, $report['quota_remaining']['tokensPerDay'] );
+		$this->assertCount( 4, $report['coverage_limits'] );
+	}
+
+	public function test_aggregate_normalization_rejects_malformed_rows_and_preserves_old_action_builder(): void {
+		$this->assertWPError( GoogleAnalyticsAbilities::normalizeAggregateReport( array( 'kind' => GoogleAnalyticsAbilities::AGGREGATE_REPORT_RESPONSE_KIND, 'dimensionHeaders' => array(), 'metricHeaders' => array(), 'rows' => array( array() ), 'totals' => array() ), array() ) );
+		$this->assertSame( array( 'date' ), wp_list_pluck( GoogleAnalyticsAbilities::buildReportRequestBody( array(), 'date_stats' )['dimensions'], 'name' ) );
+	}
+
+	public function test_aggregate_batch_request_uses_one_http_envelope_for_primary_and_comparison(): void {
+		$input = array( 'action' => 'aggregate_report', 'date_range' => array( 'start_date' => '2026-01-01', 'end_date' => '2026-01-31' ), 'comparison_date_range' => array( 'start_date' => '2025-01-01', 'end_date' => '2025-01-31' ), 'metrics' => array( 'sessions' ) );
+		$batch = GoogleAnalyticsAbilities::buildAggregateBatchRequest( $input, '123456789', 'secret-token' );
+		$this->assertNotWPError( $batch );
+		$this->assertSame( 'https://analyticsdata.googleapis.com/v1beta/properties/123456789:batchRunReports', $batch['url'] );
+		$this->assertSame( GoogleAnalyticsAbilities::AGGREGATE_MAX_RESPONSE_BYTES, $batch['options']['limit_response_size'] );
+		$this->assertCount( 2, json_decode( $batch['options']['body'], true )['requests'] );
+		$this->assertSame( $input['date_range'], $batch['ranges'][0] );
+		$this->assertSame( $input['comparison_date_range'], $batch['ranges'][1] );
+	}
+
+	public function test_aggregate_schema_is_closed_and_does_not_expose_property_id_in_output(): void {
+		$input_schema = GoogleAnalyticsAbilities::aggregateInputSchema();
+		$this->assertFalse( $input_schema['additionalProperties'] );
+		$this->assertFalse( $input_schema['properties']['filters']['items']['additionalProperties'] );
+		$this->assertFalse( $input_schema['properties']['order_by']['items']['additionalProperties'] );
+		$output_schema = GoogleAnalyticsAbilities::outputSchema();
+		$this->assertArrayNotHasKey( 'property_id', $output_schema['properties'] );
+		$response = array( 'success' => true, 'action' => 'aggregate_report', 'dimensions' => array(), 'metrics' => array( 'sessions' ), 'filters' => array(), 'reports' => array( array( 'label' => 'primary', 'date_range' => array( 'start_date' => '2026-01-01', 'end_date' => '2026-01-31' ), 'rows' => array(), 'totals' => array( 'sessions' => '0' ), 'returned_row_count' => 0, 'row_count' => 0, 'quota_remaining' => array(), 'coverage_limits' => array( 'No rows matched the requested report.' ), 'time_zone' => '', 'currency_code' => '' ) ) );
+		$validated = rest_validate_value_from_schema( $response, $output_schema, 'output' );
+		$this->assertTrue( $validated, is_wp_error( $validated ) ? $validated->get_error_message() : '' );
+	}
+
+	public function test_aggregate_exact_400_day_boundary_and_malformed_nested_values(): void {
+		$valid = GoogleAnalyticsAbilities::buildAggregateReportRequestBody( array( 'action' => 'aggregate_report', 'date_range' => array( 'start_date' => '2025-01-01', 'end_date' => '2026-02-04' ), 'metrics' => array( 'sessions' ) ) );
+		$this->assertNotWPError( $valid );
+		$malformed = array( 'kind' => GoogleAnalyticsAbilities::AGGREGATE_REPORT_RESPONSE_KIND, 'dimensionHeaders' => array( array( 'name' => 'country' ) ), 'metricHeaders' => array( array( 'name' => 'sessions', 'type' => 'TYPE_INTEGER' ) ), 'rows' => array( array( 'dimensionValues' => array( array( 'value' => 'US' ) ), 'metricValues' => array( array( 'value' => 1 ) ) ) ), 'totals' => array() );
+		$this->assertWPError( GoogleAnalyticsAbilities::normalizeAggregateReport( $malformed, array() ) );
+		$malformed['rows'][0]['metricValues'][0]['value'] = '1';
+		$malformed['rowCount'] = 1.5;
+		$this->assertWPError( GoogleAnalyticsAbilities::normalizeAggregateReport( $malformed, array() ) );
+	}
+
+	public function test_aggregate_normalizes_bounded_empty_and_schema_restriction_metadata(): void {
+		$report = array(
+			'kind' => GoogleAnalyticsAbilities::AGGREGATE_REPORT_RESPONSE_KIND,
+			'dimensionHeaders' => array(), 'metricHeaders' => array( array( 'name' => 'sessions', 'type' => 'TYPE_INTEGER' ) ),
+			'rows' => array(), 'totals' => array( array( 'metricValues' => array( array( 'value' => '0' ) ) ) ),
+			'metadata' => array( 'emptyReason' => 'NO_DATA', 'schemaRestrictionResponse' => array( 'activeMetricRestrictions' => array( array( 'restrictedMetricTypes' => array( 'COST_DATA', 'REVENUE_DATA' ), 'metricName' => 'sessions' ) ) ) ),
+		);
+		$normalized = GoogleAnalyticsAbilities::normalizeAggregateReport( $report, array(), array(), array( 'sessions' ) );
+		$this->assertNotWPError( $normalized );
+		$this->assertContains( 'Google Analytics reported an empty result for this report.', $normalized['coverage_limits'] );
+		$this->assertContains( 'Google Analytics restricted one or more requested metrics.', $normalized['coverage_limits'] );
+		$this->assertNotContains( 'NO_DATA', $normalized['coverage_limits'] );
+		$report['metadata']['schemaRestrictionResponse']['activeMetricRestrictions'][0] = array( 'metricName' => 'sessions', 'restrictedMetricType' => 'COST_DATA' );
+		$this->assertWPError( GoogleAnalyticsAbilities::normalizeAggregateReport( $report, array(), array(), array( 'sessions' ) ) );
+	}
+
+	public function test_aggregate_rejects_zero_dimension_header_or_value_mismatches(): void {
+		$base = array( 'kind' => GoogleAnalyticsAbilities::AGGREGATE_REPORT_RESPONSE_KIND, 'dimensionHeaders' => array(), 'metricHeaders' => array( array( 'name' => 'sessions' ) ), 'rows' => array(), 'totals' => array() );
+		$with_header = $base;
+		$with_header['dimensionHeaders'][] = array( 'name' => 'country' );
+		$this->assertWPError( GoogleAnalyticsAbilities::normalizeAggregateReport( $with_header, array(), array(), array( 'sessions' ) ) );
+		$with_value = $base;
+		$with_value['rows'][] = array( 'dimensionValues' => array( array( 'value' => 'US' ) ), 'metricValues' => array( array( 'value' => '1' ) ) );
+		$this->assertWPError( GoogleAnalyticsAbilities::normalizeAggregateReport( $with_value, array(), array(), array( 'sessions' ) ) );
+	}
+
+	public function test_aggregate_accepts_omitted_repeated_fields_for_empty_and_total_only_reports(): void {
+		$empty = GoogleAnalyticsAbilities::normalizeAggregateReport( array( 'kind' => GoogleAnalyticsAbilities::AGGREGATE_REPORT_RESPONSE_KIND ), array(), array( 'country' ), array( 'sessions' ) );
+		$this->assertNotWPError( $empty );
+		$this->assertSame( array( 'sessions' => '' ), $empty['totals'] );
+		$this->assertContains( 'No rows matched the requested report.', $empty['coverage_limits'] );
+		$total_only = GoogleAnalyticsAbilities::normalizeAggregateReport( array( 'kind' => GoogleAnalyticsAbilities::AGGREGATE_REPORT_RESPONSE_KIND, 'metricHeaders' => array( array( 'name' => 'sessions' ) ), 'totals' => array( array( 'metricValues' => array( array( 'value' => '12' ) ) ) ) ), array(), array( 'country' ), array( 'sessions' ) );
+		$this->assertNotWPError( $total_only );
+		$this->assertSame( '12', $total_only['totals']['sessions'] );
+	}
+
+	public function test_aggregate_output_schema_bounds_closed_rows_and_coverage(): void {
+		$report = GoogleAnalyticsAbilities::outputSchema()['properties']['reports'];
+		$row = $report['items']['properties']['rows'];
+		$this->assertSame( 2, $report['maxItems'] );
+		$this->assertSame( GoogleAnalyticsAbilities::AGGREGATE_MAX_ROWS, $row['maxItems'] );
+		$this->assertFalse( $row['items']['additionalProperties'] );
+		$this->assertSame( 10, $report['items']['properties']['coverage_limits']['maxItems'] );
+	}
+
+	public function test_cli_maps_explicit_property_id_and_fixed_action_builder_remains_compatible(): void {
+		$command = ( new \ReflectionClass( GoogleAnalyticsCommand::class ) )->newInstanceWithoutConstructor();
+		$method = new \ReflectionMethod( GoogleAnalyticsCommand::class, 'map_optional' );
+		$method->setAccessible( true );
+		$input = array();
+		$method->invokeArgs( $command, array( &$input, array( 'property-id' => '123456789' ), array( 'property-id' => 'property_id' ) ) );
+		$this->assertSame( '123456789', $input['property_id'] );
+		$this->assertSame( array( 'sessions', 'activeUsers', 'screenPageViews', 'bounceRate' ), wp_list_pluck( GoogleAnalyticsAbilities::buildReportRequestBody( array(), 'traffic_sources' )['metrics'], 'name' ) );
+	}
+
+	public function test_aggregate_errors_return_canonical_messages_without_provider_content(): void {
+		$method = new \ReflectionMethod( GoogleAnalyticsAbilities::class, 'formatAggregateApiError' );
+		$method->setAccessible( true );
+		$error = $method->invoke( null, array( 'code' => 403, 'status' => 'PERMISSION_DENIED', 'message' => 'Filter secret-token was rejected.' ), 403 );
+		$this->assertSame( 'GA4 API error (403 PERMISSION_DENIED): Permission denied.', $error );
+	}
+
+	public function test_aggregate_property_resolution_uses_configured_or_explicit_id_without_output_field(): void {
+		$this->assertSame( '123456789', GoogleAnalyticsAbilities::resolveAggregatePropertyId( array(), array( 'property_id' => '123456789' ) ) );
+		$this->assertSame( '987654321', GoogleAnalyticsAbilities::resolveAggregatePropertyId( array( 'property_id' => '987654321' ), array( 'property_id' => '123456789' ) ) );
+		$this->assertWPError( GoogleAnalyticsAbilities::resolveAggregatePropertyId( array( 'property_id' => 'not-numeric' ), array() ) );
+	}
+
+	public static function invalid_aggregate_inputs(): array {
+		$base = array( 'action' => 'aggregate_report', 'date_range' => array( 'start_date' => '2026-01-01', 'end_date' => '2026-01-31' ), 'metrics' => array( 'sessions' ) );
+		return array(
+			'too many days' => array( array_merge( $base, array( 'date_range' => array( 'start_date' => '2025-01-01', 'end_date' => '2026-02-05' ) ) ) ),
+			'arbitrary metric' => array( array_merge( $base, array( 'metrics' => array( 'evilMetric' ) ) ) ),
+			'unselected ordering' => array( array_merge( $base, array( 'order_by' => array( array( 'type' => 'dimension', 'name' => 'country' ) ) ) ) ),
+			'too many filters' => array( array_merge( $base, array( 'filters' => array_fill( 0, 5, array( 'field_name' => 'country', 'match_type' => 'EXACT', 'value' => 'US' ) ) ) ) ),
+		);
 	}
 
 	private function format_comparison_rows( array $data, int $limit ): array {

--- a/tests/ability-registration-lifecycle-smoke.php
+++ b/tests/ability-registration-lifecycle-smoke.php
@@ -81,9 +81,11 @@ if ( ! file_exists( $helper_path ) ) {
 
 require_once $helper_path;
 require_once $root . '/inc/Abilities/PageSpeed/PageSpeedAbility.php';
+require_once $root . '/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php';
 
 $registered = array();
 new \DataMachineBusiness\Abilities\PageSpeed\PageSpeedAbility();
+new \DataMachineBusiness\Abilities\Analytics\GoogleAnalyticsAbilities();
 assert_ability_registration(
 	empty( $registered ) && isset( $actions['wp_abilities_api_init'][0] ),
 	'construction before wp_abilities_api_init defers registration',
@@ -98,9 +100,18 @@ assert_ability_registration(
 	$failures,
 	$passes
 );
+assert_ability_registration(
+	isset( $registered['datamachine/google-analytics'] )
+		&& ! isset( $registered['datamachine/google-analytics']['input_schema']['oneOf'][0]['additionalProperties'] )
+		&& false === $registered['datamachine/google-analytics']['input_schema']['oneOf'][1]['additionalProperties']
+		&& \DataMachineBusiness\Abilities\Analytics\GoogleAnalyticsAbilities::AGGREGATE_MAX_ROWS === $registered['datamachine/google-analytics']['input_schema']['oneOf'][1]['properties']['limit']['maximum'],
+	'Google Analytics registered schema preserves legacy extras and closes aggregate input at 100 rows',
+	$failures,
+	$passes
+);
 
 $reflection = new ReflectionProperty( \DataMachineBusiness\Abilities\PageSpeed\PageSpeedAbility::class, 'registered' );
-$reflection->setValue( false );
+$reflection->setValue( null, false );
 $actions    = array();
 $registered = array();
 

--- a/tests/data-machine-http-client-contract-smoke.php
+++ b/tests/data-machine-http-client-contract-smoke.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Verify the upstream Data Machine HttpClient contract used by aggregate_report.
+ *
+ * Run with: WP_PATH=/path/to/wordpress DATA_MACHINE_PATH=/path/to/data-machine php tests/data-machine-http-client-contract-smoke.php
+ */
+
+$wp_path = getenv( 'WP_PATH' );
+$data_machine_path = getenv( 'DATA_MACHINE_PATH' );
+if ( empty( $wp_path ) || empty( $data_machine_path ) || ! file_exists( $wp_path . '/wp-load.php' ) || ! file_exists( $data_machine_path . '/inc/Core/HttpClient.php' ) ) {
+	fwrite( STDERR, "WP_PATH and DATA_MACHINE_PATH must point to WordPress and Data Machine.\n" );
+	exit( 2 );
+}
+
+require_once $wp_path . '/wp-load.php';
+require_once $data_machine_path . '/inc/Core/HttpClient.php';
+
+$method = new ReflectionMethod( \DataMachine\Core\HttpClient::class, 'buildRequestArgs' );
+$args = $method->invoke( null, 'POST', array( 'limit_response_size' => 4194304 ) );
+if ( 4194304 !== ( $args['limit_response_size'] ?? null ) ) {
+	fwrite( STDERR, "Data Machine HttpClient did not forward limit_response_size.\n" );
+	exit( 1 );
+}
+
+$log_context = null;
+$preempt = static function ( $preempt, $parsed_args, $url ) {
+	return array(
+		'headers'  => array(),
+		'body'     => 'response-body-secret',
+		'response' => array( 'code' => 403, 'message' => 'Forbidden' ),
+		'cookies'  => array(),
+		'filename' => null,
+	);
+};
+$log = static function ( $level, $message, $context ) use ( &$log_context ): void {
+	if ( 'HTTP Request: Error response' === $message ) {
+		$log_context = $context;
+	}
+};
+add_filter( 'pre_http_request', $preempt, 10, 3 );
+add_action( 'datamachine_log', $log, 10, 3 );
+$result = \DataMachine\Core\HttpClient::post( 'https://example.invalid/', array( 'log_response_body_preview' => false ) );
+remove_filter( 'pre_http_request', $preempt, 10 );
+remove_action( 'datamachine_log', $log, 10 );
+if ( ! empty( $result['success'] ) || ! is_array( $log_context ) || array_key_exists( 'body_preview', $log_context ) ) {
+	fwrite( STDERR, "Data Machine HttpClient did not suppress the non-2xx response-body preview.\n" );
+	exit( 1 );
+}
+
+echo "2 assertions passed.\n";

--- a/tests/fixtures/ga4-aggregate-batch-response.json
+++ b/tests/fixtures/ga4-aggregate-batch-response.json
@@ -1,0 +1,38 @@
+{
+  "kind": "analyticsData#batchRunReports",
+  "reports": [
+    {
+      "kind": "analyticsData#runReport",
+      "dimensionHeaders": [],
+      "metricHeaders": [
+        {
+          "name": "sessions",
+          "type": "TYPE_INTEGER"
+        }
+      ],
+      "rows": [],
+      "totals": [
+        {
+          "metricValues": [
+            {
+              "value": "0"
+            }
+          ]
+        }
+      ],
+      "metadata": {
+        "emptyReason": "NO_DATA",
+        "schemaRestrictionResponse": {
+          "activeMetricRestrictions": [
+            {
+              "restrictedMetricTypes": [
+                "COST_DATA"
+              ],
+              "metricName": "sessions"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/google-analytics-aggregate-http-smoke.php
+++ b/tests/google-analytics-aggregate-http-smoke.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * HTTP-boundary smoke coverage for the bounded GA4 aggregate report.
+ *
+ * Run with: php tests/google-analytics-aggregate-http-smoke.php
+ */
+
+namespace DataMachine\Core {
+	class HttpClient {
+		public static array $response = array();
+		public static array $request = array();
+
+		public static function post( string $url, array $options ): array {
+			self::$request = array( 'url' => $url, 'options' => $options );
+			return self::$response;
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI\Tools {
+	abstract class BaseTool {}
+}
+
+namespace {
+	use DataMachineBusiness\Abilities\Analytics\GoogleAnalyticsAbilities;
+	use DataMachineBusiness\Engine\AI\Tools\Global\GoogleAnalytics;
+	use DataMachine\Core\HttpClient;
+
+	$root = dirname( __DIR__ );
+	$failures = array();
+
+	define( 'ABSPATH', $root . '/' );
+	define( 'DAY_IN_SECONDS', 86400 );
+
+	class WP_Error {
+		public function __construct( private string $code, private string $message ) {}
+		public function get_error_message(): string { return $this->message; }
+	}
+
+	function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+	function sanitize_text_field( $value ): string { return trim( (string) $value ); }
+	function wp_json_encode( $value ): string { return json_encode( $value ); }
+	function wp_list_pluck( array $items, string $field ): array { return array_map( static fn( $item ) => $item[ $field ] ?? null, $items ); }
+
+	require_once $root . '/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php';
+	require_once $root . '/inc/Engine/AI/Tools/Global/GoogleAnalytics.php';
+
+	$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+		if ( ! $condition ) { $failures[] = $message; }
+	};
+	$input = array( 'action' => 'aggregate_report', 'date_range' => array( 'start_date' => '2026-01-01', 'end_date' => '2026-01-31' ), 'metrics' => array( 'sessions' ) );
+	$method = new \ReflectionMethod( GoogleAnalyticsAbilities::class, 'fetchAggregateReport' );
+	$tool = ( new \ReflectionClass( GoogleAnalytics::class ) )->newInstanceWithoutConstructor();
+	$parameters = $tool->getToolDefinition()['parameters']['oneOf'];
+	$assert( GoogleAnalyticsAbilities::MAX_LIMIT === $parameters[0]['properties']['limit']['maximum'] && GoogleAnalyticsAbilities::AGGREGATE_MAX_ROWS === $parameters[1]['properties']['limit']['maximum'], 'advertises action-specific legacy and aggregate row bounds' );
+
+	$fixture = json_decode( file_get_contents( $root . '/tests/fixtures/ga4-aggregate-batch-response.json' ), true );
+	HttpClient::$response = array( 'success' => true, 'data' => json_encode( $fixture ) );
+	$result = $method->invoke( null, $input, 'secret-token', '123456789' );
+	$assert( ! empty( $result['success'] ) && 'primary' === $result['reports'][0]['label'], 'normalizes the primary HTTP batch report' );
+	$assert( GoogleAnalyticsAbilities::AGGREGATE_MAX_RESPONSE_BYTES === HttpClient::$request['options']['limit_response_size'], 'sets the 4 MiB HTTP response limit' );
+	$assert( false === HttpClient::$request['options']['log_response_body_preview'], 'suppresses non-2xx response-body previews in HTTP logs' );
+	$assert( 1 === count( json_decode( HttpClient::$request['options']['body'], true )['requests'] ), 'uses one batch request for one period' );
+	$comparison_input = $input;
+	$comparison_input['comparison_date_range'] = array( 'start_date' => '2025-01-01', 'end_date' => '2025-01-31' );
+	$comparison_fixture = $fixture;
+	$comparison_fixture['reports'][] = array( 'kind' => 'analyticsData#runReport', 'dimensionHeaders' => array(), 'metricHeaders' => array( array( 'name' => 'sessions' ) ), 'rows' => array(), 'totals' => array() );
+	HttpClient::$response['data'] = json_encode( $comparison_fixture );
+	$comparison = $method->invoke( null, $comparison_input, 'secret-token', '123456789' );
+	$assert( ! empty( $comparison['success'] ) && array( 'primary', 'comparison' ) === array_column( $comparison['reports'], 'label' ), 'normalizes two batch reports in period order' );
+
+	$mismatched_fixture = $fixture;
+	$mismatched_fixture['reports'][0]['dimensionHeaders'] = array( array( 'name' => 'country' ) );
+	$mismatched_fixture['reports'][0]['totals'] = array();
+	HttpClient::$response['data'] = json_encode( $mismatched_fixture );
+	$mismatch = $method->invoke( null, $input, 'secret-token', '123456789' );
+	$assert( empty( $mismatch['success'] ) && 'Google Analytics returned a malformed aggregate report.' === $mismatch['error'], 'rejects response headers that do not match selected fields' );
+	$invalid_batch_kind = $fixture;
+	$invalid_batch_kind['kind'] = 'analyticsData#runReport';
+	HttpClient::$response['data'] = json_encode( $invalid_batch_kind );
+	$invalid_batch = $method->invoke( null, $input, 'secret-token', '123456789' );
+	$assert( empty( $invalid_batch['success'] ) && 'Google Analytics returned an unexpected aggregate report response.' === $invalid_batch['error'], 'rejects an incorrect batch response kind' );
+	$invalid_report_kind = $fixture;
+	$invalid_report_kind['reports'][0]['kind'] = 'analyticsData#batchRunReports';
+	HttpClient::$response['data'] = json_encode( $invalid_report_kind );
+	$invalid_report = $method->invoke( null, $input, 'secret-token', '123456789' );
+	$assert( empty( $invalid_report['success'] ) && 'Google Analytics returned a malformed aggregate report.' === $invalid_report['error'], 'rejects an incorrect report response kind' );
+	HttpClient::$response = array(
+		'success' => false,
+		'status_code' => 403,
+		'error' => 'Google Analytics Data API aggregate report POST returned HTTP 403: filter-value-secret',
+		'data' => json_encode( array( 'error' => array( 'code' => 403, 'status' => 'PERMISSION_DENIED', 'message' => 'Filter value filter-value-secret is not allowed.' ) ) ),
+	);
+	$permission_denied = $method->invoke( null, $input, 'secret-token', '123456789' );
+	$assert( 'GA4 API error (403 PERMISSION_DENIED): Permission denied.' === $permission_denied['error'] && false === str_contains( $permission_denied['error'], 'filter-value-secret' ), 'canonicalizes PERMISSION_DENIED without provider message leakage' );
+	HttpClient::$response = array( 'success' => false, 'status_code' => 502, 'error' => 'upstream raw-body-secret', 'data' => '<html>raw-body-secret</html>' );
+	$malformed_error = $method->invoke( null, $input, 'secret-token', '123456789' );
+	$assert( 'GA4 request failed with HTTP 502.' === $malformed_error['error'] && false === str_contains( $malformed_error['error'], 'raw-body-secret' ), 'uses a status-aware fallback without raw body leakage' );
+
+	if ( ! empty( $failures ) ) {
+		fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+		exit( 1 );
+	}
+
+	echo "11 assertions passed.\n";
+}

--- a/tests/google-analytics-aggregate-schema-smoke.php
+++ b/tests/google-analytics-aggregate-schema-smoke.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Validate the registered-style combined GA schema with WordPress REST schema validation.
+ *
+ * Run with: WP_PATH=/path/to/wordpress php tests/google-analytics-aggregate-schema-smoke.php
+ */
+
+$root    = dirname( __DIR__ );
+$wp_path = getenv( 'WP_PATH' );
+
+if ( empty( $wp_path ) || ! file_exists( $wp_path . '/wp-load.php' ) ) {
+	fwrite( STDERR, "WP_PATH must point to a WordPress installation.\n" );
+	exit( 2 );
+}
+
+require_once $wp_path . '/wp-load.php';
+require_once $root . '/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php';
+
+$schema = \DataMachineBusiness\Abilities\Analytics\GoogleAnalyticsAbilities::inputSchema();
+$valid_aggregate = array(
+	'action'     => 'aggregate_report',
+	'date_range' => array( 'start_date' => '2026-01-01', 'end_date' => '2026-01-31' ),
+	'metrics'    => array( 'sessions' ),
+	'limit'      => 100,
+);
+$unknown_aggregate = $valid_aggregate;
+$unknown_aggregate['unexpected'] = true;
+$legacy_with_extra = array( 'action' => 'page_stats', 'limit' => 10000, 'consumer_context' => 'preserved' );
+
+$checks = array(
+	! is_wp_error( rest_validate_value_from_schema( $valid_aggregate, $schema, 'aggregate' ) ),
+	is_wp_error( rest_validate_value_from_schema( $unknown_aggregate, $schema, 'aggregate' ) ),
+	! is_wp_error( rest_validate_value_from_schema( $legacy_with_extra, $schema, 'legacy' ) ),
+);
+
+if ( in_array( false, $checks, true ) ) {
+	fwrite( STDERR, "Aggregate schema validation failed.\n" );
+	exit( 1 );
+}
+
+echo "3 assertions passed.\n";


### PR DESCRIPTION
## Summary

- add a generic `aggregate_report` GA4 action with bounded dimensions, metrics, dates, filters, ordering, comparisons, and same-property batch reports
- validate documented GA4 batch/report response kinds and normalize bounded output
- expose action-specific AI and CLI contracts while preserving legacy action limits
- report thresholding, sampling, and aggregate privacy metadata
- normalize GA4 API errors without returning or logging raw provider bodies

Closes #115.

## Dependencies

- Extra-Chill/data-machine#3177 forwards `limit_response_size`
- Extra-Chill/data-machine#3231 suppresses sensitive non-2xx body previews

## Verification

- `php tests/google-analytics-aggregate-http-smoke.php` (11 assertions)
- `php tests/google-analytics-aggregate-schema-smoke.php` (3 assertions)
- `php tests/data-machine-http-client-contract-smoke.php` (2 assertions)
- `php tests/ability-registration-lifecycle-smoke.php` (28 assertions)
- PHP syntax checks
- `git diff --check`

A live granted GA4 property was not available, so authenticated provider behavior remains a draft gate.

## AI assistance disclosure

OpenAI GPT-5.6-sol via OpenCode traced the GA4 ownership and Data Machine HTTP contracts, implemented the bounded aggregate action and tests, and performed iterative API, privacy, and logging reviews. Chris Huber directed and reviewed the work.