### PR TITLE
Fix release quality gates for v0.17.0

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -1,0 +1,25 @@
+{
+  "schema": "homeboy/test-manifest/v1",
+  "tests": {
+    "tests/ability-registration-lifecycle-smoke.php": { "environment": "standalone-php" },
+    "tests/amazon-affiliate-tool-smoke.php": { "environment": "standalone-php" },
+    "tests/bing-webmaster-ability-smoke.php": { "environment": "standalone-php" },
+    "tests/data-machine-http-client-contract-smoke.php": { "environment": "wordpress" },
+    "tests/google-analytics-aggregate-http-smoke.php": { "environment": "standalone-php" },
+    "tests/google-analytics-aggregate-schema-smoke.php": { "environment": "wordpress" },
+    "tests/google-search-tool-smoke.php": { "environment": "standalone-php" },
+    "tests/gsc-business-registration-smoke.php": { "environment": "standalone-php" },
+    "tests/gsc-site-url-guard-smoke.php": { "environment": "standalone-php" },
+    "tests/image-broken-reference-multisite-smoke.php": { "environment": "standalone-php" },
+    "tests/image-diagnostics-ownership-smoke.php": { "environment": "standalone-php" },
+    "tests/image-optimization-pagination-smoke.php": { "environment": "standalone-php" },
+    "tests/image-optimization-scheduling-context-smoke.php": { "environment": "standalone-php" },
+    "tests/indexnow-ownership-smoke.php": { "environment": "standalone-php" },
+    "tests/indexnow-registration-smoke.php": { "environment": "standalone-php" },
+    "tests/mediavine-dimensional-smoke.php": { "environment": "standalone-php" },
+    "tests/pagespeed-ownership-smoke.php": { "environment": "standalone-php" },
+    "tests/provider-bootstrap-smoke.php": { "environment": "standalone-php" },
+    "tests/sendy-campaign-abilities-smoke.php": { "environment": "standalone-php" },
+    "tests/test-manifest-contract-smoke.php": { "environment": "standalone-php" }
+  }
+}

--- a/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
+++ b/inc/Abilities/Analytics/GoogleAnalyticsAbilities.php
@@ -91,13 +91,13 @@ class GoogleAnalyticsAbilities {
 	 */
 	const MAX_LIMIT = 10000;
 
-	const AGGREGATE_MAX_DATE_RANGE_DAYS = 400;
-	const AGGREGATE_MAX_ROWS = 100;
-	const AGGREGATE_MAX_RESPONSE_BYTES = 4194304;
-	const AGGREGATE_BATCH_RESPONSE_KIND = 'analyticsData#batchRunReports';
+	const AGGREGATE_MAX_DATE_RANGE_DAYS  = 400;
+	const AGGREGATE_MAX_ROWS             = 100;
+	const AGGREGATE_MAX_RESPONSE_BYTES   = 4194304;
+	const AGGREGATE_BATCH_RESPONSE_KIND  = 'analyticsData#batchRunReports';
 	const AGGREGATE_REPORT_RESPONSE_KIND = 'analyticsData#runReport';
-	const AGGREGATE_DIMENSIONS = array( 'browser', 'country', 'date', 'deviceCategory', 'eventName', 'firstUserDefaultChannelGroup', 'firstUserMedium', 'firstUserSource', 'hostName', 'landingPage', 'month', 'newVsReturning', 'operatingSystem', 'pagePath', 'pageTitle', 'region', 'sessionCampaignName', 'sessionDefaultChannelGroup', 'sessionMedium', 'sessionSource', 'week' );
-	const AGGREGATE_METRICS = array( 'activeUsers', 'averageSessionDuration', 'bounceRate', 'engagedSessions', 'engagementRate', 'eventCount', 'eventsPerSession', 'keyEvents', 'newUsers', 'screenPageViews', 'screenPageViewsPerSession', 'sessionKeyEventRate', 'sessions', 'sessionsPerUser', 'totalUsers', 'userKeyEventRate' );
+	const AGGREGATE_DIMENSIONS           = array( 'browser', 'country', 'date', 'deviceCategory', 'eventName', 'firstUserDefaultChannelGroup', 'firstUserMedium', 'firstUserSource', 'hostName', 'landingPage', 'month', 'newVsReturning', 'operatingSystem', 'pagePath', 'pageTitle', 'region', 'sessionCampaignName', 'sessionDefaultChannelGroup', 'sessionMedium', 'sessionSource', 'week' );
+	const AGGREGATE_METRICS              = array( 'activeUsers', 'averageSessionDuration', 'bounceRate', 'engagedSessions', 'engagementRate', 'eventCount', 'eventsPerSession', 'keyEvents', 'newUsers', 'screenPageViews', 'screenPageViewsPerSession', 'sessionKeyEventRate', 'sessions', 'sessionsPerUser', 'totalUsers', 'userKeyEventRate' );
 
 	/**
 	 * Share at which unknown landing-page coverage is material to analysis.
@@ -258,10 +258,29 @@ class GoogleAnalyticsAbilities {
 					),
 				),
 				'error'                      => array( 'type' => 'string' ),
-				'reports'                    => array( 'type' => 'array', 'maxItems' => 2, 'items' => self::aggregateReportOutputSchema() ),
-				'dimensions'                 => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => self::AGGREGATE_DIMENSIONS ) ),
-				'metrics'                    => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => self::AGGREGATE_METRICS ) ),
-				'filters'                    => array( 'type' => 'array', 'items' => self::aggregateFilterSchema() ),
+				'reports'                    => array(
+					'type'     => 'array',
+					'maxItems' => 2,
+					'items'    => self::aggregateReportOutputSchema(),
+				),
+				'dimensions'                 => array(
+					'type'  => 'array',
+					'items' => array(
+						'type' => 'string',
+						'enum' => self::AGGREGATE_DIMENSIONS,
+					),
+				),
+				'metrics'                    => array(
+					'type'  => 'array',
+					'items' => array(
+						'type' => 'string',
+						'enum' => self::AGGREGATE_METRICS,
+					),
+				),
+				'filters'                    => array(
+					'type'  => 'array',
+					'items' => self::aggregateFilterSchema(),
+				),
 			),
 		);
 	}
@@ -272,41 +291,86 @@ class GoogleAnalyticsAbilities {
 			'additionalProperties' => false,
 			'required'             => array( 'action', 'date_range', 'metrics' ),
 			'properties'           => array(
-				'action'                => array( 'type' => 'string', 'enum' => array( 'aggregate_report' ) ),
-				'property_id'           => array( 'type' => 'string', 'pattern' => '^\\d{6,20}$' ),
+				'action'                => array(
+					'type' => 'string',
+					'enum' => array( 'aggregate_report' ),
+				),
+				'property_id'           => array(
+					'type'    => 'string',
+					'pattern' => '^\\d{6,20}$',
+				),
 				'date_range'            => self::aggregateDateRangeSchema(),
 				'comparison_date_range' => self::aggregateDateRangeSchema(),
-				'dimensions'            => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => self::AGGREGATE_DIMENSIONS ), 'maxItems' => 3, 'uniqueItems' => true ),
-				'metrics'               => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => self::AGGREGATE_METRICS ), 'minItems' => 1, 'maxItems' => 8, 'uniqueItems' => true ),
-				'filters'               => array( 'type' => 'array', 'maxItems' => 4, 'items' => self::aggregateFilterSchema() ),
-				'order_by'              => array( 'type' => 'array', 'maxItems' => 2, 'items' => self::aggregateOrderSchema() ),
-				'limit'                 => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::AGGREGATE_MAX_ROWS ),
+				'dimensions'            => array(
+					'type'        => 'array',
+					'items'       => array(
+						'type' => 'string',
+						'enum' => self::AGGREGATE_DIMENSIONS,
+					),
+					'maxItems'    => 3,
+					'uniqueItems' => true,
+				),
+				'metrics'               => array(
+					'type'        => 'array',
+					'items'       => array(
+						'type' => 'string',
+						'enum' => self::AGGREGATE_METRICS,
+					),
+					'minItems'    => 1,
+					'maxItems'    => 8,
+					'uniqueItems' => true,
+				),
+				'filters'               => array(
+					'type'     => 'array',
+					'maxItems' => 4,
+					'items'    => self::aggregateFilterSchema(),
+				),
+				'order_by'              => array(
+					'type'     => 'array',
+					'maxItems' => 2,
+					'items'    => self::aggregateOrderSchema(),
+				),
+				'limit'                 => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+					'maximum' => self::AGGREGATE_MAX_ROWS,
+				),
 			),
 		);
 	}
 
 	/** Closed action-specific schemas keep aggregate bounds visible to consumers. */
 	public static function inputSchema( array $valid_actions = array() ): array {
-		$legacy_actions  = array_diff( $valid_actions ?: array_merge( array_keys( self::ACTION_REPORTS ), array( 'realtime', 'path_sequence' ) ), array( 'aggregate_report' ) );
-		$aggregate       = self::aggregateInputSchema();
-		$legacy_fields   = array(
-			'action'      => array( 'type' => 'string', 'enum' => array_values( $legacy_actions ) ),
+		$legacy_actions = array_diff( $valid_actions ? $valid_actions : array_merge( array_keys( self::ACTION_REPORTS ), array( 'realtime', 'path_sequence' ) ), array( 'aggregate_report' ) );
+		$aggregate      = self::aggregateInputSchema();
+		$legacy_fields  = array(
+			'action'      => array(
+				'type' => 'string',
+				'enum' => array_values( $legacy_actions ),
+			),
 			'property_id' => array( 'type' => 'string' ),
 			'start_date'  => array( 'type' => 'string' ),
 			'end_date'    => array( 'type' => 'string' ),
-			'limit'       => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::MAX_LIMIT ),
+			'limit'       => array(
+				'type'    => 'integer',
+				'minimum' => 1,
+				'maximum' => self::MAX_LIMIT,
+			),
 			'page_filter' => array( 'type' => 'string' ),
 			'hostname'    => array( 'type' => 'string' ),
 			'sort_by'     => array( 'type' => 'string' ),
-			'order'       => array( 'type' => 'string', 'enum' => array( 'asc', 'desc' ) ),
+			'order'       => array(
+				'type' => 'string',
+				'enum' => array( 'asc', 'desc' ),
+			),
 			'compare'     => array( 'type' => 'boolean' ),
 		);
 		return array(
 			'oneOf' => array(
 				array(
-					'type'                 => 'object',
-					'required'             => array( 'action' ),
-					'properties'           => $legacy_fields,
+					'type'       => 'object',
+					'required'   => array( 'action' ),
+					'properties' => $legacy_fields,
 				),
 				$aggregate,
 			),
@@ -319,8 +383,14 @@ class GoogleAnalyticsAbilities {
 			'additionalProperties' => false,
 			'required'             => array( 'start_date', 'end_date' ),
 			'properties'           => array(
-				'start_date' => array( 'type' => 'string', 'pattern' => '^\\d{4}-\\d{2}-\\d{2}$' ),
-				'end_date'   => array( 'type' => 'string', 'pattern' => '^\\d{4}-\\d{2}-\\d{2}$' ),
+				'start_date' => array(
+					'type'    => 'string',
+					'pattern' => '^\\d{4}-\\d{2}-\\d{2}$',
+				),
+				'end_date'   => array(
+					'type'    => 'string',
+					'pattern' => '^\\d{4}-\\d{2}-\\d{2}$',
+				),
 			),
 		);
 	}
@@ -331,9 +401,19 @@ class GoogleAnalyticsAbilities {
 			'additionalProperties' => false,
 			'required'             => array( 'field_name', 'match_type', 'value' ),
 			'properties'           => array(
-				'field_name'     => array( 'type' => 'string', 'enum' => self::AGGREGATE_DIMENSIONS ),
-				'match_type'     => array( 'type' => 'string', 'enum' => array( 'EXACT', 'CONTAINS', 'BEGINS_WITH', 'ENDS_WITH' ) ),
-				'value'          => array( 'type' => 'string', 'minLength' => 1, 'maxLength' => 200 ),
+				'field_name'     => array(
+					'type' => 'string',
+					'enum' => self::AGGREGATE_DIMENSIONS,
+				),
+				'match_type'     => array(
+					'type' => 'string',
+					'enum' => array( 'EXACT', 'CONTAINS', 'BEGINS_WITH', 'ENDS_WITH' ),
+				),
+				'value'          => array(
+					'type'      => 'string',
+					'minLength' => 1,
+					'maxLength' => 200,
+				),
 				'case_sensitive' => array( 'type' => 'boolean' ),
 				'exclude'        => array( 'type' => 'boolean' ),
 			),
@@ -346,7 +426,10 @@ class GoogleAnalyticsAbilities {
 			'additionalProperties' => false,
 			'required'             => array( 'type', 'name' ),
 			'properties'           => array(
-				'type'       => array( 'type' => 'string', 'enum' => array( 'dimension', 'metric' ) ),
+				'type'       => array(
+					'type' => 'string',
+					'enum' => array( 'dimension', 'metric' ),
+				),
 				'name'       => array( 'type' => 'string' ),
 				'descending' => array( 'type' => 'boolean' ),
 			),
@@ -359,16 +442,51 @@ class GoogleAnalyticsAbilities {
 			'additionalProperties' => false,
 			'required'             => array( 'label', 'date_range', 'rows', 'totals', 'returned_row_count', 'row_count', 'quota_remaining', 'coverage_limits' ),
 			'properties'           => array(
-				'label'              => array( 'type' => 'string', 'enum' => array( 'primary', 'comparison' ) ),
+				'label'              => array(
+					'type' => 'string',
+					'enum' => array( 'primary', 'comparison' ),
+				),
 				'date_range'         => self::aggregateDateRangeSchema(),
-				'rows'               => array( 'type' => 'array', 'maxItems' => self::AGGREGATE_MAX_ROWS, 'items' => array( 'type' => 'object', 'additionalProperties' => false, 'required' => array( 'dimensions', 'metrics' ), 'properties' => array( 'dimensions' => self::aggregateOutputRecordSchema( self::AGGREGATE_DIMENSIONS, 3, 2000 ), 'metrics' => self::aggregateOutputRecordSchema( self::AGGREGATE_METRICS, 8, 200 ) ) ) ),
+				'rows'               => array(
+					'type'     => 'array',
+					'maxItems' => self::AGGREGATE_MAX_ROWS,
+					'items'    => array(
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'required'             => array( 'dimensions', 'metrics' ),
+						'properties'           => array(
+							'dimensions' => self::aggregateOutputRecordSchema( self::AGGREGATE_DIMENSIONS, 3, 2000 ),
+							'metrics'    => self::aggregateOutputRecordSchema( self::AGGREGATE_METRICS, 8, 200 ),
+						),
+					),
+				),
 				'totals'             => self::aggregateOutputRecordSchema( self::AGGREGATE_METRICS, 8, 200 ),
 				'returned_row_count' => array( 'type' => 'integer' ),
 				'row_count'          => array( 'type' => 'integer' ),
-				'quota_remaining'    => array( 'type' => 'object', 'maxProperties' => 10, 'additionalProperties' => array( 'type' => 'integer', 'minimum' => 0 ) ),
-				'coverage_limits'    => array( 'type' => 'array', 'maxItems' => 10, 'items' => array( 'type' => 'string', 'maxLength' => 300 ) ),
-				'time_zone'          => array( 'type' => 'string', 'maxLength' => 100 ),
-				'currency_code'      => array( 'type' => 'string', 'maxLength' => 20 ),
+				'quota_remaining'    => array(
+					'type'                 => 'object',
+					'maxProperties'        => 10,
+					'additionalProperties' => array(
+						'type'    => 'integer',
+						'minimum' => 0,
+					),
+				),
+				'coverage_limits'    => array(
+					'type'     => 'array',
+					'maxItems' => 10,
+					'items'    => array(
+						'type'      => 'string',
+						'maxLength' => 300,
+					),
+				),
+				'time_zone'          => array(
+					'type'      => 'string',
+					'maxLength' => 100,
+				),
+				'currency_code'      => array(
+					'type'      => 'string',
+					'maxLength' => 20,
+				),
 			),
 		);
 	}
@@ -376,9 +494,17 @@ class GoogleAnalyticsAbilities {
 	private static function aggregateOutputRecordSchema( array $names, int $max_items, int $max_length ): array {
 		$properties = array();
 		foreach ( $names as $name ) {
-			$properties[ $name ] = array( 'type' => 'string', 'maxLength' => $max_length );
+			$properties[ $name ] = array(
+				'type'      => 'string',
+				'maxLength' => $max_length,
+			);
 		}
-		return array( 'type' => 'object', 'additionalProperties' => false, 'maxProperties' => $max_items, 'properties' => $properties );
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'maxProperties'        => $max_items,
+			'properties'           => $properties,
+		);
 	}
 
 	/** Build one bounded batchRunReports request body or return an error message. */
@@ -389,17 +515,31 @@ class GoogleAnalyticsAbilities {
 		}
 
 		$build_expression = static function ( array $filter ): array {
-			$expression = array( 'filter' => array( 'fieldName' => $filter['field_name'], 'stringFilter' => array( 'matchType' => $filter['match_type'], 'value' => $filter['value'], 'caseSensitive' => ! empty( $filter['case_sensitive'] ) ) ) );
+			$expression = array(
+				'filter' => array(
+					'fieldName'    => $filter['field_name'],
+					'stringFilter' => array(
+						'matchType'     => $filter['match_type'],
+						'value'         => $filter['value'],
+						'caseSensitive' => ! empty( $filter['case_sensitive'] ),
+					),
+				),
+			);
 			return ! empty( $filter['exclude'] ) ? array( 'notExpression' => $expression ) : $expression;
 		};
-		$body = array(
-			'dateRanges'           => array( array( 'startDate' => $input['date_range']['start_date'], 'endDate' => $input['date_range']['end_date'] ) ),
-			'dimensions'           => array_map( static fn( string $name ): array => array( 'name' => $name ), $input['dimensions'] ?? array() ),
-			'metrics'              => array_map( static fn( string $name ): array => array( 'name' => $name ), $input['metrics'] ),
-			'limit'                => (int) ( $input['limit'] ?? 25 ),
-			'keepEmptyRows'        => false,
-			'metricAggregations'   => array( 'TOTAL' ),
-			'returnPropertyQuota'  => true,
+		$body             = array(
+			'dateRanges'          => array(
+				array(
+					'startDate' => $input['date_range']['start_date'],
+					'endDate'   => $input['date_range']['end_date'],
+				),
+			),
+			'dimensions'          => array_map( static fn( string $name ): array => array( 'name' => $name ), $input['dimensions'] ?? array() ),
+			'metrics'             => array_map( static fn( string $name ): array => array( 'name' => $name ), $input['metrics'] ),
+			'limit'               => (int) ( $input['limit'] ?? 25 ),
+			'keepEmptyRows'       => false,
+			'metricAggregations'  => array( 'TOTAL' ),
+			'returnPropertyQuota' => true,
 		);
 		if ( ! empty( $input['filters'] ) ) {
 			$body['dimensionFilter'] = array( 'andGroup' => array( 'expressions' => array_map( $build_expression, $input['filters'] ) ) );
@@ -415,33 +555,54 @@ class GoogleAnalyticsAbilities {
 
 	private static function validateAggregateInput( array $input ): ?string {
 		$allowed = array( 'action', 'property_id', 'date_range', 'comparison_date_range', 'dimensions', 'metrics', 'filters', 'order_by', 'limit' );
-		if ( array_diff( array_keys( $input ), $allowed ) ) { return 'aggregate_report accepts only its documented fields.'; }
-		foreach ( array( 'date_range', 'metrics' ) as $required ) { if ( ! array_key_exists( $required, $input ) ) { return "aggregate_report requires {$required}."; } }
+		if ( array_diff( array_keys( $input ), $allowed ) ) {
+			return 'aggregate_report accepts only its documented fields.'; }
+		foreach ( array( 'date_range', 'metrics' ) as $required ) {
+			if ( ! array_key_exists( $required, $input ) ) {
+				return "aggregate_report requires {$required}."; }
+		}
 		foreach ( array( 'date_range', 'comparison_date_range' ) as $key ) {
-			if ( ! isset( $input[ $key ] ) ) { continue; }
+			if ( ! isset( $input[ $key ] ) ) {
+				continue; }
 			$range = $input[ $key ];
-			if ( ! is_array( $range ) || array_diff( array_keys( $range ), array( 'start_date', 'end_date' ) ) || ! isset( $range['start_date'], $range['end_date'] ) || ! self::isValidAggregateDate( $range['start_date'] ) || ! self::isValidAggregateDate( $range['end_date'] ) ) { return "{$key} must contain exact start_date and end_date values in YYYY-MM-DD format."; }
+			if ( ! is_array( $range ) || array_diff( array_keys( $range ), array( 'start_date', 'end_date' ) ) || ! isset( $range['start_date'], $range['end_date'] ) || ! self::isValidAggregateDate( $range['start_date'] ) || ! self::isValidAggregateDate( $range['end_date'] ) ) {
+				return "{$key} must contain exact start_date and end_date values in YYYY-MM-DD format."; }
 			$days = (int) ( ( strtotime( $range['end_date'] . ' UTC' ) - strtotime( $range['start_date'] . ' UTC' ) ) / DAY_IN_SECONDS ) + 1;
-			if ( $days < 1 || $days > self::AGGREGATE_MAX_DATE_RANGE_DAYS ) { return "{$key} must be between 1 and " . self::AGGREGATE_MAX_DATE_RANGE_DAYS . ' inclusive days.'; }
+			if ( $days < 1 || $days > self::AGGREGATE_MAX_DATE_RANGE_DAYS ) {
+				return "{$key} must be between 1 and " . self::AGGREGATE_MAX_DATE_RANGE_DAYS . ' inclusive days.'; }
 		}
-		$dimensions = $input['dimensions'] ?? array(); $metrics = $input['metrics'];
-		if ( ! is_array( $dimensions ) || count( $dimensions ) > 3 || count( $dimensions ) !== count( array_filter( $dimensions, 'is_string' ) ) || count( $dimensions ) !== count( array_unique( $dimensions ) ) || array_diff( $dimensions, self::AGGREGATE_DIMENSIONS ) ) { return 'dimensions must contain up to three unique approved dimensions.'; }
-		if ( ! is_array( $metrics ) || count( $metrics ) < 1 || count( $metrics ) > 8 || count( $metrics ) !== count( array_filter( $metrics, 'is_string' ) ) || count( $metrics ) !== count( array_unique( $metrics ) ) || array_diff( $metrics, self::AGGREGATE_METRICS ) ) { return 'metrics must contain one to eight unique approved metrics.'; }
-		if ( ! isset( $input['limit'] ) ) { $input['limit'] = 25; }
-		if ( ! is_int( $input['limit'] ) && ! ctype_digit( (string) $input['limit'] ) || (int) $input['limit'] < 1 || (int) $input['limit'] > self::AGGREGATE_MAX_ROWS ) { return 'limit must be an integer from 1 to 100.'; }
-		if ( ! is_array( $input['filters'] ?? array() ) || count( $input['filters'] ?? array() ) > 4 ) { return 'filters supports at most four entries.'; }
+		$dimensions = $input['dimensions'] ?? array();
+		$metrics    = $input['metrics'];
+		if ( ! is_array( $dimensions ) || count( $dimensions ) > 3 || count( $dimensions ) !== count( array_filter( $dimensions, 'is_string' ) ) || count( $dimensions ) !== count( array_unique( $dimensions ) ) || array_diff( $dimensions, self::AGGREGATE_DIMENSIONS ) ) {
+			return 'dimensions must contain up to three unique approved dimensions.'; }
+		if ( ! is_array( $metrics ) || count( $metrics ) < 1 || count( $metrics ) > 8 || count( $metrics ) !== count( array_filter( $metrics, 'is_string' ) ) || count( $metrics ) !== count( array_unique( $metrics ) ) || array_diff( $metrics, self::AGGREGATE_METRICS ) ) {
+			return 'metrics must contain one to eight unique approved metrics.'; }
+		if ( ! isset( $input['limit'] ) ) {
+			$input['limit'] = 25; }
+		if ( ( ! is_int( $input['limit'] ) && ! ctype_digit( (string) $input['limit'] ) ) || (int) $input['limit'] < 1 || (int) $input['limit'] > self::AGGREGATE_MAX_ROWS ) {
+			return 'limit must be an integer from 1 to 100.'; }
+		if ( ! is_array( $input['filters'] ?? array() ) || count( $input['filters'] ?? array() ) > 4 ) {
+			return 'filters supports at most four entries.'; }
 		foreach ( $input['filters'] ?? array() as $filter ) {
-			if ( ! is_array( $filter ) || array_diff( array_keys( $filter ), array( 'field_name', 'match_type', 'value', 'case_sensitive', 'exclude' ) ) || ! in_array( $filter['field_name'] ?? '', self::AGGREGATE_DIMENSIONS, true ) || ! in_array( $filter['match_type'] ?? '', array( 'EXACT', 'CONTAINS', 'BEGINS_WITH', 'ENDS_WITH' ), true ) || ! is_string( $filter['value'] ?? null ) || '' === $filter['value'] || strlen( $filter['value'] ) > 200 || ( isset( $filter['case_sensitive'] ) && ! is_bool( $filter['case_sensitive'] ) ) || ( isset( $filter['exclude'] ) && ! is_bool( $filter['exclude'] ) ) ) { return 'filters must contain approved bounded string dimension filters.'; }
+			if ( ! is_array( $filter ) || array_diff( array_keys( $filter ), array( 'field_name', 'match_type', 'value', 'case_sensitive', 'exclude' ) ) || ! in_array( $filter['field_name'] ?? '', self::AGGREGATE_DIMENSIONS, true ) || ! in_array( $filter['match_type'] ?? '', array( 'EXACT', 'CONTAINS', 'BEGINS_WITH', 'ENDS_WITH' ), true ) || ! is_string( $filter['value'] ?? null ) || '' === $filter['value'] || strlen( $filter['value'] ) > 200 || ( isset( $filter['case_sensitive'] ) && ! is_bool( $filter['case_sensitive'] ) ) || ( isset( $filter['exclude'] ) && ! is_bool( $filter['exclude'] ) ) ) {
+				return 'filters must contain approved bounded string dimension filters.'; }
 		}
-		if ( ! is_array( $input['order_by'] ?? array() ) || count( $input['order_by'] ?? array() ) > 2 ) { return 'order_by supports at most two entries.'; }
+		if ( ! is_array( $input['order_by'] ?? array() ) || count( $input['order_by'] ?? array() ) > 2 ) {
+			return 'order_by supports at most two entries.'; }
 		foreach ( $input['order_by'] ?? array() as $order ) {
-			if ( ! is_array( $order ) || array_diff( array_keys( $order ), array( 'type', 'name', 'descending' ) ) || ! in_array( $order['type'] ?? '', array( 'dimension', 'metric' ), true ) || ! in_array( $order['name'] ?? '', 'dimension' === ( $order['type'] ?? '' ) ? $dimensions : $metrics, true ) || ( isset( $order['descending'] ) && ! is_bool( $order['descending'] ) ) ) { return 'Each ordering must select a requested dimension or metric.'; }
+			if ( ! is_array( $order ) ) {
+				return 'Each ordering must select a requested dimension or metric.';
+			}
+			$order_type = isset( $order['type'] ) ? $order['type'] : '';
+			if ( array_diff( array_keys( $order ), array( 'type', 'name', 'descending' ) ) || ! in_array( $order_type, array( 'dimension', 'metric' ), true ) || ! in_array( $order['name'] ?? '', 'dimension' === $order_type ? $dimensions : $metrics, true ) || ( isset( $order['descending'] ) && ! is_bool( $order['descending'] ) ) ) {
+				return 'Each ordering must select a requested dimension or metric.'; }
 		}
 		return null;
 	}
 
 	private static function isValidAggregateDate( $date ): bool {
-		return is_string( $date ) && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) && gmdate( 'Y-m-d', strtotime( $date . ' UTC' ) ) === $date;
+		$timestamp = is_string( $date ) ? strtotime( $date . ' UTC' ) : false;
+		return is_string( $date ) && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) && false !== $timestamp && gmdate( 'Y-m-d', $timestamp ) === $date;
 	}
 
 	/** Resolve the configured default or an explicit aggregate property ID. */
@@ -455,24 +616,54 @@ class GoogleAnalyticsAbilities {
 
 	private static function fetchAggregateReport( array $input, string $access_token, string $property_id ): array {
 		$batch = self::buildAggregateBatchRequest( $input, $property_id, $access_token );
-		if ( is_wp_error( $batch ) ) { return array( 'success' => false, 'error' => $batch->get_error_message() ); }
+		if ( is_wp_error( $batch ) ) {
+			return array(
+				'success' => false,
+				'error'   => $batch->get_error_message(),
+			); }
 		$result = HttpClient::post( $batch['url'], $batch['options'] );
-		if ( ! $result['success'] ) { return array( 'success' => false, 'error' => self::formatAggregateHttpError( $result ) ); }
+		if ( ! $result['success'] ) {
+			return array(
+				'success' => false,
+				'error'   => self::formatAggregateHttpError( $result ),
+			); }
 		$data = json_decode( $result['data'], true );
-		if ( json_last_error() !== JSON_ERROR_NONE || ! is_array( $data ) ) { return array( 'success' => false, 'error' => 'Google Analytics returned an unexpected aggregate report response.' ); }
+		if ( json_last_error() !== JSON_ERROR_NONE || ! is_array( $data ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Google Analytics returned an unexpected aggregate report response.',
+			); }
 		if ( array_key_exists( 'error', $data ) ) {
 			$error = self::formatAggregateApiError( $data['error'] );
-			return array( 'success' => false, 'error' => $error ?? 'Google Analytics returned an unexpected aggregate report response.' );
+			return array(
+				'success' => false,
+				'error'   => $error ?? 'Google Analytics returned an unexpected aggregate report response.',
+			);
 		}
-		if ( array_diff( array_keys( $data ), array( 'reports', 'kind' ) ) || ! isset( $data['kind'] ) || self::AGGREGATE_BATCH_RESPONSE_KIND !== $data['kind'] || ! isset( $data['reports'] ) || ! is_array( $data['reports'] ) || ! array_is_list( $data['reports'] ) || count( $data['reports'] ) !== count( $batch['ranges'] ) ) { return array( 'success' => false, 'error' => 'Google Analytics returned an unexpected aggregate report response.' ); }
+		if ( array_diff( array_keys( $data ), array( 'reports', 'kind' ) ) || ! isset( $data['kind'] ) || self::AGGREGATE_BATCH_RESPONSE_KIND !== $data['kind'] || ! isset( $data['reports'] ) || ! is_array( $data['reports'] ) || ! array_is_list( $data['reports'] ) || count( $data['reports'] ) !== count( $batch['ranges'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Google Analytics returned an unexpected aggregate report response.',
+			); }
 		$reports = array();
 		foreach ( $data['reports'] as $index => $report ) {
 			$normalized = self::normalizeAggregateReport( $report, $batch['ranges'][ $index ], $input['dimensions'] ?? array(), $input['metrics'] );
-			if ( is_wp_error( $normalized ) ) { return array( 'success' => false, 'error' => $normalized->get_error_message() ); }
+			if ( is_wp_error( $normalized ) ) {
+				return array(
+					'success' => false,
+					'error'   => $normalized->get_error_message(),
+				); }
 			$normalized['label'] = 0 === $index ? 'primary' : 'comparison';
-			$reports[] = $normalized;
+			$reports[]           = $normalized;
 		}
-		return array( 'success' => true, 'action' => 'aggregate_report', 'dimensions' => $input['dimensions'] ?? array(), 'metrics' => $input['metrics'], 'filters' => $input['filters'] ?? array(), 'reports' => $reports );
+		return array(
+			'success'    => true,
+			'action'     => 'aggregate_report',
+			'dimensions' => $input['dimensions'] ?? array(),
+			'metrics'    => $input['metrics'],
+			'filters'    => $input['filters'] ?? array(),
+			'reports'    => $reports,
+		);
 	}
 
 	/** Return a canonical GA4 error without exposing a provider response body. */
@@ -501,14 +692,14 @@ class GoogleAnalyticsAbilities {
 		}
 
 		$messages = array(
-			'PERMISSION_DENIED' => 'Permission denied.',
-			'UNAUTHENTICATED'    => 'Authentication failed.',
-			'INVALID_ARGUMENT'   => 'The aggregate report request was rejected.',
-			'NOT_FOUND'          => 'The requested GA4 property was not found.',
-			'RESOURCE_EXHAUSTED' => 'GA4 quota is exhausted.',
+			'PERMISSION_DENIED'   => 'Permission denied.',
+			'UNAUTHENTICATED'     => 'Authentication failed.',
+			'INVALID_ARGUMENT'    => 'The aggregate report request was rejected.',
+			'NOT_FOUND'           => 'The requested GA4 property was not found.',
+			'RESOURCE_EXHAUSTED'  => 'GA4 quota is exhausted.',
 			'FAILED_PRECONDITION' => 'The GA4 property is not ready for this request.',
-			'UNAVAILABLE'        => 'GA4 is temporarily unavailable.',
-			'INTERNAL'           => 'GA4 encountered an internal error.',
+			'UNAVAILABLE'         => 'GA4 is temporarily unavailable.',
+			'INTERNAL'            => 'GA4 encountered an internal error.',
 		);
 		return 'GA4 API error (' . $error['code'] . ' ' . $error['status'] . '): ' . ( $messages[ $error['status'] ] ?? 'The GA4 request failed.' );
 	}
@@ -516,20 +707,32 @@ class GoogleAnalyticsAbilities {
 	/** Build the single bounded HTTP batch request without exposing credentials. */
 	public static function buildAggregateBatchRequest( array $input, string $property_id, string $access_token ) {
 		$primary = self::buildAggregateReportRequestBody( $input );
-		if ( is_wp_error( $primary ) ) { return $primary; }
+		if ( is_wp_error( $primary ) ) {
+			return $primary; }
 		$requests = array( $primary );
 		$ranges   = array( $input['date_range'] );
 		if ( isset( $input['comparison_date_range'] ) ) {
-			$comparison = $input;
+			$comparison               = $input;
 			$comparison['date_range'] = $input['comparison_date_range'];
 			unset( $comparison['comparison_date_range'] );
 			$requests[] = self::buildAggregateReportRequestBody( $comparison );
-			if ( is_wp_error( $requests[1] ) ) { return $requests[1]; }
+			if ( is_wp_error( $requests[1] ) ) {
+				return $requests[1]; }
 			$ranges[] = $input['comparison_date_range'];
 		}
 		return array(
 			'url'     => self::API_BASE . $property_id . ':batchRunReports',
-			'options' => array( 'timeout' => 30, 'limit_response_size' => self::AGGREGATE_MAX_RESPONSE_BYTES, 'log_response_body_preview' => false, 'headers' => array( 'Authorization' => 'Bearer ' . $access_token, 'Content-Type' => 'application/json' ), 'body' => wp_json_encode( array( 'requests' => $requests ) ), 'context' => 'Google Analytics Data API aggregate report' ),
+			'options' => array(
+				'timeout'                   => 30,
+				'limit_response_size'       => self::AGGREGATE_MAX_RESPONSE_BYTES,
+				'log_response_body_preview' => false,
+				'headers'                   => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Content-Type'  => 'application/json',
+				),
+				'body'                      => wp_json_encode( array( 'requests' => $requests ) ),
+				'context'                   => 'Google Analytics Data API aggregate report',
+			),
 			'ranges'  => $ranges,
 		);
 	}
@@ -537,50 +740,108 @@ class GoogleAnalyticsAbilities {
 	/** Normalize a single batch report without inventing coverage guarantees. */
 	public static function normalizeAggregateReport( array $report, array $date_range, array $expected_dimensions = array(), array $expected_metrics = array() ) {
 		$invalid = static fn(): \WP_Error => new \WP_Error( 'invalid_ga_aggregate_response', 'Google Analytics returned a malformed aggregate report.' );
-		if ( ! isset( $report['kind'] ) || self::AGGREGATE_REPORT_RESPONSE_KIND !== $report['kind'] ) { return $invalid(); }
+		if ( ! isset( $report['kind'] ) || self::AGGREGATE_REPORT_RESPONSE_KIND !== $report['kind'] ) {
+			return $invalid(); }
 		unset( $report['kind'] );
 		$dimension_headers = $report['dimensionHeaders'] ?? array();
 		$metric_headers    = $report['metricHeaders'] ?? array();
 		$raw_rows          = $report['rows'] ?? array();
 		$raw_totals        = $report['totals'] ?? array();
-		if ( ! is_array( $dimension_headers ) || ! is_array( $metric_headers ) || ! is_array( $raw_rows ) || ! is_array( $raw_totals ) || ! array_is_list( $dimension_headers ) || ! array_is_list( $metric_headers ) || ! array_is_list( $raw_rows ) || ! array_is_list( $raw_totals ) || count( $raw_rows ) > self::AGGREGATE_MAX_ROWS ) { return $invalid(); }
-		$headers = static function ( array $items ) { $names = array(); foreach ( $items as $item ) { if ( ! is_array( $item ) || array_diff( array_keys( $item ), array( 'name', 'type' ) ) || ! isset( $item['name'] ) || ! is_string( $item['name'] ) || '' === $item['name'] || strlen( $item['name'] ) > 100 || ( isset( $item['type'] ) && ( ! is_string( $item['type'] ) || strlen( $item['type'] ) > 100 ) ) ) { return false; } $names[] = $item['name']; } return $names; };
-		$dimensions = $headers( $dimension_headers ); $metrics = $headers( $metric_headers );
-		if ( false === $dimensions || false === $metrics || ( ! empty( $raw_rows ) && ( $dimensions !== $expected_dimensions || $metrics !== $expected_metrics ) ) || ( ! empty( $raw_totals ) && $metrics !== $expected_metrics ) || ( empty( $raw_rows ) && empty( $raw_totals ) && ( ! empty( $dimensions ) && $dimensions !== $expected_dimensions || ! empty( $metrics ) && $metrics !== $expected_metrics ) ) ) { return $invalid(); }
+		if ( ! is_array( $dimension_headers ) || ! is_array( $metric_headers ) || ! is_array( $raw_rows ) || ! is_array( $raw_totals ) || ! array_is_list( $dimension_headers ) || ! array_is_list( $metric_headers ) || ! array_is_list( $raw_rows ) || ! array_is_list( $raw_totals ) || count( $raw_rows ) > self::AGGREGATE_MAX_ROWS ) {
+			return $invalid(); }
+		$headers    = static function ( array $items ) { $names = array();
+			foreach ( $items as $item ) {
+				if ( ! is_array( $item ) || array_diff( array_keys( $item ), array( 'name', 'type' ) ) || ! isset( $item['name'] ) || ! is_string( $item['name'] ) || '' === $item['name'] || strlen( $item['name'] ) > 100 || ( isset( $item['type'] ) && ( ! is_string( $item['type'] ) || strlen( $item['type'] ) > 100 ) ) ) {
+					return false;
+				} $names[] = $item['name'];
+			} return $names;
+		};
+		$dimensions = $headers( $dimension_headers );
+		$metrics    = $headers( $metric_headers );
+		if ( false === $dimensions || false === $metrics || ( ! empty( $raw_rows ) && ( $dimensions !== $expected_dimensions || $metrics !== $expected_metrics ) ) || ( ! empty( $raw_totals ) && $metrics !== $expected_metrics ) || ( empty( $raw_rows ) && empty( $raw_totals ) && ( ( ! empty( $dimensions ) && $dimensions !== $expected_dimensions ) || ( ! empty( $metrics ) && $metrics !== $expected_metrics ) ) ) ) {
+			return $invalid(); }
 		$dimensions = empty( $dimensions ) ? $expected_dimensions : $dimensions;
 		$metrics    = empty( $metrics ) ? $expected_metrics : $metrics;
-		$record = static function ( array $headers, array $values, int $max_length ) { if ( ! array_is_list( $values ) || count( $values ) !== count( $headers ) ) { return false; } $out = array(); foreach ( $headers as $index => $name ) { $value = $values[ $index ] ?? null; if ( ! is_array( $value ) || array_keys( $value ) !== array( 'value' ) || ! is_string( $value['value'] ) || strlen( $value['value'] ) > $max_length ) { return false; } $out[ $name ] = $value['value']; } return $out; };
-		$rows = array();
+		$record     = static function ( array $headers, array $values, int $max_length ) { if ( ! array_is_list( $values ) || count( $values ) !== count( $headers ) ) {
+				return false;
+		} $out = array();
+		foreach ( $headers as $index => $name ) {
+			$value = $values[ $index ] ?? null;
+			if ( ! is_array( $value ) || array_keys( $value ) !== array( 'value' ) || ! is_string( $value['value'] ) || strlen( $value['value'] ) > $max_length ) {
+				return false;
+			} $out[ $name ] = $value['value'];
+		} return $out;
+		};
+		$rows       = array();
 		foreach ( $raw_rows as $row ) {
-			if ( ! is_array( $row ) || array_diff( array_keys( $row ), array( 'dimensionValues', 'metricValues' ) ) || ! isset( $row['dimensionValues'], $row['metricValues'] ) ) { return $invalid(); }
-			$dimension_values = $record( $dimensions, $row['dimensionValues'], 2000 ); $metric_values = $record( $metrics, $row['metricValues'], 200 );
-			if ( false === $dimension_values || false === $metric_values ) { return $invalid(); }
-			$rows[] = array( 'dimensions' => $dimension_values, 'metrics' => $metric_values );
+			if ( ! is_array( $row ) || array_diff( array_keys( $row ), array( 'dimensionValues', 'metricValues' ) ) || ! isset( $row['dimensionValues'], $row['metricValues'] ) ) {
+				return $invalid(); }
+			$dimension_values = $record( $dimensions, $row['dimensionValues'], 2000 );
+			$metric_values    = $record( $metrics, $row['metricValues'], 200 );
+			if ( false === $dimension_values || false === $metric_values ) {
+				return $invalid(); }
+			$rows[] = array(
+				'dimensions' => $dimension_values,
+				'metrics'    => $metric_values,
+			);
 		}
-		$limits = array(); $metadata = $report['metadata'] ?? array();
-		if ( ! is_array( $metadata ) || array_diff( array_keys( $metadata ), array( 'dataLossFromOtherRow', 'subjectToThresholding', 'samplingMetadatas', 'timeZone', 'currencyCode', 'emptyReason', 'schemaRestrictionResponse' ) ) || ( isset( $metadata['dataLossFromOtherRow'] ) && ! is_bool( $metadata['dataLossFromOtherRow'] ) ) || ( isset( $metadata['subjectToThresholding'] ) && ! is_bool( $metadata['subjectToThresholding'] ) ) || ( isset( $metadata['timeZone'] ) && ( ! is_string( $metadata['timeZone'] ) || strlen( $metadata['timeZone'] ) > 100 ) ) || ( isset( $metadata['currencyCode'] ) && ( ! is_string( $metadata['currencyCode'] ) || strlen( $metadata['currencyCode'] ) > 20 ) ) || ( isset( $metadata['emptyReason'] ) && ( ! is_string( $metadata['emptyReason'] ) || '' === $metadata['emptyReason'] || strlen( $metadata['emptyReason'] ) > 100 ) ) ) { return $invalid(); }
-		if ( ! empty( $metadata['dataLossFromOtherRow'] ) ) { $limits[] = 'Some dimension values were grouped into an other row, so the returned breakdown is incomplete.'; }
-		if ( ! empty( $metadata['subjectToThresholding'] ) ) { $limits[] = 'Google Analytics applied a privacy threshold to this report.'; }
-		if ( isset( $metadata['emptyReason'] ) ) { $limits[] = 'Google Analytics reported an empty result for this report.'; }
+		$limits   = array();
+		$metadata = $report['metadata'] ?? array();
+		if ( ! is_array( $metadata ) || array_diff( array_keys( $metadata ), array( 'dataLossFromOtherRow', 'subjectToThresholding', 'samplingMetadatas', 'timeZone', 'currencyCode', 'emptyReason', 'schemaRestrictionResponse' ) ) || ( isset( $metadata['dataLossFromOtherRow'] ) && ! is_bool( $metadata['dataLossFromOtherRow'] ) ) || ( isset( $metadata['subjectToThresholding'] ) && ! is_bool( $metadata['subjectToThresholding'] ) ) || ( isset( $metadata['timeZone'] ) && ( ! is_string( $metadata['timeZone'] ) || strlen( $metadata['timeZone'] ) > 100 ) ) || ( isset( $metadata['currencyCode'] ) && ( ! is_string( $metadata['currencyCode'] ) || strlen( $metadata['currencyCode'] ) > 20 ) ) || ( isset( $metadata['emptyReason'] ) && ( ! is_string( $metadata['emptyReason'] ) || '' === $metadata['emptyReason'] || strlen( $metadata['emptyReason'] ) > 100 ) ) ) {
+			return $invalid(); }
+		if ( ! empty( $metadata['dataLossFromOtherRow'] ) ) {
+			$limits[] = 'Some dimension values were grouped into an other row, so the returned breakdown is incomplete.'; }
+		if ( ! empty( $metadata['subjectToThresholding'] ) ) {
+			$limits[] = 'Google Analytics applied a privacy threshold to this report.'; }
+		if ( isset( $metadata['emptyReason'] ) ) {
+			$limits[] = 'Google Analytics reported an empty result for this report.'; }
 		if ( isset( $metadata['schemaRestrictionResponse'] ) ) {
 			$restriction = $metadata['schemaRestrictionResponse'];
-			if ( ! is_array( $restriction ) || array_keys( $restriction ) !== array( 'activeMetricRestrictions' ) || ! is_array( $restriction['activeMetricRestrictions'] ) || ! array_is_list( $restriction['activeMetricRestrictions'] ) || count( $restriction['activeMetricRestrictions'] ) > count( $expected_metrics ) ) { return $invalid(); }
+			if ( ! is_array( $restriction ) || array_keys( $restriction ) !== array( 'activeMetricRestrictions' ) || ! is_array( $restriction['activeMetricRestrictions'] ) || ! array_is_list( $restriction['activeMetricRestrictions'] ) || count( $restriction['activeMetricRestrictions'] ) > count( $expected_metrics ) ) {
+				return $invalid(); }
 			foreach ( $restriction['activeMetricRestrictions'] as $metric_restriction ) {
-				if ( ! is_array( $metric_restriction ) || count( $metric_restriction ) !== 2 || array_diff( array_keys( $metric_restriction ), array( 'metricName', 'restrictedMetricTypes' ) ) || ! isset( $metric_restriction['metricName'], $metric_restriction['restrictedMetricTypes'] ) || ! is_string( $metric_restriction['metricName'] ) || '' === $metric_restriction['metricName'] || strlen( $metric_restriction['metricName'] ) > 100 || ! in_array( $metric_restriction['metricName'], $expected_metrics, true ) || ! is_array( $metric_restriction['restrictedMetricTypes'] ) || ! array_is_list( $metric_restriction['restrictedMetricTypes'] ) || count( $metric_restriction['restrictedMetricTypes'] ) < 1 || count( $metric_restriction['restrictedMetricTypes'] ) > 2 || count( $metric_restriction['restrictedMetricTypes'] ) !== count( array_unique( $metric_restriction['restrictedMetricTypes'] ) ) || array_diff( $metric_restriction['restrictedMetricTypes'], array( 'RESTRICTED_METRIC_TYPE_UNSPECIFIED', 'COST_DATA', 'REVENUE_DATA' ) ) ) { return $invalid(); }
+				if ( ! is_array( $metric_restriction ) || count( $metric_restriction ) !== 2 || array_diff( array_keys( $metric_restriction ), array( 'metricName', 'restrictedMetricTypes' ) ) || ! isset( $metric_restriction['metricName'], $metric_restriction['restrictedMetricTypes'] ) || ! is_string( $metric_restriction['metricName'] ) || '' === $metric_restriction['metricName'] || strlen( $metric_restriction['metricName'] ) > 100 || ! in_array( $metric_restriction['metricName'], $expected_metrics, true ) || ! is_array( $metric_restriction['restrictedMetricTypes'] ) || ! array_is_list( $metric_restriction['restrictedMetricTypes'] ) || count( $metric_restriction['restrictedMetricTypes'] ) < 1 || count( $metric_restriction['restrictedMetricTypes'] ) > 2 || count( $metric_restriction['restrictedMetricTypes'] ) !== count( array_unique( $metric_restriction['restrictedMetricTypes'] ) ) || array_diff( $metric_restriction['restrictedMetricTypes'], array( 'RESTRICTED_METRIC_TYPE_UNSPECIFIED', 'COST_DATA', 'REVENUE_DATA' ) ) ) {
+					return $invalid(); }
 			}
-			if ( ! empty( $restriction['activeMetricRestrictions'] ) ) { $limits[] = 'Google Analytics restricted one or more requested metrics.'; }
+			if ( ! empty( $restriction['activeMetricRestrictions'] ) ) {
+				$limits[] = 'Google Analytics restricted one or more requested metrics.'; }
 		}
-		if ( isset( $metadata['samplingMetadatas'] ) && ( ! is_array( $metadata['samplingMetadatas'] ) || ! array_is_list( $metadata['samplingMetadatas'] ) || count( $metadata['samplingMetadatas'] ) > 5 ) ) { return $invalid(); }
-		foreach ( $metadata['samplingMetadatas'] ?? array() as $sampling ) { if ( ! is_array( $sampling ) || array_diff( array_keys( $sampling ), array( 'samplesReadCount', 'samplingSpaceSize' ) ) || ( isset( $sampling['samplesReadCount'] ) && ( ! is_string( $sampling['samplesReadCount'] ) || ! ctype_digit( $sampling['samplesReadCount'] ) ) ) || ( isset( $sampling['samplingSpaceSize'] ) && ( ! is_string( $sampling['samplingSpaceSize'] ) || ! ctype_digit( $sampling['samplingSpaceSize'] ) ) ) ) { return $invalid(); } $limits[] = 'Google Analytics sampled ' . ( $sampling['samplesReadCount'] ?? 'an unknown number of' ) . ' records from ' . ( $sampling['samplingSpaceSize'] ?? 'an unknown sampling space' ) . '.'; }
-		if ( isset( $report['rowCount'] ) && ( ! is_int( $report['rowCount'] ) || $report['rowCount'] < 0 ) ) { return $invalid(); }
+		if ( isset( $metadata['samplingMetadatas'] ) && ( ! is_array( $metadata['samplingMetadatas'] ) || ! array_is_list( $metadata['samplingMetadatas'] ) || count( $metadata['samplingMetadatas'] ) > 5 ) ) {
+			return $invalid(); }
+		foreach ( $metadata['samplingMetadatas'] ?? array() as $sampling ) {
+			if ( ! is_array( $sampling ) || array_diff( array_keys( $sampling ), array( 'samplesReadCount', 'samplingSpaceSize' ) ) || ( isset( $sampling['samplesReadCount'] ) && ( ! is_string( $sampling['samplesReadCount'] ) || ! ctype_digit( $sampling['samplesReadCount'] ) ) ) || ( isset( $sampling['samplingSpaceSize'] ) && ( ! is_string( $sampling['samplingSpaceSize'] ) || ! ctype_digit( $sampling['samplingSpaceSize'] ) ) ) ) {
+				return $invalid();
+			} $limits[] = 'Google Analytics sampled ' . ( $sampling['samplesReadCount'] ?? 'an unknown number of' ) . ' records from ' . ( $sampling['samplingSpaceSize'] ?? 'an unknown sampling space' ) . '.'; }
+		if ( isset( $report['rowCount'] ) && ( ! is_int( $report['rowCount'] ) || $report['rowCount'] < 0 ) ) {
+			return $invalid(); }
 		$row_count = $report['rowCount'] ?? count( $rows );
-		if ( $row_count > count( $rows ) ) { $limits[] = 'The result is truncated to ' . count( $rows ) . ' of ' . $row_count . ' matching rows.'; }
-		if ( empty( $rows ) ) { $limits[] = 'No rows matched the requested report.'; }
-		if ( count( $raw_totals ) > 1 || ( 1 === count( $raw_totals ) && ( ! is_array( $raw_totals[0] ) || array_keys( $raw_totals[0] ) !== array( 'metricValues' ) ) ) ) { return $invalid(); }
+		if ( $row_count > count( $rows ) ) {
+			$limits[] = 'The result is truncated to ' . count( $rows ) . ' of ' . $row_count . ' matching rows.'; }
+		if ( empty( $rows ) ) {
+			$limits[] = 'No rows matched the requested report.'; }
+		if ( count( $raw_totals ) > 1 || ( 1 === count( $raw_totals ) && ( ! is_array( $raw_totals[0] ) || array_keys( $raw_totals[0] ) !== array( 'metricValues' ) ) ) ) {
+			return $invalid(); }
 		$totals = empty( $raw_totals ) ? array_fill_keys( $metrics, '' ) : $record( $metrics, $raw_totals[0]['metricValues'], 200 );
-		if ( false === $totals || ( isset( $report['propertyQuota'] ) && ! is_array( $report['propertyQuota'] ) ) ) { return $invalid(); }
-		$quota = array(); foreach ( $report['propertyQuota'] ?? array() as $name => $value ) { if ( ! is_string( $name ) || ! is_array( $value ) || array_diff( array_keys( $value ), array( 'consumed', 'remaining' ) ) || ( isset( $value['consumed'] ) && ( ! is_int( $value['consumed'] ) || $value['consumed'] < 0 ) ) || ( isset( $value['remaining'] ) && ( ! is_int( $value['remaining'] ) || $value['remaining'] < 0 ) ) ) { return $invalid(); } if ( isset( $value['remaining'] ) ) { $quota[ $name ] = $value['remaining']; } }
-		return array( 'date_range' => $date_range, 'rows' => $rows, 'totals' => $totals, 'returned_row_count' => count( $rows ), 'row_count' => $row_count, 'time_zone' => $metadata['timeZone'] ?? '', 'currency_code' => $metadata['currencyCode'] ?? '', 'quota_remaining' => $quota, 'coverage_limits' => $limits );
+		if ( false === $totals || ( isset( $report['propertyQuota'] ) && ! is_array( $report['propertyQuota'] ) ) ) {
+			return $invalid(); }
+		$quota = array();
+		foreach ( $report['propertyQuota'] ?? array() as $name => $value ) {
+			if ( ! is_string( $name ) || ! is_array( $value ) || array_diff( array_keys( $value ), array( 'consumed', 'remaining' ) ) || ( isset( $value['consumed'] ) && ( ! is_int( $value['consumed'] ) || $value['consumed'] < 0 ) ) || ( isset( $value['remaining'] ) && ( ! is_int( $value['remaining'] ) || $value['remaining'] < 0 ) ) ) {
+				return $invalid();
+			} if ( isset( $value['remaining'] ) ) {
+				$quota[ $name ] = $value['remaining']; }
+		}
+		return array(
+			'date_range'         => $date_range,
+			'rows'               => $rows,
+			'totals'             => $totals,
+			'returned_row_count' => count( $rows ),
+			'row_count'          => $row_count,
+			'time_zone'          => $metadata['timeZone'] ?? '',
+			'currency_code'      => $metadata['currencyCode'] ?? '',
+			'quota_remaining'    => $quota,
+			'coverage_limits'    => $limits,
+		);
 	}
 
 	/**
@@ -638,7 +899,10 @@ class GoogleAnalyticsAbilities {
 		if ( 'aggregate_report' === $action ) {
 			$aggregate_property_id = self::resolveAggregatePropertyId( $input, $config );
 			if ( is_wp_error( $aggregate_property_id ) ) {
-				return array( 'success' => false, 'error' => $aggregate_property_id->get_error_message() );
+				return array(
+					'success' => false,
+					'error'   => $aggregate_property_id->get_error_message(),
+				);
 			}
 			return self::fetchAggregateReport( $input, $access_token, $aggregate_property_id );
 		}
@@ -1620,7 +1884,6 @@ class GoogleAnalyticsAbilities {
 	 * Format GA4 report rows into a flat, readable structure.
 	 *
 	 * @param array $data          Raw GA4 API response.
-	 * @param array $report_config Report configuration with dimension/metric names.
 	 * @return array Formatted rows.
 	 */
 	private static function formatReportRows( array $data ): array {
@@ -1641,7 +1904,7 @@ class GoogleAnalyticsAbilities {
 				$value = $metric_values[ $i ] ?? '0';
 				// Cast numeric strings to appropriate types.
 				if ( is_numeric( $value ) ) {
-					$formatted[ $name ] = strpos( $value, '.' ) !== false ? (float) $value : (int) $value;
+					$formatted[ $name ] = strpos( (string) $value, '.' ) !== false ? (float) $value : (int) $value;
 				} else {
 					$formatted[ $name ] = $value;
 				}
@@ -1690,7 +1953,7 @@ class GoogleAnalyticsAbilities {
 				$value                = $metric_values[ $i ] ?? '0';
 				$raw_metrics[ $name ] = $value;
 				$formatted[ $name ]   = is_numeric( $value )
-					? ( strpos( $value, '.' ) !== false ? (float) $value : (int) $value )
+					? ( strpos( (string) $value, '.' ) !== false ? (float) $value : (int) $value )
 					: $value;
 			}
 
@@ -1754,17 +2017,15 @@ class GoogleAnalyticsAbilities {
 			return $cached;
 		}
 
-		$header = self::base64url_encode(
-			wp_json_encode(
+		$header_json = wp_json_encode(
 				array(
 					'alg' => 'RS256',
 					'typ' => 'JWT',
 				)
-			)
 		);
+		$header      = self::base64url_encode( false === $header_json ? '' : $header_json );
 		$now    = time();
-		$claims = self::base64url_encode(
-			wp_json_encode(
+		$claims_json = wp_json_encode(
 				array(
 					'iss'   => $service_account['client_email'],
 					'scope' => 'https://www.googleapis.com/auth/analytics.readonly',
@@ -1772,8 +2033,8 @@ class GoogleAnalyticsAbilities {
 					'iat'   => $now,
 					'exp'   => $now + 3600,
 				)
-			)
 		);
+		$claims      = self::base64url_encode( false === $claims_json ? '' : $claims_json );
 
 		$unsigned = $header . '.' . $claims;
 

--- a/inc/Abilities/Media/BrokenImageReferenceAbilities.php
+++ b/inc/Abilities/Media/BrokenImageReferenceAbilities.php
@@ -168,8 +168,9 @@ class BrokenImageReferenceAbilities {
 				$current_blog_id = get_current_blog_id();
 
 				foreach ( $posts as $post ) {
+					/** @var \WP_Post $post */
 					++$posts_total;
-					$content = is_object( $post ) ? (string) $post->post_content : '';
+					$content = (string) $post->post_content;
 					if ( '' === $content ) {
 						continue;
 					}
@@ -204,8 +205,8 @@ class BrokenImageReferenceAbilities {
 						if ( ! $file_checker( $path ) ) {
 							$broken[] = array(
 								'blog_id'    => (int) $current_blog_id,
-								'post_id'    => (int) ( is_object( $post ) ? $post->ID : 0 ),
-								'post_title' => is_object( $post ) ? (string) $post->post_title : '',
+								'post_id'    => (int) $post->ID,
+								'post_title' => (string) $post->post_title,
 								'url'        => $normalized,
 								'attribute'  => $ref['attribute'],
 								'host_blog'  => isset( $resolved['blog_id'] ) ? (int) $resolved['blog_id'] : 0,
@@ -258,7 +259,7 @@ class BrokenImageReferenceAbilities {
 				get_sites(
 					array(
 						'fields' => 'ids',
-						'number' => '',
+						'number' => 0,
 					)
 				)
 			);
@@ -535,7 +536,7 @@ class BrokenImageReferenceAbilities {
 			}
 			// A descriptor is a trailing token like "480w" or "2x" preceded by space.
 			$parts = preg_split( '/\s+/', $candidate );
-			if ( ! is_array( $parts ) || empty( $parts ) ) {
+			if ( ! is_array( $parts ) ) {
 				continue;
 			}
 			$url = trim( $parts[0] );
@@ -661,7 +662,7 @@ class BrokenImageReferenceAbilities {
 		$best_blog_id = null;
 		$best_baseurl = '';
 		foreach ( $blog_uploads as $blog_id => $uploads ) {
-			$baseurl = $uploads['baseurl'] ?? '';
+			$baseurl = $uploads['baseurl'];
 			if ( '' === $baseurl ) {
 				continue;
 			}
@@ -698,7 +699,7 @@ class BrokenImageReferenceAbilities {
 			);
 		}
 
-		$basedir  = $blog_uploads[ $best_blog_id ]['basedir'] ?? '';
+		$basedir  = $blog_uploads[ $best_blog_id ]['basedir'];
 		$relative = substr( $url, strlen( $best_baseurl ) );
 		$fs_path  = self::build_contained_upload_path( $basedir, $relative );
 
@@ -795,7 +796,7 @@ class BrokenImageReferenceAbilities {
 	 */
 	private static function host_is_network_host( string $host, array $blog_uploads ): bool {
 		foreach ( $blog_uploads as $uploads ) {
-			$baseurl_host = strtolower( (string) wp_parse_url( $uploads['baseurl'] ?? '', PHP_URL_HOST ) );
+			$baseurl_host = strtolower( (string) wp_parse_url( $uploads['baseurl'], PHP_URL_HOST ) );
 			if ( $host === $baseurl_host ) {
 				return true;
 			}

--- a/inc/Abilities/Media/ImageOptimizationAbilities.php
+++ b/inc/Abilities/Media/ImageOptimizationAbilities.php
@@ -381,22 +381,7 @@ class ImageOptimizationAbilities {
 			);
 		}
 
-		$resolver = __NAMESPACE__ . '\\datamachine_resolve_system_agent_context';
-		if ( ! function_exists( $resolver ) ) {
-			$resolver = 'datamachine_resolve_system_agent_context';
-		}
-		if ( ! is_callable( $resolver ) ) {
-			return array_merge(
-				array(
-					'success'      => false,
-					'queued_count' => 0,
-					'message'      => 'Failed to resolve image optimization scheduling context.',
-					'error'        => 'Task scheduling context is unavailable.',
-				),
-				$scan_coverage
-			);
-		}
-		$acting = call_user_func( $resolver );
+		$acting = \datamachine_resolve_system_agent_context();
 
 		$batch = TaskScheduler::scheduleBatch(
 			'image_optimization',

--- a/inc/Abilities/Media/ImageOptimizationAbilities.php
+++ b/inc/Abilities/Media/ImageOptimizationAbilities.php
@@ -231,7 +231,7 @@ class ImageOptimizationAbilities {
 					'attachment_id' => $attachment_id,
 					'title'         => get_the_title( $attachment_id ),
 					'file_size'     => $file_size,
-					'file_size_hr'  => size_format( $file_size ),
+					'file_size_hr'  => size_format( (int) $file_size ),
 					'dimensions'    => $width . 'x' . $height,
 					'mime_type'     => $mime_type,
 					'has_webp'      => $has_webp,
@@ -356,7 +356,7 @@ class ImageOptimizationAbilities {
 				$preview[] = array(
 					'attachment_id' => $id,
 					'title'         => get_the_title( $id ),
-					'file_size'     => size_format( $file_size ),
+					'file_size'     => size_format( (int) $file_size ),
 					'mime_type'     => get_post_mime_type( $id ),
 				);
 			}
@@ -381,18 +381,30 @@ class ImageOptimizationAbilities {
 			);
 		}
 
-		$acting             = datamachine_resolve_system_agent_context();
-		$user_id            = $acting['user_id'];
-		$agent_id           = $acting['agent_id'];
-		$triggering_user_id = $acting['triggering_user_id'];
+		$resolver = __NAMESPACE__ . '\\datamachine_resolve_system_agent_context';
+		if ( ! function_exists( $resolver ) ) {
+			$resolver = 'datamachine_resolve_system_agent_context';
+		}
+		if ( ! is_callable( $resolver ) ) {
+			return array_merge(
+				array(
+					'success'      => false,
+					'queued_count' => 0,
+					'message'      => 'Failed to resolve image optimization scheduling context.',
+					'error'        => 'Task scheduling context is unavailable.',
+				),
+				$scan_coverage
+			);
+		}
+		$acting = call_user_func( $resolver );
 
 		$batch = TaskScheduler::scheduleBatch(
 			'image_optimization',
 			$item_params,
 			array(
-				'user_id'            => $user_id,
-				'agent_id'           => $agent_id,
-				'triggering_user_id' => $triggering_user_id,
+				'user_id'            => isset( $acting['user_id'] ) ? (int) $acting['user_id'] : 0,
+				'agent_id'           => isset( $acting['agent_id'] ) ? (int) $acting['agent_id'] : 0,
+				'triggering_user_id' => isset( $acting['triggering_user_id'] ) ? (int) $acting['triggering_user_id'] : 0,
 			)
 		);
 
@@ -408,7 +420,7 @@ class ImageOptimizationAbilities {
 		return array_merge( array(
 			'success'      => true,
 			'queued_count' => count( $attachment_ids ),
-			'batch_id'     => $batch['batch_id'] ?? null,
+			'batch_id'     => $batch['batch_id'],
 			'message'      => sprintf(
 				'Image optimization scheduled for %d image(s).',
 				count( $attachment_ids )

--- a/inc/Abilities/MediaHygiene/MediaHygieneAbility.php
+++ b/inc/Abilities/MediaHygiene/MediaHygieneAbility.php
@@ -121,13 +121,12 @@ class MediaHygieneAbility {
 				return self::delete_orphans( $limit, $apply );
 			case 'delete-unused':
 				return self::delete_unused( $limit, $apply );
+			default:
+				return array(
+					'success' => false,
+					'error'   => 'Unhandled action.',
+				);
 		}
-
-		// Unreachable — guarded by VALID_ACTIONS check above.
-		return array(
-			'success' => false,
-			'error'   => 'Unhandled action.',
-		);
 	}
 
 	/**
@@ -356,7 +355,7 @@ class MediaHygieneAbility {
 			return array();
 		}
 
-		$attached = array_flip( array_map( 'strval', MediaHygieneScanner::attached_file_index() ) );
+		$attached = array_fill_keys( array_map( 'strval', MediaHygieneScanner::attached_file_index() ), true );
 		$variants = MediaHygieneScanner::appended_variant_index(
 			$attached + MediaHygieneScanner::variant_index()
 		);

--- a/inc/Abilities/SEO/IndexNowAbilities.php
+++ b/inc/Abilities/SEO/IndexNowAbilities.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
 
 class IndexNowAbilities {
 
-	public const API_ENDPOINT = 'https://api.indexnow.org/indexnow';
+	public const API_ENDPOINT   = 'https://api.indexnow.org/indexnow';
 	public const MAX_BATCH_SIZE = 10000;
 
 	private static bool $registered = false;
@@ -90,16 +90,25 @@ class IndexNowAbilities {
 
 	public static function submit_urls( array $urls ): array {
 		if ( empty( $urls ) ) {
-			return array( 'success' => false, 'error' => 'No URLs provided' );
+			return array(
+				'success' => false,
+				'error'   => 'No URLs provided',
+			);
 		}
 
 		$key = self::get_or_generate_key();
 		if ( empty( $key ) ) {
-			return array( 'success' => false, 'error' => 'Could not generate IndexNow API key' );
+			return array(
+				'success' => false,
+				'error'   => 'Could not generate IndexNow API key',
+			);
 		}
 
-		$urls = array_slice( array_values( array_unique( array_filter( $urls ) ) ), 0, self::MAX_BATCH_SIZE );
-		$host = wp_parse_url( $urls[0], PHP_URL_HOST ) ?: wp_parse_url( home_url(), PHP_URL_HOST );
+		$urls   = array_slice( array_values( array_unique( array_filter( $urls ) ) ), 0, self::MAX_BATCH_SIZE );
+		$host   = wp_parse_url( $urls[0], PHP_URL_HOST );
+		if ( ! $host ) {
+			$host = wp_parse_url( home_url(), PHP_URL_HOST );
+		}
 		$result = HttpClient::post(
 			self::API_ENDPOINT,
 			array(
@@ -154,13 +163,14 @@ class IndexNowAbilities {
 	}
 
 	public static function get_or_generate_key(): string {
-		return self::get_api_key() ?: self::generate_key();
+		$key = self::get_api_key();
+		return $key ? $key : self::generate_key();
 	}
 
 	public static function generate_key(): string {
-		$key                              = str_replace( '-', '', wp_generate_uuid4() );
-		$settings                         = get_option( 'datamachine_settings', array() );
-		$settings['indexnow_api_key']     = $key;
+		$key                          = str_replace( '-', '', wp_generate_uuid4() );
+		$settings                     = get_option( 'datamachine_settings', array() );
+		$settings['indexnow_api_key'] = $key;
 		update_option( 'datamachine_settings', $settings );
 		PluginSettings::clearCache();
 		do_action( 'datamachine_log', 'info', 'IndexNow: Generated new API key', array( 'key_preview' => substr( $key, 0, 8 ) . '...' ) );
@@ -170,20 +180,38 @@ class IndexNowAbilities {
 	public static function verify_key_file(): array {
 		$key = self::get_api_key();
 		if ( empty( $key ) ) {
-			return array( 'success' => false, 'error' => 'No API key configured. Generate one first.' );
+			return array(
+				'success' => false,
+				'error'   => 'No API key configured. Generate one first.',
+			);
 		}
 
 		$url    = home_url( '/' . $key . '.txt' );
-		$result = HttpClient::get( $url, array( 'timeout' => 10, 'context' => 'IndexNow Key Verification' ) );
+		$result = HttpClient::get( $url, array(
+			'timeout' => 10,
+			'context' => 'IndexNow Key Verification',
+		) );
 		if ( ! $result['success'] ) {
-			return array( 'success' => false, 'url' => $url, 'error' => 'Key file not accessible: ' . ( $result['error'] ?? 'unknown error' ) );
+			return array(
+				'success' => false,
+				'url'     => $url,
+				'error'   => 'Key file not accessible: ' . ( $result['error'] ?? 'unknown error' ),
+			);
 		}
 
 		if ( trim( $result['data'] ?? '' ) !== $key ) {
-			return array( 'success' => false, 'url' => $url, 'error' => 'Key file content does not match API key' );
+			return array(
+				'success' => false,
+				'url'     => $url,
+				'error'   => 'Key file content does not match API key',
+			);
 		}
 
-		return array( 'success' => true, 'url' => $url, 'message' => 'Key file verified successfully' );
+		return array(
+			'success' => true,
+			'url'     => $url,
+			'message' => 'Key file verified successfully',
+		);
 	}
 
 	public static function get_status(): array {
@@ -215,8 +243,27 @@ class IndexNowAbilities {
 				'label'               => __( 'IndexNow Submit', 'data-machine-business' ),
 				'description'         => __( 'Submit one or more URLs to IndexNow for instant search engine indexing.', 'data-machine-business' ),
 				'category'            => 'datamachine-seo',
-				'input_schema'        => array( 'type' => 'object', 'required' => array( 'urls' ), 'properties' => array( 'urls' => array( 'type' => 'array', 'description' => __( 'Array of full URLs to submit', 'data-machine-business' ), 'items' => array( 'type' => 'string' ) ) ) ),
-				'output_schema'       => array( 'type' => 'object', 'properties' => array( 'success' => array( 'type' => 'boolean' ), 'message' => array( 'type' => 'string' ), 'url_count' => array( 'type' => 'integer' ), 'status_code' => array( 'type' => 'integer' ), 'error' => array( 'type' => 'string' ) ) ),
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'urls' ),
+					'properties' => array(
+						'urls' => array(
+							'type'        => 'array',
+							'description' => __( 'Array of full URLs to submit', 'data-machine-business' ),
+							'items'       => array( 'type' => 'string' ),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'message'     => array( 'type' => 'string' ),
+						'url_count'   => array( 'type' => 'integer' ),
+						'status_code' => array( 'type' => 'integer' ),
+						'error'       => array( 'type' => 'string' ),
+					),
+				),
 				'execute_callback'    => array( $this, 'execute_submit' ),
 				'permission_callback' => fn() => PermissionHelper::can_manage(),
 				'meta'                => array( 'show_in_rest' => true ),
@@ -231,8 +278,21 @@ class IndexNowAbilities {
 				'label'               => __( 'IndexNow Status', 'data-machine-business' ),
 				'description'         => __( 'Get IndexNow integration status including enabled state and API key.', 'data-machine-business' ),
 				'category'            => 'datamachine-seo',
-				'input_schema'        => array( 'type' => 'object', 'properties' => array() ),
-				'output_schema'       => array( 'type' => 'object', 'properties' => array( 'success' => array( 'type' => 'boolean' ), 'enabled' => array( 'type' => 'boolean' ), 'has_key' => array( 'type' => 'boolean' ), 'key_preview' => array( 'type' => 'string' ), 'key_file_url' => array( 'type' => 'string' ), 'endpoint' => array( 'type' => 'string' ) ) ),
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'enabled'      => array( 'type' => 'boolean' ),
+						'has_key'      => array( 'type' => 'boolean' ),
+						'key_preview'  => array( 'type' => 'string' ),
+						'key_file_url' => array( 'type' => 'string' ),
+						'endpoint'     => array( 'type' => 'string' ),
+					),
+				),
 				'execute_callback'    => array( $this, 'execute_status' ),
 				'permission_callback' => fn() => PermissionHelper::can_manage(),
 				'meta'                => array( 'show_in_rest' => true ),
@@ -247,8 +307,19 @@ class IndexNowAbilities {
 				'label'               => __( 'IndexNow Generate Key', 'data-machine-business' ),
 				'description'         => __( 'Generate a new IndexNow API key and save it to settings.', 'data-machine-business' ),
 				'category'            => 'datamachine-seo',
-				'input_schema'        => array( 'type' => 'object', 'properties' => array() ),
-				'output_schema'       => array( 'type' => 'object', 'properties' => array( 'success' => array( 'type' => 'boolean' ), 'key_preview' => array( 'type' => 'string' ), 'key_file_url' => array( 'type' => 'string' ), 'message' => array( 'type' => 'string' ) ) ),
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'key_preview'  => array( 'type' => 'string' ),
+						'key_file_url' => array( 'type' => 'string' ),
+						'message'      => array( 'type' => 'string' ),
+					),
+				),
 				'execute_callback'    => array( $this, 'execute_generate_key' ),
 				'permission_callback' => fn() => PermissionHelper::can_manage(),
 				'meta'                => array( 'show_in_rest' => true ),
@@ -263,8 +334,19 @@ class IndexNowAbilities {
 				'label'               => __( 'IndexNow Verify Key', 'data-machine-business' ),
 				'description'         => __( 'Verify that the IndexNow key file is accessible and correct.', 'data-machine-business' ),
 				'category'            => 'datamachine-seo',
-				'input_schema'        => array( 'type' => 'object', 'properties' => array() ),
-				'output_schema'       => array( 'type' => 'object', 'properties' => array( 'success' => array( 'type' => 'boolean' ), 'url' => array( 'type' => 'string' ), 'message' => array( 'type' => 'string' ), 'error' => array( 'type' => 'string' ) ) ),
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success' => array( 'type' => 'boolean' ),
+						'url'     => array( 'type' => 'string' ),
+						'message' => array( 'type' => 'string' ),
+						'error'   => array( 'type' => 'string' ),
+					),
+				),
 				'execute_callback'    => array( $this, 'execute_verify_key' ),
 				'permission_callback' => fn() => PermissionHelper::can_manage(),
 				'meta'                => array( 'show_in_rest' => true ),
@@ -275,25 +357,39 @@ class IndexNowAbilities {
 	public function execute_submit( array $input ): array {
 		$urls = $input['urls'] ?? array();
 		if ( empty( $urls ) || ! is_array( $urls ) ) {
-			return array( 'success' => false, 'error' => 'urls parameter is required and must be a non-empty array' );
+			return array(
+				'success' => false,
+				'error'   => 'urls parameter is required and must be a non-empty array',
+			);
 		}
 
 		$urls = array_filter( array_map( 'esc_url_raw', $urls ) );
-		return empty( $urls ) ? array( 'success' => false, 'error' => 'No valid URLs after sanitization' ) : self::submit_urls( $urls );
+		return empty( $urls ) ? array(
+			'success' => false,
+			'error'   => 'No valid URLs after sanitization',
+		) : self::submit_urls( $urls );
 	}
 
 	public function execute_status( array $input ): array {
+		unset( $input );
 		$status            = self::get_status();
 		$status['success'] = true;
 		return $status;
 	}
 
 	public function execute_generate_key( array $input ): array {
+		unset( $input );
 		$key = self::generate_key();
-		return array( 'success' => true, 'key_preview' => substr( $key, 0, 8 ) . '...', 'key_file_url' => home_url( '/' . $key . '.txt' ), 'message' => 'New IndexNow API key generated' );
+		return array(
+			'success'      => true,
+			'key_preview'  => substr( $key, 0, 8 ) . '...',
+			'key_file_url' => home_url( '/' . $key . '.txt' ),
+			'message'      => 'New IndexNow API key generated',
+		);
 	}
 
 	public function execute_verify_key( array $input ): array {
+		unset( $input );
 		return self::verify_key_file();
 	}
 }

--- a/inc/Cli/GoogleAnalyticsCommand.php
+++ b/inc/Cli/GoogleAnalyticsCommand.php
@@ -183,7 +183,17 @@ class GoogleAnalyticsCommand extends BaseCommand {
 				'order'       => 'order',
 			)
 		);
-		foreach ( array( 'date-range' => 'date_range', 'comparison-date-range' => 'comparison_date_range', 'dimensions' => 'dimensions', 'metrics' => 'metrics', 'filters' => 'filters', 'order-by' => 'order_by' ) as $flag => $key ) {
+		foreach (
+			array(
+				'date-range'            => 'date_range',
+				'comparison-date-range' => 'comparison_date_range',
+				'dimensions'            => 'dimensions',
+				'metrics'               => 'metrics',
+				'filters'               => 'filters',
+				'order-by'              => 'order_by',
+			)
+			as $flag => $key
+		) {
 			if ( isset( $assoc_args[ $flag ] ) ) {
 				$input[ $key ] = json_decode( $assoc_args[ $flag ], true );
 			}
@@ -248,7 +258,7 @@ class GoogleAnalyticsCommand extends BaseCommand {
 
 		// JSON output: dump the whole result.
 		if ( 'json' === $format ) {
-			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT ) );
 			return;
 		}
 

--- a/inc/Cli/IndexNowCommand.php
+++ b/inc/Cli/IndexNowCommand.php
@@ -48,7 +48,14 @@ class IndexNowCommand extends BaseCommand {
 			}
 			$urls[] = $url;
 		} elseif ( $post_type ) {
-			$posts = get_posts( array( 'post_type' => $post_type, 'post_status' => 'publish', 'posts_per_page' => min( $limit, IndexNowAbilities::MAX_BATCH_SIZE ), 'fields' => 'ids' ) );
+			$posts = get_posts(
+				array(
+					'post_type'      => $post_type,
+					'post_status'    => 'publish',
+					'posts_per_page' => min( $limit, IndexNowAbilities::MAX_BATCH_SIZE ),
+					'fields'         => 'ids',
+				)
+			);
 			if ( empty( $posts ) ) {
 				WP_CLI::error( "No published posts found for post type '{$post_type}'" );
 			}

--- a/inc/Engine/AI/System/Tasks/ImageOptimizationTask.php
+++ b/inc/Engine/AI/System/Tasks/ImageOptimizationTask.php
@@ -166,6 +166,7 @@ class ImageOptimizationTask extends SystemTask {
 		if ( is_wp_error( $editor ) ) {
 			return array(
 				'success' => false,
+				'new_size' => 0,
 				'error'   => 'Image editor not available: ' . $editor->get_error_message(),
 			);
 		}
@@ -176,6 +177,7 @@ class ImageOptimizationTask extends SystemTask {
 		if ( is_wp_error( $saved ) ) {
 			return array(
 				'success' => false,
+				'new_size' => 0,
 				'error'   => 'Compression failed: ' . $saved->get_error_message(),
 			);
 		}
@@ -183,7 +185,8 @@ class ImageOptimizationTask extends SystemTask {
 		clearstatcache( true, $file_path );
 		return array(
 			'success'  => true,
-			'new_size' => filesize( $file_path ),
+			'new_size' => (int) filesize( $file_path ),
+			'error'    => '',
 		);
 	}
 
@@ -194,13 +197,14 @@ class ImageOptimizationTask extends SystemTask {
 	 * @return array{success: bool, webp_path: string, webp_size: int, error: string}
 	 */
 	private function generateWebP( string $file_path, int $quality, int $attachment_id ): array {
-		$webp_path = preg_replace( '/\.(jpe?g|png)$/i', '.webp', $file_path );
+		$webp_path = (string) preg_replace( '/\.(jpe?g|png)$/i', '.webp', $file_path );
 
 		if ( file_exists( $webp_path ) ) {
 			return array(
 				'success'   => true,
 				'webp_path' => $webp_path,
-				'webp_size' => filesize( $webp_path ),
+				'webp_size' => (int) filesize( $webp_path ),
+				'error'     => '',
 			);
 		}
 
@@ -208,6 +212,8 @@ class ImageOptimizationTask extends SystemTask {
 		if ( is_wp_error( $editor ) ) {
 			return array(
 				'success' => false,
+				'webp_path' => '',
+				'webp_size' => 0,
 				'error'   => 'Image editor not available: ' . $editor->get_error_message(),
 			);
 		}
@@ -218,14 +224,17 @@ class ImageOptimizationTask extends SystemTask {
 		if ( is_wp_error( $saved ) ) {
 			return array(
 				'success' => false,
+				'webp_path' => '',
+				'webp_size' => 0,
 				'error'   => 'WebP generation failed: ' . $saved->get_error_message(),
 			);
 		}
 
 		return array(
 			'success'   => true,
-			'webp_path' => $saved['path'],
-			'webp_size' => filesize( $saved['path'] ),
+			'webp_path' => (string) $saved['path'],
+			'webp_size' => (int) filesize( $saved['path'] ),
+			'error'     => '',
 		);
 	}
 }

--- a/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
+++ b/inc/Engine/AI/Tools/Global/GoogleAnalytics.php
@@ -146,8 +146,6 @@ class GoogleAnalytics extends BaseTool {
 	/**
 	 * Save configuration from settings page.
 	 *
-	 * @param string $tool_id     Tool identifier.
-	 * @param array  $config_data Configuration data.
 	 */
 	protected function get_config_option_name(): string {
 		return GoogleAnalyticsAbilities::CONFIG_OPTION;

--- a/tests/GoogleSearchConsoleBusinessTest.php
+++ b/tests/GoogleSearchConsoleBusinessTest.php
@@ -46,7 +46,7 @@ class GoogleSearchConsoleBusinessTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertStringContainsString(
 			'datamachine analytics gsc',
-			$this->read_file( 'data-machine-business.php' )
+			$this->read_file( 'inc/Cli/CommandRegistry.php' )
 		);
 	}
 

--- a/tests/gsc-business-registration-smoke.php
+++ b/tests/gsc-business-registration-smoke.php
@@ -66,7 +66,7 @@ assert_business_gsc(
 );
 
 assert_business_gsc(
-	business_gsc_file_contains( 'data-machine-business.php', "datamachine analytics gsc" ),
+	business_gsc_file_contains( 'inc/Cli/CommandRegistry.php', "'datamachine analytics gsc'" ),
 	'business registers the GSC WP-CLI command',
 	$failures,
 	$passes

--- a/tests/image-optimization-scheduling-context-smoke.php
+++ b/tests/image-optimization-scheduling-context-smoke.php
@@ -25,7 +25,9 @@ namespace DataMachineBusiness\Abilities\Media {
 	function absint( $value ): int {
 		return abs( (int) $value );
 	}
+}
 
+namespace {
 	function datamachine_resolve_system_agent_context(): array {
 		return array(
 			'user_id'            => '17',
@@ -33,9 +35,7 @@ namespace DataMachineBusiness\Abilities\Media {
 			'triggering_user_id' => '43',
 		);
 	}
-}
 
-namespace {
 	define( 'ABSPATH', __DIR__ . '/' );
 
 	require_once dirname( __DIR__ ) . '/inc/Abilities/Media/ImageOptimizationAbilities.php';

--- a/tests/image-optimization-scheduling-context-smoke.php
+++ b/tests/image-optimization-scheduling-context-smoke.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Runtime smoke test for image optimization scheduler context propagation.
+ *
+ * Run with: php tests/image-optimization-scheduling-context-smoke.php
+ *
+ * @package DataMachineBusiness\Tests
+ */
+
+namespace DataMachine\Engine\Tasks {
+	class TaskScheduler {
+		/** @var array<string, mixed>|null */
+		public static ?array $context = null;
+
+		public static function scheduleBatch( string $task_type, array $item_params, array $context ): array {
+			self::$context = $context;
+			return array(
+				'batch_id' => 'image-context-smoke',
+			);
+		}
+	}
+}
+
+namespace DataMachineBusiness\Abilities\Media {
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+
+	function datamachine_resolve_system_agent_context(): array {
+		return array(
+			'user_id'            => '17',
+			'agent_id'           => '29',
+			'triggering_user_id' => '43',
+		);
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Media/ImageOptimizationAbilities.php';
+
+	$result = \DataMachineBusiness\Abilities\Media\ImageOptimizationAbilities::optimizeImages(
+		array(
+			'attachment_id' => 101,
+		)
+	);
+
+	$expected_context = array(
+		'user_id'            => 17,
+		'agent_id'           => 29,
+		'triggering_user_id' => 43,
+	);
+	if ( true !== $result['success'] || 'image-context-smoke' !== $result['batch_id'] || $expected_context !== \DataMachine\Engine\Tasks\TaskScheduler::$context ) {
+		fwrite( STDERR, "Image optimization scheduling context smoke failed.\n" );
+		exit( 1 );
+	}
+
+	echo "Image optimization scheduling context smoke passed.\n";
+}

--- a/tests/test-manifest-contract-smoke.php
+++ b/tests/test-manifest-contract-smoke.php
@@ -15,12 +15,14 @@ if ( ! is_array( $manifest ) || 'homeboy/test-manifest/v1' !== ( $manifest['sche
 	exit( 1 );
 }
 
-$smokes = glob( __DIR__ . '/*-smoke.php' );
-sort( $smokes );
-$expected = array_map(
-	static fn( string $path ): string => 'tests/' . basename( $path ),
-	$smokes
-);
+$expected = array();
+$files    = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( __DIR__, FilesystemIterator::SKIP_DOTS ) );
+foreach ( $files as $file ) {
+	if ( $file->isFile() && str_ends_with( $file->getFilename(), '-smoke.php' ) ) {
+		$expected[] = 'tests/' . str_replace( DIRECTORY_SEPARATOR, '/', substr( $file->getPathname(), strlen( __DIR__ ) + 1 ) );
+	}
+}
+sort( $expected );
 $declared = array_keys( $manifest['tests'] );
 sort( $declared );
 

--- a/tests/test-manifest-contract-smoke.php
+++ b/tests/test-manifest-contract-smoke.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Ensure every standalone or WordPress smoke declares its execution environment.
+ *
+ * Run with: php tests/test-manifest-contract-smoke.php
+ *
+ * @package DataMachineBusiness\Tests
+ */
+
+$root     = dirname( __DIR__ );
+$manifest = json_decode( file_get_contents( $root . '/homeboy-test-manifest.json' ), true );
+
+if ( ! is_array( $manifest ) || 'homeboy/test-manifest/v1' !== ( $manifest['schema'] ?? '' ) || ! isset( $manifest['tests'] ) || ! is_array( $manifest['tests'] ) ) {
+	fwrite( STDERR, "Invalid Homeboy test manifest.\n" );
+	exit( 1 );
+}
+
+$smokes = glob( __DIR__ . '/*-smoke.php' );
+sort( $smokes );
+$expected = array_map(
+	static fn( string $path ): string => 'tests/' . basename( $path ),
+	$smokes
+);
+$declared = array_keys( $manifest['tests'] );
+sort( $declared );
+
+if ( $expected !== $declared ) {
+	fwrite( STDERR, "Homeboy test manifest does not classify every smoke test exactly.\n" );
+	exit( 1 );
+}
+
+$wordpress_smokes = array(
+	'tests/data-machine-http-client-contract-smoke.php',
+	'tests/google-analytics-aggregate-schema-smoke.php',
+);
+foreach ( $manifest['tests'] as $path => $test ) {
+	$expected_environment = in_array( $path, $wordpress_smokes, true ) ? 'wordpress' : 'standalone-php';
+	if ( $expected_environment !== ( $test['environment'] ?? null ) ) {
+		fwrite( STDERR, "Unexpected environment for {$path}.\n" );
+		exit( 1 );
+	}
+}
+
+echo "Homeboy test manifest contract passed for " . count( $expected ) . " smoke tests.\n";


### PR DESCRIPTION
## Summary

- restore PHPCS and PHPStan compliance across the unreleased v0.17.0 range
- preserve image optimization actor context when scheduling background work
- classify every smoke test by its required runtime and enforce manifest coverage
- update GSC registration tests to verify the canonical command registry

Closes #117.

## Verification

- `homeboy review audit data-machine-business --placement local --profile pr --changed-since origin/main --summary`
- `homeboy review lint data-machine-business --changed-only --placement local --json-summary`
- `homeboy review test data-machine-business --skip-lint --placement local --json-summary` (`134/134`)
- `php tests/gsc-business-registration-smoke.php` (`6/6`)

## AI assistance disclosure

OpenAI GPT-5.6-sol via OpenCode inspected the failed release gates, updated the implementation and test contracts, and ran the verification workflow. Chris Huber directed and reviewed the work.